### PR TITLE
Modifies gdal import to gracefully handle new and old import string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ tmp/
 
 # Static files
 api/static/*
+
+# Intellij
+.idea

--- a/api/app/weather_models/process_grib.py
+++ b/api/app/weather_models/process_grib.py
@@ -8,7 +8,6 @@ import logging.config
 from typing import List
 from sqlalchemy.dialects.postgresql import array
 import sqlalchemy.exc
-import gdal
 from pyproj import CRS, Transformer
 import app.db.database
 from app.stations import get_stations_synchronously
@@ -16,6 +15,10 @@ from app.db.models import (
     PredictionModel, PredictionModelRunTimestamp, ModelRunGridSubsetPrediction)
 from app.db.crud.weather_models import (
     get_prediction_model, get_or_create_prediction_run, get_or_create_grid_subset)
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Discovered gdal import string has changed.

See https://pypi.org/project/GDAL/3.2.1/#usage (the example try/catch block)

Verified the approach works with old `import gdal` on Sybrand's machine.

Also snuck in `.gitignore` declaration to ignore Intellij IDE config folder.