### PR TITLE
Row sorting: Force empty rows to the bottom

### DIFF
--- a/web/src/features/fbaCalculator/RowManager.ts
+++ b/web/src/features/fbaCalculator/RowManager.ts
@@ -50,84 +50,91 @@ export class RowManager {
     tableRows: FBATableRow[]
   ): FBATableRow[] => {
     const reverseOrder = order === 'asc' ? 'desc' : 'asc'
+    const orderByWithEmptyAtBottom = (field: string, otherOrder?: Order) => {
+      const partition = _.partition(tableRows, x => !!_.get(x, field, null))
+      return _.concat(
+        _.orderBy(partition[0], field, otherOrder ? otherOrder : order),
+        partition[1]
+      )
+    }
     switch (sortByColumn) {
       case SortByColumn.Zone: {
-        return _.orderBy(tableRows, 'zone_code', order)
+        return orderByWithEmptyAtBottom('zone_code')
       }
       case SortByColumn.Station: {
-        return _.orderBy(tableRows, 'station_name', order)
+        return orderByWithEmptyAtBottom('station_name')
       }
       case SortByColumn.Elevation: {
-        return _.orderBy(tableRows, 'elevation', order)
+        return orderByWithEmptyAtBottom('elevation')
       }
       case SortByColumn.FuelType: {
-        return _.orderBy(tableRows, 'fuel_type', order)
+        return orderByWithEmptyAtBottom('fuel_type')
       }
       case SortByColumn.GrassCure: {
-        return _.orderBy(tableRows, 'grass_cure', order)
+        return orderByWithEmptyAtBottom('grass_cure')
       }
       case SortByColumn.Status: {
-        return _.orderBy(tableRows, 'status', order)
+        return orderByWithEmptyAtBottom('status')
       }
       case SortByColumn.Temperature: {
-        return _.orderBy(tableRows, 'temp', order)
+        return orderByWithEmptyAtBottom('temp')
       }
       case SortByColumn.RelativeHumidity: {
-        return _.orderBy(tableRows, 'rh', order)
+        return orderByWithEmptyAtBottom('rh')
       }
       case SortByColumn.WindDirection: {
-        return _.orderBy(tableRows, 'wind_direction', order)
+        return orderByWithEmptyAtBottom('wind_direction')
       }
       case SortByColumn.WindSpeed: {
-        return _.orderBy(tableRows, 'wind_speed', order)
+        return orderByWithEmptyAtBottom('wind_speed')
       }
       case SortByColumn.Precipitation: {
-        return _.orderBy(tableRows, 'precipitation', order)
+        return orderByWithEmptyAtBottom('precipitation')
       }
       case SortByColumn.FFMC: {
-        return _.orderBy(tableRows, 'fine_fuel_moisture_code', order)
+        return orderByWithEmptyAtBottom('fine_fuel_moisture_code')
       }
       case SortByColumn.DMC: {
-        return _.orderBy(tableRows, 'duff_moisture_code', order)
+        return orderByWithEmptyAtBottom('duff_moisture_code')
       }
       case SortByColumn.DC: {
-        return _.orderBy(tableRows, 'drought_code', order)
+        return orderByWithEmptyAtBottom('drought_code')
       }
       case SortByColumn.ISI: {
-        return _.orderBy(tableRows, 'initial_spread_index', order)
+        return orderByWithEmptyAtBottom('initial_spread_index')
       }
       case SortByColumn.BUI: {
-        return _.orderBy(tableRows, 'build_up_index', order)
+        return orderByWithEmptyAtBottom('build_up_index')
       }
       case SortByColumn.FWI: {
-        return _.orderBy(tableRows, 'fire_weather_index', order)
+        return orderByWithEmptyAtBottom('fire_weather_index')
       }
       case SortByColumn.HFI: {
-        return _.orderBy(tableRows, 'head_fire_intensity', order)
+        return orderByWithEmptyAtBottom('head_fire_intensity')
       }
       case SortByColumn.CriticalHours4000: {
-        return _.orderBy(tableRows, 'critical_hours_hfi_4000.start', reverseOrder)
+        return orderByWithEmptyAtBottom('critical_hours_hfi_4000.start', reverseOrder)
       }
       case SortByColumn.CriticalHours10000: {
-        return _.orderBy(tableRows, 'critical_hours_hfi_10000.start', reverseOrder)
+        return orderByWithEmptyAtBottom('critical_hours_hfi_10000.start', reverseOrder)
       }
       case SortByColumn.ThirtyMinFireSize: {
-        return _.orderBy(tableRows, 'thirty_minute_fire_size', order)
+        return orderByWithEmptyAtBottom('thirty_minute_fire_size')
       }
       case SortByColumn.SixtyMinFireSize: {
-        return _.orderBy(tableRows, 'sixty_minute_fire_size', order)
+        return orderByWithEmptyAtBottom('sixty_minute_fire_size')
       }
       case SortByColumn.ROS: {
-        return _.orderBy(tableRows, 'rate_of_spread', order)
+        return orderByWithEmptyAtBottom('rate_of_spread')
       }
       case SortByColumn.FireType: {
-        return _.orderBy(tableRows, 'fire_type', order)
+        return orderByWithEmptyAtBottom('fire_type')
       }
       case SortByColumn.CFB: {
-        return _.orderBy(tableRows, 'percentage_crown_fraction_burned', order)
+        return orderByWithEmptyAtBottom('percentage_crown_fraction_burned')
       }
       case SortByColumn.FlameLength: {
-        return _.orderBy(tableRows, 'flame_length', order)
+        return orderByWithEmptyAtBottom('flame_length')
       }
 
       default: {
@@ -137,7 +144,7 @@ export class RowManager {
   }
   public static updateRows<T extends { id: number }>(
     existingRows: Array<T>,
-    updatedCalculatedRows: FBAStation[]
+    updatedCalculatedRows: Partial<FBAStation>[]
   ): Array<T> {
     const rows = [...existingRows]
     const updatedRowById = new Map(updatedCalculatedRows.map(row => [row.id, row]))

--- a/web/src/features/fbaCalculator/RowManager.ts
+++ b/web/src/features/fbaCalculator/RowManager.ts
@@ -50,8 +50,16 @@ export class RowManager {
     tableRows: FBATableRow[]
   ): FBATableRow[] => {
     const reverseOrder = order === 'asc' ? 'desc' : 'asc'
+    /**
+     * Partitions table rows into non-empty and empty row arrays, sorts the non-empty row array,
+     * then concatenates the empty row array to the end of the sorted, non-empty row array.
+     *
+     * @param field FBATableRow field to order by
+     * @param otherOrder optional Order ordering should follow, otherwise the current order
+     * @returns rows sorted by the specified field, with empty rows always at the end
+     */
     const orderByWithEmptyAtBottom = (field: string, otherOrder?: Order) => {
-      const partition = _.partition(tableRows, x => !!_.get(x, field, null))
+      const partition = _.partition(tableRows, row => !!_.get(row, field, null))
       return _.concat(
         _.orderBy(partition[0], field, otherOrder ? otherOrder : order),
         partition[1]

--- a/web/src/features/fbaCalculator/RowManager.ts
+++ b/web/src/features/fbaCalculator/RowManager.ts
@@ -144,7 +144,7 @@ export class RowManager {
   }
   public static updateRows<T extends { id: number }>(
     existingRows: Array<T>,
-    updatedCalculatedRows: Partial<FBAStation>[]
+    updatedCalculatedRows: FBAStation[]
   ): Array<T> {
     const rows = [...existingRows]
     const updatedRowById = new Map(updatedCalculatedRows.map(row => [row.id, row]))

--- a/web/src/features/fbaCalculator/rowManager.test.ts
+++ b/web/src/features/fbaCalculator/rowManager.test.ts
@@ -1,3 +1,4 @@
+import { FBAStation } from 'api/fbaCalcAPI'
 import { FBATableRow, RowManager, SortByColumn } from 'features/fbaCalculator/RowManager'
 
 describe('RowManager', () => {
@@ -74,7 +75,7 @@ describe('RowManager', () => {
     fire_weather_index: 2,
     head_fire_intensity: 2,
     critical_hours_hfi_4000: { start: 14.0, end: 19.0 },
-    critical_hours_hfi_10000: undefined,
+    critical_hours_hfi_10000: { start: 15.0, end: 18.0 },
     rate_of_spread: 2,
     fire_type: 'b',
     percentage_crown_fraction_burned: 2,
@@ -83,35 +84,77 @@ describe('RowManager', () => {
     thirty_minute_fire_size: 2
   }
 
-  const inputRows = [firstInputRow, secondInputRow]
+  const emptyInputRow = {
+    id: 2,
+    weatherStation: null,
+    fuelType: null,
+    grassCure: undefined,
+    windSpeed: undefined,
+    wind_speed: undefined
+  }
 
-  const calculatedRows = [firstCalculatedRow, secondCalculatedRow]
+  const emptyCalculatedRow: Partial<FBAStation> = {
+    id: 2,
+    station_code: undefined,
+    station_name: undefined,
+    zone_code: undefined,
+    elevation: undefined,
+    fuel_type: undefined,
+    status: undefined,
+    temp: undefined,
+    rh: undefined,
+    wind_direction: undefined,
+    wind_speed: undefined,
+    precipitation: undefined,
+    grass_cure: undefined,
+    fine_fuel_moisture_code: undefined,
+    drought_code: undefined,
+    initial_spread_index: undefined,
+    build_up_index: undefined,
+    duff_moisture_code: undefined,
+    fire_weather_index: undefined,
+    head_fire_intensity: undefined,
+    critical_hours_hfi_4000: undefined,
+    critical_hours_hfi_10000: undefined,
+    rate_of_spread: undefined,
+    fire_type: undefined,
+    percentage_crown_fraction_burned: undefined,
+    flame_length: undefined,
+    thirty_minute_fire_size: undefined,
+    sixty_minute_fire_size: undefined
+  }
+
+  const inputRows = [emptyInputRow, firstInputRow, secondInputRow]
+
+  const calculatedRows = [emptyCalculatedRow, firstCalculatedRow, secondCalculatedRow]
   it('should merge input rows and calculated rows correctly', () => {
-    const mergedRows = RowManager.updateRows(inputRows, calculatedRows)
+    const nonEmptyInputRows = [firstInputRow, secondInputRow]
+    const nonEmptyCalculatedRows = [firstCalculatedRow, secondCalculatedRow]
+    const mergedRows = RowManager.updateRows(nonEmptyInputRows, nonEmptyCalculatedRows)
 
     // Maintains row order
-    expect(mergedRows[0].id).toBe(inputRows[0].id)
-    expect(mergedRows[1].id).toBe(inputRows[1].id)
+    expect(mergedRows[0].id).toBe(nonEmptyInputRows[0].id)
+    expect(mergedRows[1].id).toBe(nonEmptyInputRows[1].id)
 
     // Sets calculated values
-    expect(mergedRows[0].wind_speed).toEqual(calculatedRows[0].wind_speed)
-    expect(mergedRows[0].windSpeed).toEqual(calculatedRows[0].wind_speed)
+    expect(mergedRows[0].wind_speed).toEqual(nonEmptyCalculatedRows[0].wind_speed)
+    expect(mergedRows[0].windSpeed).toEqual(nonEmptyCalculatedRows[0].wind_speed)
 
     // Set values remain
-    expect(mergedRows[0].windSpeed).toEqual(inputRows[0].windSpeed)
+    expect(mergedRows[0].windSpeed).toEqual(nonEmptyInputRows[0].windSpeed)
 
     // Builds GridMenuOptions based on user selected options
     expect(mergedRows[0].weatherStation).toEqual({
-      value: inputRows[0].weatherStation.value,
-      label: inputRows[0].weatherStation.label
+      value: nonEmptyInputRows[0].weatherStation?.value,
+      label: nonEmptyInputRows[0].weatherStation?.label
     })
     expect(mergedRows[0].fuelType).toEqual({
-      value: inputRows[0].fuelType.value,
-      label: inputRows[0].fuelType.label
+      value: nonEmptyInputRows[0].fuelType?.value,
+      label: nonEmptyInputRows[0].fuelType?.label
     })
 
-    // No values are lost
-    expect(mergedRows.length).toEqual(inputRows.length)
+    // No rows are lost
+    expect(mergedRows.length).toEqual(nonEmptyInputRows.length)
   })
   describe('Sorting columns', () => {
     let mergedRows: FBATableRow[]
@@ -121,20 +164,25 @@ describe('RowManager', () => {
     it('sorts by zone code', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.Zone, 'asc', mergedRows)
       expect(sortedRowsAsc[0].zone_code).toBe('a')
+      expect(sortedRowsAsc[2].zone_code).toBe(emptyCalculatedRow.zone_code)
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.Zone, 'desc', mergedRows)
       expect(sortedRowsDesc[0].zone_code).toBe('b')
+      expect(sortedRowsDesc[2].zone_code).toBe(emptyCalculatedRow.zone_code)
     })
     it('sorts by station name', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.Station, 'asc', mergedRows)
       expect(sortedRowsAsc[0].station_name).toBe('AFTON')
+      expect(sortedRowsAsc[2].station_name).toBe(emptyCalculatedRow.station_name)
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.Station, 'desc', mergedRows)
       expect(sortedRowsDesc[0].station_name).toBe('ALEXIS CREEK')
+      expect(sortedRowsDesc[2].station_name).toBe(emptyCalculatedRow.station_name)
     })
     it('sorts by elevation', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.Elevation, 'asc', mergedRows)
       expect(sortedRowsAsc[0].elevation).toBe(1)
+      expect(sortedRowsAsc[2].elevation).toBe(emptyCalculatedRow.elevation)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.Elevation,
@@ -142,10 +190,12 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].elevation).toBe(2)
+      expect(sortedRowsDesc[2].elevation).toBe(emptyCalculatedRow.elevation)
     })
     it('sorts by fuel type', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.FuelType, 'asc', mergedRows)
       expect(sortedRowsAsc[0].fuel_type).toBe('c1')
+      expect(sortedRowsAsc[2].fuel_type).toBe(emptyCalculatedRow.fuel_type)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.FuelType,
@@ -153,10 +203,12 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].fuel_type).toBe('c2')
+      expect(sortedRowsDesc[2].fuel_type).toBe(emptyCalculatedRow.fuel_type)
     })
     it('sorts by grass cure', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.GrassCure, 'asc', mergedRows)
       expect(sortedRowsAsc[0].grass_cure).toBe(1)
+      expect(sortedRowsAsc[2].grass_cure).toBe(emptyCalculatedRow.grass_cure)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.GrassCure,
@@ -164,13 +216,16 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].grass_cure).toBe(2)
+      expect(sortedRowsDesc[2].grass_cure).toBe(emptyCalculatedRow.grass_cure)
     })
     it('sorts by status', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.Status, 'asc', mergedRows)
       expect(sortedRowsAsc[0].status).toBe('a')
