### PR TITLE
Remove launchpad and OCP3 deployment

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,32 +19,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Clean up api (OCP3)
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_cleanup.sh ${SUFFIX} apply
-
       - name: Clean up api - dev (OCP4)
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools PROJ_DEV=e1e498-dev openshift/scripts/oc_cleanup_dev.sh ${SUFFIX} apply
+        shell: bash
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools PROJ_DEV=e1e498-dev bash openshift/scripts/oc_cleanup_dev.sh ${SUFFIX} apply
 
       - name: Clean up api - tools (OCP4)
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_TOOL_TOKEN }}
-          SCRIPT: PROJ_TOOLS=e1e498-tools PROJ_DEV=e1e498-dev openshift/scripts/oc_cleanup_tools.sh ${SUFFIX} apply
-
-      - name: Clean up database (OCP3)
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_cleanup_db_ocp3.sh ${SUFFIX} apply
+        shell: bash
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_TOOL_TOKEN }}"
+          PROJ_TOOLS=e1e498-tools PROJ_DEV=e1e498-dev bash openshift/scripts/oc_cleanup_tools.sh ${SUFFIX} apply
 
       - name: Clean up database (OCP4)
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools PROJ_DEV=e1e498-dev openshift/scripts/oc_cleanup_db.sh ${SUFFIX} apply
+        shell: bash
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools PROJ_DEV=e1e498-dev bash openshift/scripts/oc_cleanup_db.sh ${SUFFIX} apply

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Deploy PostGIS instance
         shell: bash
         run: |
-          oc login "https://api.silver.devops.gov.bc.ca:6443" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          oc login "${{OPENSHIFT_CLUSTER}}" --token="${{ secrets.OC4_DEV_TOKEN }}"
           EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools bash openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
         # uses: bcgov/openshift-launchpad-deployment@v1.2
         # with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -23,106 +23,84 @@ jobs:
         run: |
           oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
           EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools bash openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
-        # uses: bcgov/openshift-launchpad-deployment@v1.2
-        # with:
-        # AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-        # SCRIPT: EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
 
-  # prepare-database-backups-ocp4:
-  #   name: Prepare Dev Database Backups (OCP4)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set Variables
-  #       shell: bash
-  #       run: |
-  #         echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
+  prepare-database-backups-ocp4:
+    name: Prepare Dev Database Backups (OCP4)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Variables
+        shell: bash
+        run: |
+          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
 
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: Postgres Backup Deployment Config
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_postgres.sh ${SUFFIX} apply
+      - name: Postgres Backup Deployment Config
+        shell: bash
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_postgres.sh ${SUFFIX} apply
 
-  #     - name: Postgres Backup Cronjob
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_postgres_cronjob.sh ${SUFFIX} apply
+      - name: Postgres Backup Cronjob
+        shell: bash
+        run: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_postgres_cronjob.sh ${SUFFIX} apply
 
-  #     - name: Prepare MariaDB Backup Deployment Config
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_mariadb.sh ${SUFFIX} apply
+      - name: Prepare MariaDB Backup Deployment Config
+        shell: bash
+        run: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_mariadb.sh ${SUFFIX} apply
 
-  #     - name: Prepare MariaDB Backup Cronjob
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_mariadb_cronjob.sh ${SUFFIX} apply
+      - name: Prepare MariaDB Backup Cronjob
+        shell: bash
+        run: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_mariadb_cronjob.sh ${SUFFIX} apply
 
-  # build-and-deploy-ocp4:
-  #   name: Build, Deploy to Dev & ZAP Baseline Scan (OCP4)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set Variables
-  #       shell: bash
-  #       run: |
-  #         echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
+  build-and-deploy-ocp4:
+    name: Build, Deploy to Dev & ZAP Baseline Scan (OCP4)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Variables
+        shell: bash
+        run: |
+          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
 
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: Build Image
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_TOOL_TOKEN }}
-  #         SCRIPT: GIT_BRANCH=${GITHUB_HEAD_REF} PROJ_TOOLS="e1e498-tools" PROJ_DEV="e1e498-dev" DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/e1e498-tools/uvicorn-gunicorn-fastapi:python3.8-latest" openshift/scripts/oc_build.sh ${SUFFIX} apply
+      - name: Build Image
+        shell: bash
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          GIT_BRANCH=${GITHUB_HEAD_REF} PROJ_TOOLS="e1e498-tools" PROJ_DEV="e1e498-dev" DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/e1e498-tools/uvicorn-gunicorn-fastapi:python3.8-latest" bash openshift/scripts/oc_build.sh ${SUFFIX} apply
 
-  #     - name: Deploy to Dev
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" SECOND_LEVEL_DOMAIN="apps.silver.devops.gov.bc.ca" openshift/scripts/oc_deploy.sh ${SUFFIX} apply
+      - name: Deploy to Dev
+        shell: bash
+        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" SECOND_LEVEL_DOMAIN="apps.silver.devops.gov.bc.ca" bash openshift/scripts/oc_deploy.sh ${SUFFIX} apply
 
-  #     - name: Hourly actuals cronjob (Marvin)
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh ${SUFFIX} apply
+      - name: Hourly actuals cronjob (Marvin)
+        shell: bash
+        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh ${SUFFIX} apply
 
-  #     - name: Noon forecasts cronjob (Bender)
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh ${SUFFIX} apply
+      - name: Noon forecasts cronjob (Bender)
+        shell: bash
+        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh ${SUFFIX} apply
 
-  #     - name: Environment Canada GDPS cronjob (Donald)
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_gdps_cronjob.sh ${SUFFIX} apply
+      - name: Environment Canada GDPS cronjob (Donald)
+        shell: bash
+        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_gdps_cronjob.sh ${SUFFIX} apply
 
-  #     - name: Environment Canada HRDPS cronjob (Donald)
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_hrdps_cronjob.sh ${SUFFIX} apply
+      - name: Environment Canada HRDPS cronjob (Donald)
+        shell: bash
+        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh ${SUFFIX} apply
 
-  #     - name: Environment Canada RDPS cronjob (Donald)
-  #       uses: bcgov/openshift-launchpad-deployment@v1.2
-  #       with:
-  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
+      - name: Environment Canada RDPS cronjob (Donald)
+        shell: bash
+        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
 
