### PR TITLE
Replaced precip mm/cm with mm

### DIFF
--- a/web/src/features/fireWeather/components/graphs/PrecipitationGraph.tsx
+++ b/web/src/features/fireWeather/components/graphs/PrecipitationGraph.tsx
@@ -126,14 +126,14 @@ const PrecipitationGraph = (props: Props) => {
             dtick: 86400000.0 // Set the interval between ticks to one day: https://plotly.com/javascript/reference/#scatter-marker-colorbar-dtick
           },
           yaxis: {
-            title: 'Daily Precipitation (mm/cm)',
+            title: 'Daily Precipitation (mm)',
             tickfont: { size: 14 },
             gridcolor: 'transparent',
             fixedrange: true,
             range: y2Range
           },
           yaxis2: {
-            title: 'Accumulated Precipitation (mm/cm)',
+            title: 'Accumulated Precipitation (mm)',
             tickfont: { size: 14 },
             overlaying: 'y',
             side: 'right',

--- a/web/src/features/fireWeather/components/graphs/plotlyHelper.ts
+++ b/web/src/features/fireWeather/components/graphs/plotlyHelper.ts
@@ -477,9 +477,7 @@ export const populateGraphDataForPrecip = (
       width: 2.5
     },
     hoverinfo: 'y',
-    hovertemplate: show
-      ? `Accumulated ${name}: %{y:.2f} (mm)<extra></extra>`
-      : undefined
+    hovertemplate: show ? `Accumulated ${name}: %{y:.2f} (mm)<extra></extra>` : undefined
   }
 
   const maxAccumPrecip = findMaxNumber(accumPrecips)

--- a/web/src/features/fireWeather/components/graphs/plotlyHelper.ts
+++ b/web/src/features/fireWeather/components/graphs/plotlyHelper.ts
@@ -461,7 +461,7 @@ export const populateGraphDataForPrecip = (
       color: show ? color : 'transparent'
     },
     hoverinfo: show ? 'y' : 'skip',
-    hovertemplate: show ? `${name}: %{y:.2f} (mm/cm)<extra></extra>` : undefined
+    hovertemplate: show ? `${name}: %{y:.2f} (mm)<extra></extra>` : undefined
   }
 
   const accumPrecipsline: Data = {
@@ -478,7 +478,7 @@ export const populateGraphDataForPrecip = (
     },
     hoverinfo: 'y',
     hovertemplate: show
-      ? `Accumulated ${name}: %{y:.2f} (mm/cm)<extra></extra>`
+      ? `Accumulated ${name}: %{y:.2f} (mm)<extra></extra>`
       : undefined
   }
 

--- a/web/src/features/fireWeather/components/tables/NoonWxValueTables.tsx
+++ b/web/src/features/fireWeather/components/tables/NoonWxValueTables.tsx
@@ -52,7 +52,7 @@ export const noonModelTableColumns: Column[] = [
   ...sharedColumns,
   {
     id: 'delta_precipitation',
-    label: 'Precip (mm/cm)',
+    label: 'Precip (mm)',
     minWidth: 70,
     maxWidth: 100,
     align: 'right',
@@ -88,7 +88,7 @@ export const noonForecastTableColumns: Column[] = [
   ...sharedColumns,
   {
     id: 'total_precipitation',
-    label: 'Precip (mm/cm)',
+    label: 'Precip (mm)',
     minWidth: 70,
     maxWidth: 100,
     align: 'right',

--- a/web/src/features/fireWeather/components/tables/ObservationTable.tsx
+++ b/web/src/features/fireWeather/components/tables/ObservationTable.tsx
@@ -43,7 +43,7 @@ export const columns: Column[] = [
   },
   {
     id: 'precipitation',
-    label: 'Precip (mm/cm)',
+    label: 'Precip (mm)',
     minWidth: 70,
     maxWidth: 100,
     align: 'right',


### PR DESCRIPTION
The original ticket was to create a tooltip in the tables to explain the "mm/cm" units for precip. After consulting with Jesse and Matt, they felt the more appropriate units for precip were simply mm. So I've just updated the labels in the tables & graphs. No tooltip added.