+      expect(sortedRowsAsc[2].status).toBe(emptyCalculatedRow.status)
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.Status, 'desc', mergedRows)
       expect(sortedRowsDesc[0].status).toBe('b')
+      expect(sortedRowsDesc[2].status).toBe(emptyCalculatedRow.status)
     })
     it('sorts by temperature', () => {
       const sortedRowsAsc = RowManager.sortRows(
@@ -179,6 +234,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsAsc[0].temp).toBe(1)
+      expect(sortedRowsAsc[2].temp).toBe(emptyCalculatedRow.temp)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.Temperature,
@@ -186,6 +242,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].temp).toBe(2)
+      expect(sortedRowsDesc[2].temp).toBe(emptyCalculatedRow.temp)
     })
     it('sorts by rh', () => {
       const sortedRowsAsc = RowManager.sortRows(
@@ -194,6 +251,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsAsc[0].rh).toBe(1)
+      expect(sortedRowsAsc[2].rh).toBe(emptyCalculatedRow.rh)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.RelativeHumidity,
@@ -201,6 +259,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].rh).toBe(2)
+      expect(sortedRowsDesc[2].rh).toBe(emptyCalculatedRow.rh)
     })
     it('sorts by wind direction', () => {
       const sortedRowsAsc = RowManager.sortRows(
@@ -209,6 +268,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsAsc[0].wind_direction).toBe(1)
+      expect(sortedRowsAsc[2].wind_direction).toBe(emptyCalculatedRow.wind_direction)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.WindDirection,
@@ -216,10 +276,12 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].wind_direction).toBe(2)
+      expect(sortedRowsDesc[2].wind_direction).toBe(emptyCalculatedRow.wind_direction)
     })
     it('sorts by wind speed', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.WindSpeed, 'asc', mergedRows)
       expect(sortedRowsAsc[0].wind_speed).toBe(1)
