### PR TITLE
Border highlighting for adjusted windspeed inputs

### DIFF
--- a/web/src/features/fbaCalculator/components/FBAInputGrid.tsx
+++ b/web/src/features/fbaCalculator/components/FBAInputGrid.tsx
@@ -74,7 +74,8 @@ const useStyles = makeStyles({
     maxWidth: 1900
   },
   adjustedValueCell: {
-    fontWeight: 'bold'
+    fontWeight: 'bold',
+    color: '#460270'
   }
 })
 
@@ -313,14 +314,7 @@ const FBAInputGrid = (props: FBAInputGridProps) => {
                     <TableCell>{row.temp}</TableCell>
                     <TableCell>{row.rh}</TableCell>
                     <TableCell>{row.wind_direction}</TableCell>
-                    <TableCell
-                      className={
-                        !isUndefined(row.status) &&
-                        row.status.toLowerCase() === 'adjusted'
-                          ? classes.adjustedValueCell
-                          : undefined
-                      }
-                    >
+                    <TableCell>
                       <WindSpeedCell
                         fbaInputGridProps={props}
                         inputValue={row.windSpeed}

--- a/web/src/features/fbaCalculator/components/FBAInputGrid.tsx
+++ b/web/src/features/fbaCalculator/components/FBAInputGrid.tsx
@@ -323,7 +323,6 @@ const FBAInputGrid = (props: FBAInputGridProps) => {
                     >
                       <WindSpeedCell
                         fbaInputGridProps={props}
-                        classNameMap={classes}
                         inputValue={row.windSpeed}
                         calculatedValue={
                           calculatedResults.length > 0 && ri < calculatedResults.length

--- a/web/src/features/fbaCalculator/components/WindSpeedCell.tsx
+++ b/web/src/features/fbaCalculator/components/WindSpeedCell.tsx
@@ -16,9 +16,6 @@ export interface WindSpeedCellProps {
 const useStyles = makeStyles({
   windSpeed: {
     width: 80
-  },
-  adjustedValueCell: {
-    border: '2px solid #460270'
   }
 })
 

--- a/web/src/features/fbaCalculator/components/WindSpeedCell.tsx
+++ b/web/src/features/fbaCalculator/components/WindSpeedCell.tsx
@@ -1,5 +1,5 @@
-import { TextField, Tooltip } from '@material-ui/core'
-import { ClassNameMap } from '@material-ui/core/styles/withStyles'
+import { TextField, Tooltip, makeStyles } from '@material-ui/core'
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles'
 import { FBAInputGridProps } from 'features/fbaCalculator/components/FBAInputGrid'
 import { updateFBARow, buildUpdatedNumberRow } from 'features/fbaCalculator/tableState'
 import { isWindSpeedInvalid } from 'features/fbaCalculator/validation'
@@ -8,12 +8,32 @@ import React, { ChangeEvent, useState, useEffect } from 'react'
 
 export interface WindSpeedCellProps {
   fbaInputGridProps: Pick<FBAInputGridProps, 'stationOptions' | 'inputRows' | 'updateRow'>
-  classNameMap: ClassNameMap<'windSpeed'>
   inputValue: number | undefined
   calculatedValue: number | undefined
   rowId: number
 }
+
+const useStyles = makeStyles({
+  windSpeed: {
+    width: 80
+  },
+  adjustedValueCell: {
+    border: '2px solid #460270'
+  }
+})
+
+const adjustedTheme = createMuiTheme({
+  overrides: {
+    MuiInputBase: {
+      root: {
+        border: '2px solid #460270'
+      }
+    }
+  }
+})
+
 const WindSpeedCell = (props: WindSpeedCellProps) => {
+  const classes = useStyles()
   const value = props.calculatedValue ? props.calculatedValue : props.inputValue
   const [windSpeedValue, setWindSpeedValue] = useState(value)
   useEffect(() => {
@@ -55,13 +75,13 @@ const WindSpeedCell = (props: WindSpeedCellProps) => {
 
   const hasError = isWindSpeedInvalid(windSpeedValue)
 
-  return (
+  const buildTextField = () => (
     <Tooltip title="Cannot exceed 120" aria-label="cannot-exceed-120">
       <TextField
         data-testid={`windSpeedInput-${props.rowId}`}
         type="number"
         inputMode="numeric"
-        className={props.classNameMap.windSpeed}
+        className={classes.windSpeed}
         size="small"
         variant="outlined"
         inputProps={{ min: 0, max: 120, step: 'any' }}
@@ -72,6 +92,12 @@ const WindSpeedCell = (props: WindSpeedCellProps) => {
         error={hasError}
       />
     </Tooltip>
+  )
+
+  return props.inputValue && !hasError ? (
+    <ThemeProvider theme={adjustedTheme}>{buildTextField()}</ThemeProvider>
+  ) : (
+    buildTextField()
   )
 }
 

--- a/web/src/features/fbaCalculator/components/windSpeedCell.test.tsx
+++ b/web/src/features/fbaCalculator/components/windSpeedCell.test.tsx
@@ -60,12 +60,28 @@ describe('WindSpeedCell', () => {
     expect(screen.getByTestId('windSpeedInput-0').firstChild?.firstChild).toHaveValue(120)
     expect(screen.getByTestId('windSpeedInput-0').firstChild).not.toHaveClass('Mui-error')
   })
-  it('should not return field in error state when wind speed is set to float under 100', () => {
-    const row = buildInputRow(99.9)
+  it('should not return field in error state when wind speed is set to float under 120', () => {
+    const row = buildInputRow(119.9)
     const props = buildProps(row)
     render(<WindSpeedCell {...props} />)
     expect(screen.getByTestId('windSpeedInput-0').firstChild?.firstChild).toHaveValue(
-      99.9
+      119.9
     )
+  })
+  it('should return field with adjusted border color and weight when there is an input value', () => {
+    const row = buildInputRow(1)
+    const props = buildProps(row)
+    render(<WindSpeedCell {...props} />)
+    expect(screen.getByTestId('windSpeedInput-0').firstChild).toHaveStyle({
+      border: '2px solid #460270'
+    })
+  })
+  it('should return field without adjusted border color and weight when there is no input value', () => {
+    const row = buildInputRow(undefined)
+    const props = buildProps(row)
+    render(<WindSpeedCell {...props} />)
+    expect(screen.getByTestId('windSpeedInput-0').firstChild).toHaveStyle({
+      border: ''
+    })
   })
 })

--- a/web/src/features/fbaCalculator/components/windSpeedCell.test.tsx
+++ b/web/src/features/fbaCalculator/components/windSpeedCell.test.tsx
@@ -20,10 +20,6 @@ describe('WindSpeedCell', () => {
     calculatedValue,
     rowId: 0
   })
-  interface WindSpeedInput {
-    windSpeed: number | undefined
-    calculatedWindSpeed: number | undefined
-  }
   const buildInputRow = (windSpeed: number | undefined) => ({
     id: 0,
     weatherStation: undefined,

--- a/web/src/features/fbaCalculator/components/windSpeedCell.test.tsx
+++ b/web/src/features/fbaCalculator/components/windSpeedCell.test.tsx
@@ -16,7 +16,6 @@ describe('WindSpeedCell', () => {
         /** no op */
       }
     },
-    classNameMap: { windSpeed: '' },
     inputValue: inputRow.windSpeed,
     calculatedValue,
     rowId: 0


### PR DESCRIPTION
Test: https://wps-pr-1212.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator

 - [x] When wind speed is adjusted, a bold/coloured style is applied to the Adjusted status label and the wind speed value that changed (usability heuristics: visibility of system status, recognition rather than recall) 
 - Based on code sandbox quick prototyping of material ui component theme overriding: https://codesandbox.io/s/material-demo-forked-rol4j