-  #     # # f.y.i.: ZAP Scan must be able to log an issue or it will fail.
-  #     - name: ZAP Scan
-  #       uses: zaproxy/action-baseline@v0.4.0
-  #       with:
-  #         target: "https://wps-pr-${{ github.event.number }}.apps.silver.devops.gov.bc.ca"
-  #         rules_file_name: ".zap/rules.tsv"
-  #         # Do not return failure on warnings - TODO: this has to be resolved!
-  #         cmd_options: "-I"
+      # # f.y.i.: ZAP Scan must be able to log an issue or it will fail.
+      - name: ZAP Scan
+        uses: zaproxy/action-baseline@v0.4.0
+        with:
+          target: "https://wps-pr-${{ github.event.number }}.apps.silver.devops.gov.bc.ca"
+          rules_file_name: ".zap/rules.tsv"
+          # Do not return failure on warnings - TODO: this has to be resolved!
+          cmd_options: "-I"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build Image
         shell: bash
         run: |
-          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_TOOL_TOKEN }}"
           GIT_BRANCH=${GITHUB_HEAD_REF} PROJ_TOOLS="e1e498-tools" PROJ_DEV="e1e498-dev" DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/e1e498-tools/uvicorn-gunicorn-fastapi:python3.8-latest" bash openshift/scripts/oc_build.sh ${SUFFIX} apply
 
       - name: Deploy to Dev

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,217 +19,109 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Deploy PostGIS instance
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
-
-  prepare-database:
-    name: Prepare Dev Database (OCP3)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set Variables
         shell: bash
         run: |
-          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
+          oc login "https://api.silver.devops.gov.bc.ca:6443" --token="${{ secrets.OC4_DEV_TOKEN }}"
+        # uses: bcgov/openshift-launchpad-deployment@v1.2
+        # with:
+        # AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+        # SCRIPT: EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
 
-      - name: Checkout
-        uses: actions/checkout@v2
+  # prepare-database-backups-ocp4:
+  #   name: Prepare Dev Database Backups (OCP4)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set Variables
+  #       shell: bash
+  #       run: |
+  #         echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
 
-      - name: Deploy PostGIS instance
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_db_ocp3.sh ${SUFFIX} apply
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
 
-  prepare-database-backups:
-    name: Prepare Dev Database Backups (OCP3)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set Variables
-        shell: bash
-        run: |
-          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
+  #     - name: Postgres Backup Deployment Config
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_postgres.sh ${SUFFIX} apply
 
-      - name: Checkout
-        uses: actions/checkout@v2
+  #     - name: Postgres Backup Cronjob
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_postgres_cronjob.sh ${SUFFIX} apply
 
-      - name: Prepare Matomo Backup Volume PVC
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_provision_matomo_backup_pvc.sh ${SUFFIX} apply
+  #     - name: Prepare MariaDB Backup Deployment Config
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_mariadb.sh ${SUFFIX} apply
 
-      - name: Prepare Matomo Backup Deployment Config
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_provision_matomo_backup.sh ${SUFFIX} apply
+  #     - name: Prepare MariaDB Backup Cronjob
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_mariadb_cronjob.sh ${SUFFIX} apply
 
-      - name: Prepare Matomo Backup Cronjob
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_provision_matomo_backup_cronjob.sh ${SUFFIX} apply
+  # build-and-deploy-ocp4:
+  #   name: Build, Deploy to Dev & ZAP Baseline Scan (OCP4)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set Variables
+  #       shell: bash
+  #       run: |
+  #         echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
 
-  prepare-database-backups-ocp4:
-    name: Prepare Dev Database Backups (OCP4)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set Variables
-        shell: bash
-        run: |
-          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
 
-      - name: Checkout
-        uses: actions/checkout@v2
+  #     - name: Build Image
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_TOOL_TOKEN }}
+  #         SCRIPT: GIT_BRANCH=${GITHUB_HEAD_REF} PROJ_TOOLS="e1e498-tools" PROJ_DEV="e1e498-dev" DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/e1e498-tools/uvicorn-gunicorn-fastapi:python3.8-latest" openshift/scripts/oc_build.sh ${SUFFIX} apply
 
-      - name: Postgres Backup Deployment Config
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_postgres.sh ${SUFFIX} apply
+  #     - name: Deploy to Dev
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" SECOND_LEVEL_DOMAIN="apps.silver.devops.gov.bc.ca" openshift/scripts/oc_deploy.sh ${SUFFIX} apply
 
-      - name: Postgres Backup Cronjob
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_postgres_cronjob.sh ${SUFFIX} apply
+  #     - name: Hourly actuals cronjob (Marvin)
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh ${SUFFIX} apply
 
-      - name: Prepare MariaDB Backup Deployment Config
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_mariadb.sh ${SUFFIX} apply
+  #     - name: Noon forecasts cronjob (Bender)
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh ${SUFFIX} apply
 
-      - name: Prepare MariaDB Backup Cronjob
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True openshift/scripts/oc_provision_backup_mariadb_cronjob.sh ${SUFFIX} apply
+  #     - name: Environment Canada GDPS cronjob (Donald)
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_gdps_cronjob.sh ${SUFFIX} apply
 
-  build-and-deploy:
-    name: Build, Deploy to Dev & ZAP Baseline Scan (OCP3)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set Variables
-        shell: bash
-        run: |
-          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
+  #     - name: Environment Canada HRDPS cronjob (Donald)
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_hrdps_cronjob.sh ${SUFFIX} apply
 
-      - name: Checkout
-        uses: actions/checkout@v2
+  #     - name: Environment Canada RDPS cronjob (Donald)
+  #       uses: bcgov/openshift-launchpad-deployment@v1.2
+  #       with:
+  #         AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
+  #         SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
 