+      expect(sortedRowsAsc[2].wind_speed).toBe(emptyCalculatedRow.wind_speed)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.WindSpeed,
@@ -227,6 +289,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].wind_speed).toBe(2)
+      expect(sortedRowsDesc[2].wind_speed).toBe(emptyCalculatedRow.wind_speed)
     })
 
     it('sorts by precipitation', () => {
@@ -236,6 +299,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsAsc[0].precipitation).toBe(1)
+      expect(sortedRowsAsc[2].precipitation).toBe(emptyCalculatedRow.precipitation)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.Precipitation,
@@ -243,58 +307,93 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].precipitation).toBe(2)
+      expect(sortedRowsDesc[2].precipitation).toBe(emptyCalculatedRow.precipitation)
     })
 
     it('sorts by ffmc', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.FFMC, 'asc', mergedRows)
       expect(sortedRowsAsc[0].fine_fuel_moisture_code).toBe(1)
+      expect(sortedRowsAsc[2].fine_fuel_moisture_code).toBe(
+        emptyCalculatedRow.fine_fuel_moisture_code
+      )
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.FFMC, 'desc', mergedRows)
       expect(sortedRowsDesc[0].fine_fuel_moisture_code).toBe(2)
+      expect(sortedRowsDesc[2].fine_fuel_moisture_code).toBe(
+        emptyCalculatedRow.fine_fuel_moisture_code
+      )
     })
     it('sorts by dmc', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.DMC, 'asc', mergedRows)
       expect(sortedRowsAsc[0].duff_moisture_code).toBe(1)
