### PR TITLE
Calculate HFI for HFI calculator and display it

### DIFF
--- a/api/app/schemas/hfi_calc.py
+++ b/api/app/schemas/hfi_calc.py
@@ -24,6 +24,7 @@ class StationDaily(BaseModel):
     observation_valid: Optional[bool] = None
     observation_valid_comment: Optional[str] = None
     rate_of_spread: Optional[float] = None
+    hfi: Optional[float] = None
 
 
 class StationDailyResponse(BaseModel):

--- a/api/app/tests/test_hfi_dailies.feature
+++ b/api/app/tests/test_hfi_dailies.feature
@@ -19,7 +19,7 @@ Feature: /hfi-calc/daily
         And <danger_class>
 
         Examples:
-            | status_code | start_time_stamp | end_time_stamp | status   | temperature | relative_humidity | wind_direction | wind_speed | precipitation | grass_cure_percentage | ffmc | dc  | dmc | isi | bui | fwi | danger_class |
-            | 200         | 0                | 1              | Observed | 1.0         | 1.0               | 1.0            | 1.0        | 1.0           | 1.0                   | 1.0  | 1.0 | 1.0 | 1.0 | 1.0 | 1.0 | 1.0          |
+            | status_code | start_time_stamp | end_time_stamp | status | temperature | relative_humidity | wind_direction | wind_speed | precipitation | grass_cure_percentage | ffmc | dc  | dmc | isi | bui | fwi | danger_class |
+            | 200         | 0                | 1              | ACTUAL | 1.0         | 1.0               | 1.0            | 1.0        | 1.0           | 1.0                   | 1.0  | 1.0 | 1.0 | 1.0 | 1.0 | 1.0 | 1.0          |
 
 

--- a/api/app/utils/hfi_calculator.py
+++ b/api/app/utils/hfi_calculator.py
@@ -6,7 +6,7 @@ from app.db.crud.hfi_calc import get_all_stations
 from app.db.database import get_read_session_scope
 
 
-# PC, PDF, CC, CDH from the Red Book. Assumes values of 1 CBH.
+# PC, PDF, CC, CDH, CBH from the Red Book where applicable.
 # CC: Assume values of None for non grass types, and 0 for O1A and O1B.
 # TODO: Store then in the DB as columns in FuelType
 # CFL is based on Table 8, page 35, of "Development and Structure of the Canadian Forest Fire Behaviour

--- a/api/app/wildfire_one/schema_parsers.py
+++ b/api/app/wildfire_one/schema_parsers.py
@@ -167,7 +167,7 @@ def generate_station_daily(raw_daily, station: WFWXWeatherStation, fuel_type: st
 
     hfi = None
     try:
-        if ros is not None and cfb is not None:
+        if ros is not None and cfb is not None and cfl is not None:
             hfi = cffdrs.head_fire_intensity(fuel_type=fuel_type,
                                              percentage_conifer=pc,
                                              percentage_dead_balsam_fir=pdf,
@@ -177,7 +177,7 @@ def generate_station_daily(raw_daily, station: WFWXWeatherStation, fuel_type: st
 
     return StationDaily(
         code=station.code,
-        status="Observed" if raw_daily.get('recordType', '').get('id') == 'ACTUAL' else "Forecasted",
+        status=raw_daily.get('recordType', '').get('id', None),
         temperature=raw_daily.get('temperature', None),
         relative_humidity=raw_daily.get('relativeHumidity', None),
         wind_speed=raw_daily.get('windSpeed', None),

--- a/api/app/wildfire_one/schema_parsers.py
+++ b/api/app/wildfire_one/schema_parsers.py
@@ -167,7 +167,7 @@ def generate_station_daily(raw_daily, station: WFWXWeatherStation, fuel_type: st
 
     hfi = None
     try:
-        if sfc is not None and ros is not None and cfb is not None:
+        if ros is not None and cfb is not None:
             hfi = cffdrs.head_fire_intensity(fuel_type=fuel_type,
                                              percentage_conifer=pc,
                                              percentage_dead_balsam_fir=pdf,

--- a/web/src/api/hfiCalculatorAPI.ts
+++ b/web/src/api/hfiCalculatorAPI.ts
@@ -17,6 +17,7 @@ export interface StationDaily {
   fwi: number
   danger_class: number
   rate_of_spread: number
+  hfi: number
   observation_valid: number
   observation_valid_comment: string
 }

--- a/web/src/features/hfiCalculator/components/DailyViewTable.tsx
+++ b/web/src/features/hfiCalculator/components/DailyViewTable.tsx
@@ -159,6 +159,7 @@ const DailyViewTable = (props: Props) => {
                   <br />
                   (m/min)
                 </TableCell>
+                <TableCell>HFI</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -231,6 +232,9 @@ const DailyViewTable = (props: Props) => {
                                     <TableCell>{daily?.danger_class}</TableCell>
                                     <TableCell>
                                       {daily?.rate_of_spread?.toFixed(DECIMAL_PLACES)}
+                                    </TableCell>
+                                    <TableCell>
+                                      {daily?.hfi?.toFixed(DECIMAL_PLACES)}
                                     </TableCell>
                                   </TableRow>
                                 )


### PR DESCRIPTION
Test: https://wps-pr-1214.apps.silver.devops.gov.bc.ca/hfi-calculator

- [x] Given I am logged into the HFI calc, When I look at the daily view table, Then the HFI column is populated for every station displayed.

- HFI depends on `ros`, `cfl` and `sfc` calculated values which are all conditionally computed only if their respective calculations execute without a `CFFDRSException` raised. I'm noticing the `buildUpIndex` field from WFWX API is frequently `None` which causes `sfc` to be None.
- `hfi` depends on `tfc` which does not raise a `CFFDRSException` if `sfc` is `None` so I assume their is a reasonable default set for it.