### PR TITLE
Fix partial db copy and database size scripts

### DIFF
--- a/api/scripts/copy_partial_db_from_pod_to_local.sh
+++ b/api/scripts/copy_partial_db_from_pod_to_local.sh
@@ -18,6 +18,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(dirname "$0")"
+
 source "$SCRIPT_DIR/common_oc_checks.sh"
 
 #####################
@@ -38,7 +40,7 @@ FILENAME="dump_db.tar"
 # --clean clean (drop) database objects before recreating
 # -Ft output file format (custom, directory, tar, plain text (default))
 # --exclude-table-data get the table definitions, but not the data
-PG_DUMP="pg_dump --file=/tmp/${FILENAME} --clean -Ft ${DATABASE} --exclude-table-data=model_run_grid_subset_predictions --exclude-table-data=weather_station_model_predictions"
+PG_DUMP="pg_dump --file=/tmp/${FILENAME} --clean -Fc ${DATABASE} --exclude-table-data=model_run_grid_subset_predictions --exclude-table-data=weather_station_model_predictions --exclude-table-data=c_haines_polygons"
 # command to dump database on pod.
 BACKUP_COMMAND="${RSH} ${PG_DUMP}"
 

--- a/api/scripts/database_size_report.sh
+++ b/api/scripts/database_size_report.sh
@@ -25,7 +25,6 @@ source "$SCRIPT_DIR/common_oc_checks.sh"
 #
 # See https://wiki.postgresql.org/wiki/TOAST for more info.
 
-https://wiki.postgresql.org/wiki/TOAST
 SIZE_REPORT_QUERY="SELECT *, pg_size_pretty(total_bytes) AS total
     , pg_size_pretty(index_bytes) AS index
     , pg_size_pretty(toast_bytes) AS toast


### PR DESCRIPTION
api/scripts/copy_partial_db_from_pod_to_local.sh: 
- add missing variable
- exclude large `c_haines_polygons` table
- Use custom format for `pg_dump` (tar format has 4GB limit). Custom format is suitable for `pg_restore`: https://www.postgresql.org/docs/9.4/app-pgdump.html

api/scripts/database_size_report.sh
- Remove accidental plain text link