+      expect(sortedRowsAsc[2].duff_moisture_code).toBe(
+        emptyCalculatedRow.duff_moisture_code
+      )
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.DMC, 'desc', mergedRows)
       expect(sortedRowsDesc[0].duff_moisture_code).toBe(2)
+      expect(sortedRowsDesc[2].duff_moisture_code).toBe(
+        emptyCalculatedRow.duff_moisture_code
+      )
     })
     it('sorts by dc', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.DC, 'asc', mergedRows)
       expect(sortedRowsAsc[0].drought_code).toBe(1)
+      expect(sortedRowsAsc[2].drought_code).toBe(emptyCalculatedRow.drought_code)
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.DC, 'desc', mergedRows)
       expect(sortedRowsDesc[0].drought_code).toBe(2)
+      expect(sortedRowsDesc[2].drought_code).toBe(emptyCalculatedRow.drought_code)
     })
 
     it('sorts by isi', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.ISI, 'asc', mergedRows)
       expect(sortedRowsAsc[0].initial_spread_index).toBe(1)
+      expect(sortedRowsAsc[2].initial_spread_index).toBe(
+        emptyCalculatedRow.initial_spread_index
+      )
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.ISI, 'desc', mergedRows)
       expect(sortedRowsDesc[0].initial_spread_index).toBe(2)
