### PR TITLE
increase memory limit in production

### DIFF
--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                     // CPU: CPU spikes above 1, but is mostly sitting below 0.1.
                     sh "CPU_REQUEST=75m CPU_LIMIT=2000m MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi PVC_SIZE=45Gi PROJ_TARGET=${projProd} ./openshift/scripts/oc_provision_db.sh prod apply"
                     // Deploy API
-                    sh "CPU_REQUEST=50m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=2Gi REPLICAS=3 PROJ_TARGET=${projProd} VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca ./openshift/scripts/oc_deploy.sh prod apply"
+                    sh "CPU_REQUEST=50m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=3Gi REPLICAS=3 PROJ_TARGET=${projProd} VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca ./openshift/scripts/oc_deploy.sh prod apply"
                     // Env Canada Subscriber
                     sh "PROJ_TARGET=${projProd} ./openshift/scripts/oc_provision_ec_gdps_cronjob.sh prod apply"
                     sh "PROJ_TARGET=${projProd} ./openshift/scripts/oc_provision_ec_hrdps_cronjob.sh prod apply"


### PR DESCRIPTION
With more R code running, we need to allocate more memory. We quickly started hitting our 2GB limit.