-      - name: Build Image
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_TOOL_TOKEN_EDIT }}
-          SCRIPT: GIT_BRANCH=${GITHUB_HEAD_REF} DOCKER_FILE="Dockerfile.ocp3" openshift/scripts/oc_build.sh ${SUFFIX} apply
-
-      - name: Deploy to Dev
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_deploy.sh ${SUFFIX} apply
-
-      - name: Hourly actuals cronjob (Marvin)
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh ${SUFFIX} apply
-
-      - name: Noon forecasts cronjob (Bender)
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh ${SUFFIX} apply
-
-      - name: Environment Canada GDPS cronjob (Donald)
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_provision_ec_gdps_cronjob.sh ${SUFFIX} apply
-
-      - name: Environment Canada HRDPS cronjob (Donald)
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_provision_ec_hrdps_cronjob.sh ${SUFFIX} apply
-
-      - name: Environment Canada RDPS cronjob (Donald)
-        uses: bcgov/openshift-launchpad-deployment@v1.1
-        with:
-          AUTH_TOKEN: ${{ secrets.OC_DEV_TOKEN_EDIT }}
-          SCRIPT: openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
-
-      # f.y.i.: ZAP Scan must be able to log an issue or it will fail.
-      - name: ZAP Scan
-        uses: zaproxy/action-baseline@v0.4.0
-        with:
-          target: "https://wps-pr-${{ github.event.number }}.pathfinder.gov.bc.ca"
-          rules_file_name: ".zap/rules.tsv"
-          # Do not return failure on warnings - TODO: this has to be resolved!
-          cmd_options: "-I"
-
-  build-and-deploy-ocp4:
-    name: Build, Deploy to Dev & ZAP Baseline Scan (OCP4)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set Variables
-        shell: bash
-        run: |
-          echo "SUFFIX=pr-${{ github.event.number }}" >> $GITHUB_ENV
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Build Image
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_TOOL_TOKEN }}
-          SCRIPT: GIT_BRANCH=${GITHUB_HEAD_REF} PROJ_TOOLS="e1e498-tools" PROJ_DEV="e1e498-dev" DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/e1e498-tools/uvicorn-gunicorn-fastapi:python3.8-latest" openshift/scripts/oc_build.sh ${SUFFIX} apply
-
-      - name: Deploy to Dev
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" SECOND_LEVEL_DOMAIN="apps.silver.devops.gov.bc.ca" openshift/scripts/oc_deploy.sh ${SUFFIX} apply
-
-      - name: Hourly actuals cronjob (Marvin)
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh ${SUFFIX} apply
-
-      - name: Noon forecasts cronjob (Bender)
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh ${SUFFIX} apply
-
-      - name: Environment Canada GDPS cronjob (Donald)
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_gdps_cronjob.sh ${SUFFIX} apply
-
-      - name: Environment Canada HRDPS cronjob (Donald)
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_hrdps_cronjob.sh ${SUFFIX} apply
-
-      - name: Environment Canada RDPS cronjob (Donald)
-        uses: bcgov/openshift-launchpad-deployment@v1.2
-        with:
-          AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}
-          SCRIPT: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
-
-      # # f.y.i.: ZAP Scan must be able to log an issue or it will fail.
-      - name: ZAP Scan
-        uses: zaproxy/action-baseline@v0.4.0
-        with:
-          target: "https://wps-pr-${{ github.event.number }}.apps.silver.devops.gov.bc.ca"
-          rules_file_name: ".zap/rules.tsv"
-          # Do not return failure on warnings - TODO: this has to be resolved!
-          cmd_options: "-I"
+  #     # # f.y.i.: ZAP Scan must be able to log an issue or it will fail.
+  #     - name: ZAP Scan
+  #       uses: zaproxy/action-baseline@v0.4.0
+  #       with:
+  #         target: "https://wps-pr-${{ github.event.number }}.apps.silver.devops.gov.bc.ca"
+  #         rules_file_name: ".zap/rules.tsv"
+  #         # Do not return failure on warnings - TODO: this has to be resolved!
+  #         cmd_options: "-I"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Deploy PostGIS instance
         shell: bash
         run: |
-          oc login "${{OPENSHIFT_CLUSTER}}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
           EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools bash openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
         # uses: bcgov/openshift-launchpad-deployment@v1.2
         # with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           oc login "https://api.silver.devops.gov.bc.ca:6443" --token="${{ secrets.OC4_DEV_TOKEN }}"
-          EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
+          EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools bash openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
         # uses: bcgov/openshift-launchpad-deployment@v1.2
         # with:
         # AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,6 +22,7 @@ jobs:
         shell: bash
         run: |
           oc login "https://api.silver.devops.gov.bc.ca:6443" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          EPHEMERAL_STORAGE=True PROJ_TARGET=e1e498-dev APP_USER="wps" IMAGE_STREAM_NAMESPACE=e1e498-tools openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
         # uses: bcgov/openshift-launchpad-deployment@v1.2
         # with:
         # AUTH_TOKEN: ${{ secrets.OC4_DEV_TOKEN }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,19 +40,25 @@ jobs:
         shell: bash
         run: |
           oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
-          SCRIPT: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_postgres.sh ${SUFFIX} apply
+          PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_postgres.sh ${SUFFIX} apply
 
       - name: Postgres Backup Cronjob
         shell: bash
-        run: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_postgres_cronjob.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_postgres_cronjob.sh ${SUFFIX} apply
 
       - name: Prepare MariaDB Backup Deployment Config
         shell: bash
-        run: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_mariadb.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_mariadb.sh ${SUFFIX} apply
 
       - name: Prepare MariaDB Backup Cronjob
         shell: bash
-        run: PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_mariadb_cronjob.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          PROJ_TARGET=e1e498-dev PROJ_TOOLS=e1e498-tools IMAGE_NAMESPACE=e1e498-tools EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_backup_mariadb_cronjob.sh ${SUFFIX} apply
 
   build-and-deploy-ocp4:
     name: Build, Deploy to Dev & ZAP Baseline Scan (OCP4)
@@ -74,27 +80,39 @@ jobs:
 
       - name: Deploy to Dev
         shell: bash
-        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" SECOND_LEVEL_DOMAIN="apps.silver.devops.gov.bc.ca" bash openshift/scripts/oc_deploy.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" SECOND_LEVEL_DOMAIN="apps.silver.devops.gov.bc.ca" bash openshift/scripts/oc_deploy.sh ${SUFFIX} apply
 
       - name: Hourly actuals cronjob (Marvin)
         shell: bash
-        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh ${SUFFIX} apply
 
       - name: Noon forecasts cronjob (Bender)
         shell: bash
-        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh ${SUFFIX} apply
 
       - name: Environment Canada GDPS cronjob (Donald)
         shell: bash
-        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_gdps_cronjob.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_gdps_cronjob.sh ${SUFFIX} apply
 
       - name: Environment Canada HRDPS cronjob (Donald)
         shell: bash
-        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh ${SUFFIX} apply
 
       - name: Environment Canada RDPS cronjob (Donald)
         shell: bash
-        run: POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          POSTGRES_WRITE_HOST=patroni-wps-${SUFFIX}-leader POSTGRES_READ_HOST=patroni-wps-${SUFFIX}-replica PROJ_TARGET="e1e498-dev" PROJ_TOOLS="e1e498-tools" POSTGRES_USER="wps" POSTGRES_DATABASE="wps" IMAGE_REGISTRY="image-registry.openshift-image-registry.svc:5000" PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
 
       # # f.y.i.: ZAP Scan must be able to log an issue or it will fail.
       - name: ZAP Scan

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,148 +4,147 @@ on:
   pull_request:
     branches:
       - main