+      expect(sortedRowsDesc[2].initial_spread_index).toBe(
+        emptyCalculatedRow.initial_spread_index
+      )
     })
     it('sorts by bui', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.BUI, 'asc', mergedRows)
       expect(sortedRowsAsc[0].build_up_index).toBe(1)
+      expect(sortedRowsAsc[2].build_up_index).toBe(emptyCalculatedRow.build_up_index)
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.BUI, 'desc', mergedRows)
       expect(sortedRowsDesc[0].build_up_index).toBe(2)
+      expect(sortedRowsDesc[2].build_up_index).toBe(emptyCalculatedRow.build_up_index)
     })
     it('sorts by fwi', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.FWI, 'asc', mergedRows)
       expect(sortedRowsAsc[0].fire_weather_index).toBe(1)
+      expect(sortedRowsAsc[2].fire_weather_index).toBe(
+        emptyCalculatedRow.fire_weather_index
+      )
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.FWI, 'desc', mergedRows)
       expect(sortedRowsDesc[0].fire_weather_index).toBe(2)
+      expect(sortedRowsDesc[2].fire_weather_index).toBe(
+        emptyCalculatedRow.fire_weather_index
+      )
     })
 
     it('sorts by hfi', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.HFI, 'asc', mergedRows)
       expect(sortedRowsAsc[0].head_fire_intensity).toBe(1)
