### PR TITLE
Story/FBC Empty State/1130

### DIFF
--- a/web/src/api/fbCalcAPI.ts
+++ b/web/src/api/fbCalcAPI.ts
@@ -37,7 +37,7 @@ export interface FetchableFBCStation {
   stationCode: number
   fuelType: string
   percentageConifer: number | undefined
-  grassCurePercentage: number | null
+  grassCurePercentage: number | null | undefined
   percentageDeadBalsamFir: number | undefined
   crownBaseHeight: number | undefined
 }

--- a/web/src/features/fireBehaviourCalculator/FireBehaviourCalculatorPage.tsx
+++ b/web/src/features/fireBehaviourCalculator/FireBehaviourCalculatorPage.tsx
@@ -22,15 +22,14 @@ import {
   getMostRecentIdFromRows,
   getRowsFromUrlParams,
   getUrlParamsFromRows,
-  GridMenuOption
+  GridMenuOption,
+  theEmptyOption
 } from './utils'
 
 export const FireBehaviourCalculator: React.FunctionComponent = () => {
   const [dateOfInterest, setDateOfInterest] = useState(DateTime.now().toISODate())
 
   const { stations } = useSelector(selectFireWeatherStations)
-
-  const theEmptyOption: GridMenuOption = { label: '', value: '' }
 
   const stationMenuOptions: GridMenuOption[] = [
     theEmptyOption,

--- a/web/src/features/fireBehaviourCalculator/FireBehaviourCalculatorPage.tsx
+++ b/web/src/features/fireBehaviourCalculator/FireBehaviourCalculatorPage.tsx
@@ -14,14 +14,15 @@ import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
 import DatePicker from './components/DatePicker'
-import FBCInputGrid, { FBCInputRow, GridMenuOption } from './components/FBCInputGrid'
+import FBCInputGrid, { FBCInputRow } from './components/FBCInputGrid'
 import FBCResultTable from './components/FBCResultTable'
 import { FuelTypes } from './fuelTypes'
 import { fetchFireBehaviourStations } from './slices/fireBehaviourCalcSlice'
 import {
   getMostRecentIdFromRows,
   getRowsFromUrlParams,
-  getUrlParamsFromRows
+  getUrlParamsFromRows,
+  GridMenuOption
 } from './utils'
 
 export const FireBehaviourCalculator: React.FunctionComponent = () => {
@@ -29,19 +30,23 @@ export const FireBehaviourCalculator: React.FunctionComponent = () => {
 
   const { stations } = useSelector(selectFireWeatherStations)
 
-  const stationMenuOptions: GridMenuOption[] = (stations as GeoJsonStation[]).map(
-    station => ({
+  const theEmptyOption: GridMenuOption = { label: '', value: '' }
+
+  const stationMenuOptions: GridMenuOption[] = [
+    theEmptyOption,
+    ...(stations as GeoJsonStation[]).map(station => ({
       value: station.properties.code,
       label: `${station.properties.name} (${station.properties.code})`
-    })
-  )
+    }))
+  ]
 
-  const fuelTypeMenuOptions: GridMenuOption[] = Object.entries(FuelTypes.get()).map(
-    ([key, value]) => ({
+  const fuelTypeMenuOptions: GridMenuOption[] = [
+    theEmptyOption,
+    ...Object.entries(FuelTypes.get()).map(([key, value]) => ({
       value: key,
       label: value.friendlyName
-    })
-  )
+    }))
+  ]
   const location = useLocation()
   const history = useHistory()
 
@@ -55,11 +60,11 @@ export const FireBehaviourCalculator: React.FunctionComponent = () => {
   const addStation = () => {
     const newRowId = rowId + 1
     setRowId(newRowId)
-    const newRow = {
+    const newRow: FBCInputRow = {
       id: rowId,
-      weatherStation: stationMenuOptions[0].value.toString(),
-      fuelType: fuelTypeMenuOptions[0].value.toString(),
-      grassCure: 0
+      weatherStation: undefined,
+      fuelType: undefined,
+      grassCure: undefined
     }
     const newRows = [...rows, newRow]
     setRows(newRows)

--- a/web/src/features/fireBehaviourCalculator/components/FBCInputGrid.tsx
+++ b/web/src/features/fireBehaviourCalculator/components/FBCInputGrid.tsx
@@ -60,7 +60,7 @@ const GrassCurePercentageEdit = (props: NumberEditProps) => {
       id="grass-cure-percentage-number"
       type="number"
       value={props.value}
-      required={true}
+      required={false}
     />
   )
 }
@@ -166,10 +166,11 @@ const FBCInputGrid = (props: FBCInputGridProps) => {
     return (
       <Autocomplete
         id={`combo-box-fuel-types-${Math.random()}`}
+        disableClearable={true}
         getOptionSelected={(option, value) => isEqual(option, value)}
         options={options}
         getOptionLabel={option => option?.label}
-        style={{ width: 300, height: '100%', marginTop: 20 }}
+        style={{ width: 300 }}
         renderInput={params => <TextField {...params} label={label} variant="outlined" />}
         onChange={handleChange}
         value={finalVal}

--- a/web/src/features/fireBehaviourCalculator/fuelTypes.ts
+++ b/web/src/features/fireBehaviourCalculator/fuelTypes.ts
@@ -1,3 +1,5 @@
+import { isNull, isUndefined } from 'lodash'
+
 export interface FBCFuelType {
   name: string
   friendlyName: string
@@ -6,7 +8,10 @@ export interface FBCFuelType {
   crown_base_height: number | undefined
 }
 export class FuelTypes {
-  static lookup(key: string): FBCFuelType {
+  static lookup(key: string | null | undefined): FBCFuelType | null {
+    if (isUndefined(key) || isNull(key)) {
+      return null
+    }
     return FuelTypes.get()[key]
   }
   static getFriendlyNames(): string[] {

--- a/web/src/features/fireBehaviourCalculator/slices/fireBehaviourCalcSlice.ts
+++ b/web/src/features/fireBehaviourCalculator/slices/fireBehaviourCalcSlice.ts
@@ -55,7 +55,8 @@ export const fetchFireBehaviourStations = (
   const fetchableFireStations = fbcInputRows.flatMap(row => {
     const fuelTypeDetails = FuelTypes.lookup(row.fuelType)
     if (
-      fuelTypeDetails !== null &&
+      !isNull(fuelTypeDetails) &&
+      !isUndefined(fuelTypeDetails) &&
       !isNull(row.weatherStation) &&
       !isUndefined(row.weatherStation) &&
       !isNull(row.fuelType) &&

--- a/web/src/features/fireBehaviourCalculator/slices/fireBehaviourCalcSlice.ts
+++ b/web/src/features/fireBehaviourCalculator/slices/fireBehaviourCalcSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { FBCStation, postFBCStations } from 'api/fbCalcAPI'
 
 import { AppThunk } from 'app/store'
+import { isNull, isUndefined } from 'lodash'
 import { logError } from 'utils/error'
 import { FBCInputRow } from '../components/FBCInputGrid'
 import { FuelTypes } from '../fuelTypes'
@@ -51,16 +52,26 @@ export const fetchFireBehaviourStations = (
   date: string,
   fbcInputRows: FBCInputRow[]
 ): AppThunk => async dispatch => {
-  const fetchableFireStations = fbcInputRows.map(row => {
+  const fetchableFireStations = fbcInputRows.flatMap(row => {
     const fuelTypeDetails = FuelTypes.lookup(row.fuelType)
-    return {
-      date,
-      stationCode: parseInt(row.weatherStation),
-      fuelType: fuelTypeDetails.name,
-      percentageConifer: fuelTypeDetails.percentage_conifer,
-      grassCurePercentage: row.grassCure,
-      percentageDeadBalsamFir: fuelTypeDetails.percentage_dead_balsam_fir,
-      crownBaseHeight: fuelTypeDetails.crown_base_height
+    if (
+      fuelTypeDetails !== null &&
+      !isNull(row.weatherStation) &&
+      !isUndefined(row.weatherStation) &&
+      !isNull(row.fuelType) &&
+      !isUndefined(row.fuelType)
+    ) {
+      return {
+        date,
+        stationCode: parseInt(row.weatherStation),
+        fuelType: fuelTypeDetails.name,
+        percentageConifer: fuelTypeDetails.percentage_conifer,
+        grassCurePercentage: row.grassCure,
+        percentageDeadBalsamFir: fuelTypeDetails.percentage_dead_balsam_fir,
+        crownBaseHeight: fuelTypeDetails.crown_base_height
+      }
+    } else {
+      return []
     }
   })
   try {

--- a/web/src/features/fireBehaviourCalculator/utils.ts
+++ b/web/src/features/fireBehaviourCalculator/utils.ts
@@ -92,3 +92,10 @@ export const getMostRecentIdFromRows = (rows: FBCInputRow[]): number => {
   const lastId = _.isEmpty(rows) ? 0 : lastIdFromExisting
   return lastId
 }
+
+export interface GridMenuOption {
+  label: string
+  value: string | number
+}
+
+export const theEmptyOption: GridMenuOption = { label: '', value: '' }


### PR DESCRIPTION
https://wps-pr-1142.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator

- Empty state has "select a" user prompt label
- Investigated empty state label misalignment but it's not clear that MaterialUI supports styling this easily + this current table is temporary
- Remove the "X" clear button from select drop downs as they do not work