+# jobs:
+#   lint-and-test:
+#     name: Lint, Test with Coverage & SonarQube
+#     # Ubuntu 18.04 (a.k.a. ubuntu-latest) comes with gdal 2.2.3, which has bugs that cause unit tests to fail
+#     runs-on: ubuntu-20.04
+#     strategy:
+#       matrix:
+#         python-version: [3.8]
+#         node-version: [14.x]
+#     steps:
+#       - name: Checkout repo
+#         uses: actions/checkout@v2
+#         with:
+#           # For sonar-scanner to work properly we can't use a shallow fetch.
+#           fetch-depth: 0
 
-jobs:
-  lint-and-test:
-    name: Lint, Test with Coverage & SonarQube
-    # Ubuntu 18.04 (a.k.a. ubuntu-latest) comes with gdal 2.2.3, which has bugs that cause unit tests to fail
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: [3.8]
-        node-version: [14.x]
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          # For sonar-scanner to work properly we can't use a shallow fetch.
-          fetch-depth: 0
+#       - name: Setup kernel for react, increase watchers
+#         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-      - name: Setup kernel for react, increase watchers
-        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+#       - name: Setup Python ${{ matrix.python-version }} (api)
+#         uses: actions/setup-python@v1
+#         with:
+#           python-version: ${{ matrix.python-version }}
 
-      - name: Setup Python ${{ matrix.python-version }} (api)
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
+#       - name: Use Node.js ${{ matrix.node-version }}
+#         uses: actions/setup-node@v1
+#         with:
+#           node-version: ${{ matrix.node-version }}
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
+#       - name: Cache poetry installer
+#         uses: actions/cache@v2
+#         id: cache-poetry-installer
+#         env:
+#           cache-name: cache-poetry-installer
+#         with:
+#           path: "~/poetry_installer"
+#           key: "1.0.8"
 
-      - name: Cache poetry installer
-        uses: actions/cache@v2
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "1.0.8"
+#       - name: Download poetry installer
+#         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
+#         run: |
+#           echo
+#           mkdir ~/poetry_installer
+#           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py > ~/poetry_installer/get-poetry.py
 
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo 
-          mkdir ~/poetry_installer
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py > ~/poetry_installer/get-poetry.py
+#       - name: Install poetry (api)
+#         run: |
+#           cd ~/poetry_installer
+#           python get-poetry.py --version 1.1.4
+#           source ~/.poetry/env
+#           poetry config virtualenvs.create true
+#           poetry config virtualenvs.in-project false
 
-      - name: Install poetry (api)
-        run: |
-          cd ~/poetry_installer
-          python get-poetry.py --version 1.1.4
-          source ~/.poetry/env
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
+#       - name: Install libgdal-dev (api)
+#         # The python gdal component relies on libgdal-dev being installed.
+#         run: |
+#           sudo apt-get update --fix-missing && sudo apt-get -y install libgdal-dev
 
-      - name: Install libgdal-dev (api)
-        # The python gdal component relies on libgdal-dev being installed.
-        run: |
-          sudo apt-get update --fix-missing && sudo apt-get -y install libgdal-dev
+#       # poetry cache folder: /home/runner/.cache/pypoetry
+#       - name: Cache poetry
+#         uses: actions/cache@v2
+#         env:
+#           cache-name: cache-poetry
+#         with:
+#           path: ~/.cache/pypoetry
+#           key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
+#           restore-keys: |
+#             ${{ runner.os }}-poetry-cache-
 
-      # poetry cache folder: /home/runner/.cache/pypoetry
-      - name: Cache poetry
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-cache-
+#       - name: Install gdal python (api)
+#         # We don't have much control over what version of gdal we're getting, it's pretty much whatever is
+#         # available to us. As such, gdal is not installed by poetry, since the versio will differ between
+#         # platforms.
+#         working-directory: ./api
+#         run: |
+#           source ~/.poetry/env
+#           CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal poetry run pip install gdal==$(gdal-config --version)
 
-      - name: Install gdal python (api)
-        # We don't have much control over what version of gdal we're getting, it's pretty much whatever is
-        # available to us. As such, gdal is not installed by poetry, since the versio will differ between
-        # platforms.
-        working-directory: ./api
-        run: |
-          source ~/.poetry/env
-          CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal poetry run pip install gdal==$(gdal-config --version)
+#       - name: Install remaining python dependencies (api)
+#         working-directory: ./api
+#         run: |
+#           source ~/.poetry/env
+#           poetry install
 
-      - name: Install remaining python dependencies (api)
-        working-directory: ./api
-        run: |
-          source ~/.poetry/env
-          poetry install
+#       - name: Lint (api)
+#         working-directory: ./api
+#         run: |
+#           source ~/.poetry/env
+#           poetry run pylint --rcfile=.pylintrc app/*.py app/**/*.py
 
-      - name: Lint (api)
-        working-directory: ./api
-        run: |
-          source ~/.poetry/env
-          poetry run pylint --rcfile=.pylintrc app/*.py app/**/*.py
+#       - name: Unit Test with coverage (api)
+#         working-directory: ./api
+#         run: |
+#           source ~/.poetry/env
+#           ORIGINS=testorigin poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings --verbose
 
-      - name: Unit Test with coverage (api)
-        working-directory: ./api
-        run: |
-          source ~/.poetry/env
-          ORIGINS=testorigin poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings --verbose
+#       - name: Create coverage report (api)
+#         # Create coverage report, and then replace occurrences of
+#         # 'filename="app' with 'filename="api/app" in coverage-report.xml
+#         working-directory: ./api
+#         shell: bash
+#         run: |
+#           source ~/.poetry/env
+#           poetry run coverage report
+#           poetry run coverage xml -o coverage-reports/coverage-report.xml
+#           sed -i 's/filename="app/filename="api\/app/' coverage-reports/coverage-report.xml
 
-      - name: Create coverage report (api)
-        # Create coverage report, and then replace occurrences of
-        # 'filename="app' with 'filename="api/app" in coverage-report.xml
-        working-directory: ./api
-        shell: bash
-        run: |
-          source ~/.poetry/env
-          poetry run coverage report
-          poetry run coverage xml -o coverage-reports/coverage-report.xml
-          sed -i 's/filename="app/filename="api\/app/' coverage-reports/coverage-report.xml
+#       - uses: actions/cache@v2
+#         with:
+#           path: |
+#             **/node_modules
+#             ~/.cache/Cypress
+#           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+#       - name: Install node dependencies (web)
+#         working-directory: ./web
+#         if: steps.yarn-cache.outputs.cache-hit != 'true'
+#         run: yarn install
 
