### PR TITLE
Hotfix: Gracefully handle both conider and conifer

### DIFF
--- a/web/src/features/fbaCalculator/fuelTypes.ts
+++ b/web/src/features/fbaCalculator/fuelTypes.ts
@@ -1,4 +1,4 @@
-import { isUndefined } from 'lodash'
+import { isEqual, isUndefined } from 'lodash'
 
 export interface FBAFuelType {
   name: string
@@ -11,6 +11,10 @@ export class FuelTypes {
   static lookup(key: string | undefined): FBAFuelType | null {
     if (isUndefined(key)) {
       return null
+    }
+    // Special handling for API breaking typo fix in https://github.com/bcgov/wps/pull/1240 (conider -> conifer)
+    if (isEqual(key, 'm2_50conider')) {
+      return FuelTypes.get()['m2_50conifer']
     }
     return FuelTypes.get()[key]
   }
@@ -108,13 +112,6 @@ export class FuelTypes {
         crown_base_height: 6
       },
       m2_50conifer: {
-        name: 'M2',
-        friendlyName: 'M2 50% conifer / 50% deciduous',
-        percentage_conifer: 50,
-        percentage_dead_balsam_fir: undefined,
-        crown_base_height: 6
-      },
-      m2_50conider: {
         name: 'M2',
         friendlyName: 'M2 50% conifer / 50% deciduous',
         percentage_conifer: 50,


### PR DESCRIPTION
Tests: 
- `m2_50conifer`: https://wps-pr-1255.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=322&f=m2_50conifer&c=NaN&w=NaN
- `m2_50conider`: https://wps-pr-1255.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=322&f=m2_50conider&c=NaN&w=NaN

- `FuelTypes.lookup` for `m2_50conider` and `m2_50conifer` return the same object keyed by `m2_50conifer`
- Removes `m2_50conider` key from fuel type map so it is not a drop down option anymore