+      expect(sortedRowsAsc[2].head_fire_intensity).toBe(
+        emptyCalculatedRow.head_fire_intensity
+      )
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.HFI, 'desc', mergedRows)
       expect(sortedRowsDesc[0].head_fire_intensity).toBe(2)
+      expect(sortedRowsDesc[2].head_fire_intensity).toBe(
+        emptyCalculatedRow.head_fire_intensity
+      )
     })
 
     it('sorts by 4000 kW/m critical hours', () => {
@@ -307,6 +406,9 @@ describe('RowManager', () => {
         end: 19,
         start: 14
       })
+      expect(sortedRowsAsc[2].critical_hours_hfi_4000).toStrictEqual(
+        emptyCalculatedRow.critical_hours_hfi_4000
+      )
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.CriticalHours4000,
@@ -317,6 +419,9 @@ describe('RowManager', () => {
         start: 9,
         end: 2
       })
+      expect(sortedRowsDesc[2].critical_hours_hfi_4000).toBe(
+        emptyCalculatedRow.critical_hours_hfi_4000
+      )
     })
 
     it('sorts by 10000 kW/m critical hours', () => {
@@ -325,7 +430,13 @@ describe('RowManager', () => {
         'asc',
         mergedRows
       )
-      expect(sortedRowsAsc[0].critical_hours_hfi_10000).toBe(undefined)
+      expect(sortedRowsAsc[0].critical_hours_hfi_10000).toStrictEqual({
+        start: 15.0,
+        end: 18.0
+      })
+      expect(sortedRowsAsc[2].critical_hours_hfi_10000).toStrictEqual(
+        emptyCalculatedRow.critical_hours_hfi_10000
+      )
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.CriticalHours10000,
@@ -336,6 +447,9 @@ describe('RowManager', () => {
         start: 14.0,
         end: 18.0
       })
+      expect(sortedRowsDesc[2].critical_hours_hfi_10000).toBe(
+        emptyCalculatedRow.critical_hours_hfi_10000
+      )
     })
 
     it('sorts by 30 minute fire size', () => {
@@ -345,6 +459,9 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsAsc[0].thirty_minute_fire_size).toBe(1)
+      expect(sortedRowsAsc[2].thirty_minute_fire_size).toBe(
+        emptyCalculatedRow.thirty_minute_fire_size
+      )
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.ThirtyMinFireSize,
@@ -352,6 +469,9 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].thirty_minute_fire_size).toBe(2)
+      expect(sortedRowsDesc[2].thirty_minute_fire_size).toBe(
+        emptyCalculatedRow.thirty_minute_fire_size
+      )
     })
     it('sorts by 60 minute fire size', () => {
       const sortedRowsAsc = RowManager.sortRows(
@@ -360,6 +480,9 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsAsc[0].sixty_minute_fire_size).toBe(1)
+      expect(sortedRowsAsc[2].sixty_minute_fire_size).toBe(
+        emptyCalculatedRow.sixty_minute_fire_size
+      )
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.SixtyMinFireSize,
@@ -367,17 +490,23 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].sixty_minute_fire_size).toBe(2)
+      expect(sortedRowsDesc[2].sixty_minute_fire_size).toBe(
+        emptyCalculatedRow.sixty_minute_fire_size
+      )
     })
     it('sorts by rate of spread', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.ROS, 'asc', mergedRows)
       expect(sortedRowsAsc[0].rate_of_spread).toBe(1)