-      - name: Install node dependencies (web)
-        working-directory: ./web
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install
+#       - name: Lint (web)
+#         working-directory: ./web
+#         run: yarn run lint
 
-      - name: Lint (web)
-        working-directory: ./web
-        run: yarn run lint
+#       # "Error: ENOSPC: System limit for number of file watchers reached" can be addressed
+#       # with this: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
+#       # It seems unnecessary at the moment because tests pass anyway
+#       - name: Cypress tests with coverage (web)
+#         working-directory: ./web
+#         run: yarn run cypress:ci
 
-      # "Error: ENOSPC: System limit for number of file watchers reached" can be addressed
-      # with this: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
-      # It seems unnecessary at the moment because tests pass anyway
-      - name: Cypress tests with coverage (web)
-        working-directory: ./web
-        run: yarn run cypress:ci
+#       - name: Unit tests (web)
+#         working-directory: ./web
+#         run: yarn run test:ci
 
-      - name: Unit tests (web)
-        working-directory: ./web
-        run: yarn run test:ci
+#       - name: Fix code coverage paths (web)
+#         # Due to the way sonarscanner mounts thing when running in docker, we need to change the coverage file.
+#         working-directory: ./web/coverage
+#         run: sed -i 's/\/home\/runner\/work\/wps\/wps\/web\//\/github\/workspace\//g' lcov.info
 
-      - name: Fix code coverage paths (web)
-        # Due to the way sonarscanner mounts thing when running in docker, we need to change the coverage file.
-        working-directory: ./web/coverage
-        run: sed -i 's/\/home\/runner\/work\/wps\/wps\/web\//\/github\/workspace\//g' lcov.info
-
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#       - name: SonarCloud Scan
+#         uses: sonarsource/sonarcloud-github-action@master
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,147 +4,147 @@ on:
   pull_request:
     branches:
       - main
-# jobs:
-#   lint-and-test:
-#     name: Lint, Test with Coverage & SonarQube
-#     # Ubuntu 18.04 (a.k.a. ubuntu-latest) comes with gdal 2.2.3, which has bugs that cause unit tests to fail
-#     runs-on: ubuntu-20.04
-#     strategy:
-#       matrix:
-#         python-version: [3.8]
-#         node-version: [14.x]
-#     steps:
-#       - name: Checkout repo
-#         uses: actions/checkout@v2
-#         with:
-#           # For sonar-scanner to work properly we can't use a shallow fetch.
-#           fetch-depth: 0
+jobs:
+  lint-and-test:
+    name: Lint, Test with Coverage & SonarQube
+    # Ubuntu 18.04 (a.k.a. ubuntu-latest) comes with gdal 2.2.3, which has bugs that cause unit tests to fail
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.8]
+        node-version: [14.x]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          # For sonar-scanner to work properly we can't use a shallow fetch.
+          fetch-depth: 0
 
-#       - name: Setup kernel for react, increase watchers
-#         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - name: Setup kernel for react, increase watchers
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-#       - name: Setup Python ${{ matrix.python-version }} (api)
-#         uses: actions/setup-python@v1
-#         with:
-#           python-version: ${{ matrix.python-version }}
+      - name: Setup Python ${{ matrix.python-version }} (api)
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
 
-#       - name: Use Node.js ${{ matrix.node-version }}
-#         uses: actions/setup-node@v1
-#         with:
-#           node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-#       - name: Cache poetry installer
-#         uses: actions/cache@v2
-#         id: cache-poetry-installer
-#         env:
-#           cache-name: cache-poetry-installer
-#         with:
-#           path: "~/poetry_installer"
-#           key: "1.0.8"
+      - name: Cache poetry installer
+        uses: actions/cache@v2
+        id: cache-poetry-installer
+        env:
+          cache-name: cache-poetry-installer
+        with:
+          path: "~/poetry_installer"
+          key: "1.0.8"
 
-#       - name: Download poetry installer
-#         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-#         run: |
-#           echo
-#           mkdir ~/poetry_installer
-#           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py > ~/poetry_installer/get-poetry.py
+      - name: Download poetry installer
+        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
+        run: |
+          echo
+          mkdir ~/poetry_installer
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py > ~/poetry_installer/get-poetry.py
 
-#       - name: Install poetry (api)
-#         run: |
-#           cd ~/poetry_installer
-#           python get-poetry.py --version 1.1.4
-#           source ~/.poetry/env
-#           poetry config virtualenvs.create true
-#           poetry config virtualenvs.in-project false
+      - name: Install poetry (api)
+        run: |
+          cd ~/poetry_installer
+          python get-poetry.py --version 1.1.4
+          source ~/.poetry/env
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project false
 
-#       - name: Install libgdal-dev (api)
-#         # The python gdal component relies on libgdal-dev being installed.
-#         run: |
-#           sudo apt-get update --fix-missing && sudo apt-get -y install libgdal-dev
+      - name: Install libgdal-dev (api)
+        # The python gdal component relies on libgdal-dev being installed.
+        run: |
+          sudo apt-get update --fix-missing && sudo apt-get -y install libgdal-dev
 
-#       # poetry cache folder: /home/runner/.cache/pypoetry
-#       - name: Cache poetry
-#         uses: actions/cache@v2
-#         env:
-#           cache-name: cache-poetry
-#         with:
-#           path: ~/.cache/pypoetry
-#           key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
-#           restore-keys: |
-#             ${{ runner.os }}-poetry-cache-
+      # poetry cache folder: /home/runner/.cache/pypoetry
+      - name: Cache poetry
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-poetry
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-cache-
 
-#       - name: Install gdal python (api)
-#         # We don't have much control over what version of gdal we're getting, it's pretty much whatever is
-#         # available to us. As such, gdal is not installed by poetry, since the versio will differ between
-#         # platforms.
-#         working-directory: ./api
-#         run: |
-#           source ~/.poetry/env
-#           CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal poetry run pip install gdal==$(gdal-config --version)
+      - name: Install gdal python (api)
+        # We don't have much control over what version of gdal we're getting, it's pretty much whatever is
+        # available to us. As such, gdal is not installed by poetry, since the versio will differ between
+        # platforms.
+        working-directory: ./api
+        run: |
+          source ~/.poetry/env
+          CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal poetry run pip install gdal==$(gdal-config --version)
 
-#       - name: Install remaining python dependencies (api)
-#         working-directory: ./api
-#         run: |
-#           source ~/.poetry/env
-#           poetry install
+      - name: Install remaining python dependencies (api)
+        working-directory: ./api
+        run: |
+          source ~/.poetry/env
+          poetry install
 
