### PR TITLE
patroni replicas 3->2 and increase size

### DIFF
--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                     // The size of the storage is in fact 30Gi ; The volume claim for a
                     // stateful set cannot be altered. The stateful set needs to be re-created
                     // and data needs to be restored from backup.
-                    sh "CPU_REQUEST=100m CPU_LIMIT=2000m MEMORY_REQUEST=4Gi MEMORY_LIMIT=8Gi PVC_SIZE=25Gi PROJ_TARGET=${projProd} ./openshift/scripts/oc_provision_db.sh prod apply"
+                    sh "CPU_REQUEST=100m CPU_LIMIT=2000m MEMORY_REQUEST=4Gi MEMORY_LIMIT=8Gi PVC_SIZE=37Gi PROJ_TARGET=${projProd} ./openshift/scripts/oc_provision_db.sh prod apply"
                     // Deploy API
                     sh "CPU_REQUEST=500m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=2Gi REPLICAS=3 PROJ_TARGET=${projProd} SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca ./openshift/scripts/oc_deploy.sh prod apply"
                     // Env Canada Subscriber

--- a/openshift/templates/patroni.yaml
+++ b/openshift/templates/patroni.yaml
@@ -255,7 +255,7 @@ parameters:
     description: |
       The number of StatefulSet replicas to use.
     displayName: REPLICAS
-    value: "3"
+    value: "2"
   - name: CPU_REQUEST
     description: |
       Starting amount of CPU the container can use.


### PR DESCRIPTION
We no longer have space for 3 replicas.
- reduce replicas to 2 (so we have one leader, one follower).
- increase pvc size to 37Gi leaves us more wiggle room.