+      expect(sortedRowsAsc[2].rate_of_spread).toBe(emptyCalculatedRow.rate_of_spread)
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.ROS, 'desc', mergedRows)
       expect(sortedRowsDesc[0].rate_of_spread).toBe(2)
+      expect(sortedRowsDesc[2].rate_of_spread).toBe(emptyCalculatedRow.rate_of_spread)
     })
     it('sorts by fire type', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.FireType, 'asc', mergedRows)
       expect(sortedRowsAsc[0].fire_type).toBe('a')
+      expect(sortedRowsAsc[2].fire_type).toBe(emptyCalculatedRow.fire_type)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.FireType,
@@ -385,13 +514,20 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].fire_type).toBe('b')
+      expect(sortedRowsDesc[2].fire_type).toBe(emptyCalculatedRow.fire_type)
     })
     it('sorts by crown fire burned percentage', () => {
       const sortedRowsAsc = RowManager.sortRows(SortByColumn.CFB, 'asc', mergedRows)
       expect(sortedRowsAsc[0].percentage_crown_fraction_burned).toBe(1)
+      expect(sortedRowsAsc[2].percentage_crown_fraction_burned).toBe(
+        emptyCalculatedRow.percentage_crown_fraction_burned
+      )
 
       const sortedRowsDesc = RowManager.sortRows(SortByColumn.CFB, 'desc', mergedRows)
       expect(sortedRowsDesc[0].percentage_crown_fraction_burned).toBe(2)
+      expect(sortedRowsDesc[2].percentage_crown_fraction_burned).toBe(
+        emptyCalculatedRow.percentage_crown_fraction_burned
+      )
     })
     it('sorts by flame length', () => {
       const sortedRowsAsc = RowManager.sortRows(
@@ -400,6 +536,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsAsc[0].flame_length).toBe(1)
+      expect(sortedRowsAsc[2].flame_length).toBe(emptyCalculatedRow.flame_length)
 
       const sortedRowsDesc = RowManager.sortRows(
         SortByColumn.FlameLength,
@@ -407,6 +544,7 @@ describe('RowManager', () => {
         mergedRows
       )
       expect(sortedRowsDesc[0].flame_length).toBe(2)
+      expect(sortedRowsDesc[2].flame_length).toBe(emptyCalculatedRow.flame_length)
     })
   })
 })


### PR DESCRIPTION
Test: https://wps-pr-1272.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator

- Users do not want to see empty rows at the top when sorting columns, regardless of whether sort order is ascending or descending
- Lodash `orderBy` is designed to order `NaN`, nullish and symbol values at the top when ascending, bottom when descending: https://github.com/lodash/lodash/issues/4169
- Solution: Partition nullish values based on sort key into their own array, sort non-nullish values in it's own partition, then concatenate nullish partition at the end of the sorted result.

- [x] Sorting always maintains rows with empty column values at the bottom of the table