-#       - name: Lint (api)
-#         working-directory: ./api
-#         run: |
-#           source ~/.poetry/env
-#           poetry run pylint --rcfile=.pylintrc app/*.py app/**/*.py
+      - name: Lint (api)
+        working-directory: ./api
+        run: |
+          source ~/.poetry/env
+          poetry run pylint --rcfile=.pylintrc app/*.py app/**/*.py
 
-#       - name: Unit Test with coverage (api)
-#         working-directory: ./api
-#         run: |
-#           source ~/.poetry/env
-#           ORIGINS=testorigin poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings --verbose
+      - name: Unit Test with coverage (api)
+        working-directory: ./api
+        run: |
+          source ~/.poetry/env
+          ORIGINS=testorigin poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings --verbose
 
-#       - name: Create coverage report (api)
-#         # Create coverage report, and then replace occurrences of
-#         # 'filename="app' with 'filename="api/app" in coverage-report.xml
-#         working-directory: ./api
-#         shell: bash
-#         run: |
-#           source ~/.poetry/env
-#           poetry run coverage report
-#           poetry run coverage xml -o coverage-reports/coverage-report.xml
-#           sed -i 's/filename="app/filename="api\/app/' coverage-reports/coverage-report.xml
+      - name: Create coverage report (api)
+        # Create coverage report, and then replace occurrences of
+        # 'filename="app' with 'filename="api/app" in coverage-report.xml
+        working-directory: ./api
+        shell: bash
+        run: |
+          source ~/.poetry/env
+          poetry run coverage report
+          poetry run coverage xml -o coverage-reports/coverage-report.xml
+          sed -i 's/filename="app/filename="api\/app/' coverage-reports/coverage-report.xml
 
-#       - uses: actions/cache@v2
-#         with:
-#           path: |
-#             **/node_modules
-#             ~/.cache/Cypress
-#           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-#       - name: Install node dependencies (web)
-#         working-directory: ./web
-#         if: steps.yarn-cache.outputs.cache-hit != 'true'
-#         run: yarn install
+      - name: Install node dependencies (web)
+        working-directory: ./web
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
 
-#       - name: Lint (web)
-#         working-directory: ./web
-#         run: yarn run lint
+      - name: Lint (web)
+        working-directory: ./web
+        run: yarn run lint
 
-#       # "Error: ENOSPC: System limit for number of file watchers reached" can be addressed
-#       # with this: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
-#       # It seems unnecessary at the moment because tests pass anyway
-#       - name: Cypress tests with coverage (web)
-#         working-directory: ./web
-#         run: yarn run cypress:ci
+      # "Error: ENOSPC: System limit for number of file watchers reached" can be addressed
+      # with this: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
+      # It seems unnecessary at the moment because tests pass anyway
+      - name: Cypress tests with coverage (web)
+        working-directory: ./web
+        run: yarn run cypress:ci
 
-#       - name: Unit tests (web)
-#         working-directory: ./web
-#         run: yarn run test:ci
+      - name: Unit tests (web)
+        working-directory: ./web
+        run: yarn run test:ci
 
-#       - name: Fix code coverage paths (web)
-#         # Due to the way sonarscanner mounts thing when running in docker, we need to change the coverage file.
-#         working-directory: ./web/coverage
-#         run: sed -i 's/\/home\/runner\/work\/wps\/wps\/web\//\/github\/workspace\//g' lcov.info
+      - name: Fix code coverage paths (web)
+        # Due to the way sonarscanner mounts thing when running in docker, we need to change the coverage file.
+        working-directory: ./web/coverage
+        run: sed -i 's/\/home\/runner\/work\/wps\/wps\/web\//\/github\/workspace\//g' lcov.info
 
-#       - name: SonarCloud Scan
-#         uses: sonarsource/sonarcloud-github-action@master
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -6,134 +6,134 @@ on:
       - main
 
 jobs:
-  # coverage:
-  #   name: SonarQube - (main)
-  #   # Ubuntu 18.04 (a.k.a. ubuntu-latest) comes with gdal 2.2.3, which has bugs that cause unit tests to fail
-  #   runs-on: ubuntu-20.04
-  #   strategy:
-  #     matrix:
-  #       python-version: [3.8]
-  #       node-version: [14.x]
-  #   steps:
-  #     - name: Checkout repo (main)
-  #       uses: actions/checkout@v2
-  #       with:
-  #         # For sonar-scanner to work properly we can't use a shallow fetch.
-  #         fetch-depth: 0
+  coverage:
+    name: SonarQube - (main)
+    # Ubuntu 18.04 (a.k.a. ubuntu-latest) comes with gdal 2.2.3, which has bugs that cause unit tests to fail
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.8]
+        node-version: [14.x]
+    steps:
+      - name: Checkout repo (main)
+        uses: actions/checkout@v2
+        with:
+          # For sonar-scanner to work properly we can't use a shallow fetch.
+          fetch-depth: 0
 
-  #     - name: Setup Python ${{ matrix.python-version }} (api)
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
+      - name: Setup Python ${{ matrix.python-version }} (api)
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
 
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-  #     - name: Cache poetry installer
-  #       uses: actions/cache@v2
-  #       id: cache-poetry-installer
-  #       env:
-  #         cache-name: cache-poetry-installer
-  #       with:
-  #         path: "~/poetry_installer"
-  #         key: "1.0.8"
+      - name: Cache poetry installer
+        uses: actions/cache@v2
+        id: cache-poetry-installer
+        env:
+          cache-name: cache-poetry-installer
+        with:
+          path: "~/poetry_installer"
+          key: "1.0.8"
 
-  #     - name: Download poetry installer
-  #       if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-  #       run: |
-  #         echo
-  #         mkdir ~/poetry_installer
-  #         curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py > ~/poetry_installer/get-poetry.py
+      - name: Download poetry installer
+        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
+        run: |
+          echo
+          mkdir ~/poetry_installer
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py > ~/poetry_installer/get-poetry.py
 
-  #     - name: Install poetry (api)
-  #       run: |
-  #         cd ~/poetry_installer
-  #         python get-poetry.py --version 1.1.4
-  #         source ~/.poetry/env
-  #         poetry config virtualenvs.create true
-  #         poetry config virtualenvs.in-project false
+      - name: Install poetry (api)
+        run: |
+          cd ~/poetry_installer
+          python get-poetry.py --version 1.1.4
+          source ~/.poetry/env
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project false
 
-  #     - name: Install libgdal-dev (api)
-  #       # The python gdal component relies on libgdal-dev being installed.
-  #       run: |
-  #         sudo apt-get update --fix-missing && sudo apt-get -y install libgdal-dev
+      - name: Install libgdal-dev (api)
+        # The python gdal component relies on libgdal-dev being installed.
+        run: |
+          sudo apt-get update --fix-missing && sudo apt-get -y install libgdal-dev
 
