### PR TITLE
removed set-env

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set Variables
         shell: bash
         run: |
-          echo "::set-env name=SUFFIX::pr-${{ github.event.number }}"
+          echo "name=SUFFIX::pr-${{ github.event.number }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set Variables
         shell: bash
         run: |
-          echo "name=SUFFIX::pr-${{ github.event.number }}" >> $GITHUB_ENV
+          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set Variables
         shell: bash
         run: |
-          echo "name=SUFFIX::pr-${{ github.event.number }}" >> $GITHUB_ENV
+          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       - name: Set Variables
         shell: bash
         run: |
-          echo "name=SUFFIX::pr-${{ github.event.number }}" >> $GITHUB_ENV
+          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set Variables
         shell: bash
         run: |
-          echo "::set-env name=SUFFIX::pr-${{ github.event.number }}"
+          echo "name=SUFFIX::pr-${{ github.event.number }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       - name: Set Variables
         shell: bash
         run: |
-          echo "::set-env name=SUFFIX::pr-${{ github.event.number }}"
+          echo "name=SUFFIX::pr-${{ github.event.number }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Replaced set-env as per
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files