-  #     # poetry cache folder: /home/runner/.cache/pypoetry
-  #     - name: Cache poetry
-  #       uses: actions/cache@v2
-  #       env:
-  #         cache-name: cache-poetry
-  #       with:
-  #         path: ~/.cache/pypoetry
-  #         key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-poetry-cache-
+      # poetry cache folder: /home/runner/.cache/pypoetry
+      - name: Cache poetry
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-poetry
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-cache-
 
-  #     - name: Install gdal python (api)
-  #       # We don't have much control over what version of gdal we're getting, it's pretty much whatever is
-  #       # available to us. As such, gdal is not installed by poetry, since the versio will differ between
-  #       # platforms.
-  #       working-directory: ./api
-  #       run: |
-  #         source ~/.poetry/env
-  #         CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal poetry run pip install gdal==$(gdal-config --version)
+      - name: Install gdal python (api)
+        # We don't have much control over what version of gdal we're getting, it's pretty much whatever is
+        # available to us. As such, gdal is not installed by poetry, since the versio will differ between
+        # platforms.
+        working-directory: ./api
+        run: |
+          source ~/.poetry/env
+          CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal poetry run pip install gdal==$(gdal-config --version)
 
-  #     - name: Install remaining python dependencies (api)
-  #       working-directory: ./api
-  #       run: |
-  #         source ~/.poetry/env
-  #         poetry install
+      - name: Install remaining python dependencies (api)
+        working-directory: ./api
+        run: |
+          source ~/.poetry/env
+          poetry install
 
-  #     - name: Unit Test with coverage (api)
-  #       working-directory: ./api
-  #       run: |
-  #         source ~/.poetry/env
-  #         ORIGINS=testorigin poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings --verbose
+      - name: Unit Test with coverage (api)
+        working-directory: ./api
+        run: |
+          source ~/.poetry/env
+          ORIGINS=testorigin poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings --verbose
 
-  #     - name: Create coverage report (api)
-  #       # Create coverage report, and then replace occurrences of
-  #       # 'filename="app' with 'filename="api/app" in coverage-report.xml
-  #       working-directory: ./api
-  #       shell: bash
-  #       run: |
-  #         source ~/.poetry/env
-  #         poetry run coverage report
-  #         poetry run coverage xml -o coverage-reports/coverage-report.xml
-  #         sed -i 's/filename="app/filename="api\/app/' coverage-reports/coverage-report.xml
+      - name: Create coverage report (api)
+        # Create coverage report, and then replace occurrences of
+        # 'filename="app' with 'filename="api/app" in coverage-report.xml
+        working-directory: ./api
+        shell: bash
+        run: |
+          source ~/.poetry/env
+          poetry run coverage report
+          poetry run coverage xml -o coverage-reports/coverage-report.xml
+          sed -i 's/filename="app/filename="api\/app/' coverage-reports/coverage-report.xml
 
-  #     - uses: actions/cache@v2
-  #       with:
-  #         path: "**/node_modules"
-  #         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-  #     - name: Install node dependencies (web)
-  #       working-directory: ./web
-  #       run: npm install yarn --no-package-lock && yarn
+      - name: Install node dependencies (web)
+        working-directory: ./web
+        run: npm install yarn --no-package-lock && yarn
 
-  #     - name: Lint (web)
-  #       working-directory: ./web
-  #       run: yarn run lint
+      - name: Lint (web)
+        working-directory: ./web
+        run: yarn run lint
 
-  #     # "Error: ENOSPC: System limit for number of file watchers reached" can be addressed
-  #     # with this: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
-  #     # It seems unnecessary at the moment because tests pass anyway
-  #     - name: Cypress tests with coverage (web)
-  #       working-directory: ./web
-  #       run: yarn run cypress:ci
+      # "Error: ENOSPC: System limit for number of file watchers reached" can be addressed
+      # with this: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
+      # It seems unnecessary at the moment because tests pass anyway
+      - name: Cypress tests with coverage (web)
+        working-directory: ./web
+        run: yarn run cypress:ci
 
-  #     - name: Unit tests (web)
-  #       working-directory: ./web
-  #       run: yarn run test:ci
+      - name: Unit tests (web)
+        working-directory: ./web
+        run: yarn run test:ci
 
-  #     - name: Fix code coverage paths (web)
-  #       # Due to the way sonarscanner mounts thing when running in docker, we need to change the coverage file.
-  #       working-directory: ./web/coverage
-  #       run: sed -i 's/\/home\/runner\/work\/wps\/wps\/web\//\/github\/workspace\//g' lcov.info
+      - name: Fix code coverage paths (web)
+        # Due to the way sonarscanner mounts thing when running in docker, we need to change the coverage file.
+        working-directory: ./web/coverage
+        run: sed -i 's/\/home\/runner\/work\/wps\/wps\/web\//\/github\/workspace\//g' lcov.info
 
-  #     - name: SonarCloud Scan
-  #       uses: sonarsource/sonarcloud-github-action@master
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -6,134 +6,134 @@ on:
       - main
 
 jobs:
-  coverage:
-    name: SonarQube - (main)
-    # Ubuntu 18.04 (a.k.a. ubuntu-latest) comes with gdal 2.2.3, which has bugs that cause unit tests to fail
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: [3.8]
-        node-version: [14.x]
-    steps:
-      - name: Checkout repo (main)
-        uses: actions/checkout@v2
-        with:
-          # For sonar-scanner to work properly we can't use a shallow fetch.
-          fetch-depth: 0
+  # coverage:
+  #   name: SonarQube - (main)
+  #   # Ubuntu 18.04 (a.k.a. ubuntu-latest) comes with gdal 2.2.3, which has bugs that cause unit tests to fail
+  #   runs-on: ubuntu-20.04
+  #   strategy:
+  #     matrix:
+  #       python-version: [3.8]
+  #       node-version: [14.x]
+  #   steps:
+  #     - name: Checkout repo (main)
+  #       uses: actions/checkout@v2
+  #       with:
+  #         # For sonar-scanner to work properly we can't use a shallow fetch.
+  #         fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }} (api)
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
+  #     - name: Setup Python ${{ matrix.python-version }} (api)
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
+  #     - name: Use Node.js ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
 
-      - name: Cache poetry installer
-        uses: actions/cache@v2
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "1.0.8"
+  #     - name: Cache poetry installer
+  #       uses: actions/cache@v2
+  #       id: cache-poetry-installer
+  #       env:
+  #         cache-name: cache-poetry-installer
+  #       with:
+  #         path: "~/poetry_installer"
+  #         key: "1.0.8"
 
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo 
-          mkdir ~/poetry_installer
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py > ~/poetry_installer/get-poetry.py
+  #     - name: Download poetry installer
+  #       if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
+  #       run: |
+  #         echo
+  #         mkdir ~/poetry_installer
+  #         curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py > ~/poetry_installer/get-poetry.py
 
-      - name: Install poetry (api)
-        run: |
-          cd ~/poetry_installer
-          python get-poetry.py --version 1.1.4
-          source ~/.poetry/env
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
+  #     - name: Install poetry (api)
+  #       run: |
+  #         cd ~/poetry_installer
+  #         python get-poetry.py --version 1.1.4
+  #         source ~/.poetry/env
+  #         poetry config virtualenvs.create true
+  #         poetry config virtualenvs.in-project false
 
-      - name: Install libgdal-dev (api)
-        # The python gdal component relies on libgdal-dev being installed.
-        run: |
-          sudo apt-get update --fix-missing && sudo apt-get -y install libgdal-dev
+  #     - name: Install libgdal-dev (api)
+  #       # The python gdal component relies on libgdal-dev being installed.
+  #       run: |
+  #         sudo apt-get update --fix-missing && sudo apt-get -y install libgdal-dev
 
-      # poetry cache folder: /home/runner/.cache/pypoetry
-      - name: Cache poetry
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-cache-
+  #     # poetry cache folder: /home/runner/.cache/pypoetry
+  #     - name: Cache poetry
+  #       uses: actions/cache@v2
+  #       env:
+  #         cache-name: cache-poetry
+  #       with:
+  #         path: ~/.cache/pypoetry
+  #         key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-poetry-cache-
 
-      - name: Install gdal python (api)
-        # We don't have much control over what version of gdal we're getting, it's pretty much whatever is
-        # available to us. As such, gdal is not installed by poetry, since the versio will differ between
-        # platforms.
-        working-directory: ./api
-        run: |
-          source ~/.poetry/env
-          CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal poetry run pip install gdal==$(gdal-config --version)
+  #     - name: Install gdal python (api)
+  #       # We don't have much control over what version of gdal we're getting, it's pretty much whatever is
+  #       # available to us. As such, gdal is not installed by poetry, since the versio will differ between
+  #       # platforms.
+  #       working-directory: ./api
+  #       run: |
+  #         source ~/.poetry/env
+  #         CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal poetry run pip install gdal==$(gdal-config --version)
 
-      - name: Install remaining python dependencies (api)
-        working-directory: ./api
-        run: |
-          source ~/.poetry/env
-          poetry install
+  #     - name: Install remaining python dependencies (api)
+  #       working-directory: ./api
+  #       run: |
+  #         source ~/.poetry/env
+  #         poetry install
 
-      - name: Unit Test with coverage (api)
-        working-directory: ./api
-        run: |
-          source ~/.poetry/env
-          ORIGINS=testorigin poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings --verbose
+  #     - name: Unit Test with coverage (api)
+  #       working-directory: ./api
+  #       run: |
+  #         source ~/.poetry/env
+  #         ORIGINS=testorigin poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings --verbose
 
-      - name: Create coverage report (api)
-        # Create coverage report, and then replace occurrences of
-        # 'filename="app' with 'filename="api/app" in coverage-report.xml
-        working-directory: ./api
-        shell: bash
-        run: |
-          source ~/.poetry/env
-          poetry run coverage report
-          poetry run coverage xml -o coverage-reports/coverage-report.xml
-          sed -i 's/filename="app/filename="api\/app/' coverage-reports/coverage-report.xml
+  #     - name: Create coverage report (api)
+  #       # Create coverage report, and then replace occurrences of
+  #       # 'filename="app' with 'filename="api/app" in coverage-report.xml
+  #       working-directory: ./api
+  #       shell: bash
+  #       run: |
+  #         source ~/.poetry/env
+  #         poetry run coverage report
+  #         poetry run coverage xml -o coverage-reports/coverage-report.xml
+  #         sed -i 's/filename="app/filename="api\/app/' coverage-reports/coverage-report.xml
 
-      - uses: actions/cache@v2
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+  #     - uses: actions/cache@v2
+  #       with:
+  #         path: "**/node_modules"
+  #         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Install node dependencies (web)
-        working-directory: ./web
-        run: npm install yarn --no-package-lock && yarn
+  #     - name: Install node dependencies (web)
+  #       working-directory: ./web
+  #       run: npm install yarn --no-package-lock && yarn
 
-      - name: Lint (web)
-        working-directory: ./web
-        run: yarn run lint
+  #     - name: Lint (web)
+  #       working-directory: ./web
+  #       run: yarn run lint
 
-      # "Error: ENOSPC: System limit for number of file watchers reached" can be addressed
-      # with this: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
-      # It seems unnecessary at the moment because tests pass anyway
-      - name: Cypress tests with coverage (web)
-        working-directory: ./web
-        run: yarn run cypress:ci
+  #     # "Error: ENOSPC: System limit for number of file watchers reached" can be addressed
+  #     # with this: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
+  #     # It seems unnecessary at the moment because tests pass anyway
+  #     - name: Cypress tests with coverage (web)
+  #       working-directory: ./web
+  #       run: yarn run cypress:ci
 
-      - name: Unit tests (web)
-        working-directory: ./web
-        run: yarn run test:ci
+  #     - name: Unit tests (web)
+  #       working-directory: ./web
+  #       run: yarn run test:ci
 
-      - name: Fix code coverage paths (web)
-        # Due to the way sonarscanner mounts thing when running in docker, we need to change the coverage file.
-        working-directory: ./web/coverage
-        run: sed -i 's/\/home\/runner\/work\/wps\/wps\/web\//\/github\/workspace\//g' lcov.info
+  #     - name: Fix code coverage paths (web)
+  #       # Due to the way sonarscanner mounts thing when running in docker, we need to change the coverage file.
+  #       working-directory: ./web/coverage
+  #       run: sed -i 's/\/home\/runner\/work\/wps\/wps\/web\//\/github\/workspace\//g' lcov.info
 
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #     - name: SonarCloud Scan
+  #       uses: sonarsource/sonarcloud-github-action@master
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
I don't think we need the launchpad? https://github.com/marketplace/actions/openshift-client-installer: "Note that GitHub's Ubuntu Environments come with oc 4.6 installed."

- Switch to using default oc that comes with github actions.
- Remove OCP3 related actions.