### PR TITLE
FireBAT: Progress bar fix

### DIFF
--- a/web/src/features/fbaCalculator/components/FBAProgressRow.tsx
+++ b/web/src/features/fbaCalculator/components/FBAProgressRow.tsx
@@ -1,0 +1,49 @@
+import {
+  createMuiTheme,
+  LinearProgress,
+  TableCell,
+  TableRow,
+  ThemeProvider
+} from '@material-ui/core'
+import { theme } from 'app/theme'
+
+import React from 'react'
+
+interface FBAProgressRowProps {
+  loading: boolean
+}
+
+const adjustedTheme = createMuiTheme({
+  overrides: {
+    MuiTableRow: {
+      root: {
+        position: 'sticky',
+        left: 0,
+        zIndex: theme.zIndex.appBar + 2
+      }
+    },
+    MuiTableCell: {
+      root: {
+        height: 0
+      }
+    }
+  }
+})
+
+const FBAProgressRow = (props: FBAProgressRowProps) => {
+  return (
+    <React.Fragment>
+      {props.loading && (
+        <ThemeProvider theme={adjustedTheme}>
+          <TableRow>
+            <TableCell colSpan={21} padding="none">
+              <LinearProgress />
+            </TableCell>
+          </TableRow>
+        </ThemeProvider>
+      )}
+    </React.Fragment>
+  )
+}
+
+export default React.memo(FBAProgressRow)

--- a/web/src/features/fbaCalculator/components/FBAProgressRow.tsx
+++ b/web/src/features/fbaCalculator/components/FBAProgressRow.tsx
@@ -11,32 +11,27 @@ import React from 'react'
 
 interface FBAProgressRowProps {
   loading: boolean
+  zIndexOffset: number
 }
 
-const adjustedTheme = createMuiTheme({
-  overrides: {
-    MuiTableRow: {
-      root: {
-        position: 'sticky',
-        left: 0,
-        zIndex: theme.zIndex.appBar + 2
-      }
-    },
-    MuiTableCell: {
-      root: {
-        height: 0
+const FBAProgressRow = (props: FBAProgressRowProps) => {
+  const adjustedTheme = createMuiTheme({
+    overrides: {
+      MuiTableRow: {
+        root: {
+          position: 'sticky',
+          left: 0,
+          zIndex: theme.zIndex.appBar + props.zIndexOffset
+        }
       }
     }
-  }
-})
-
-const FBAProgressRow = (props: FBAProgressRowProps) => {
+  })
   return (
     <React.Fragment>
       {props.loading && (
         <ThemeProvider theme={adjustedTheme}>
-          <TableRow>
-            <TableCell colSpan={21} padding="none">
+          <TableRow data-testid="progress-row-fba">
+            <TableCell colSpan={21} padding="none" data-testid="progress-row-cell-fba">
               <LinearProgress />
             </TableCell>
           </TableRow>

--- a/web/src/features/fbaCalculator/components/FBATable.tsx
+++ b/web/src/features/fbaCalculator/components/FBATable.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { difference, filter, findIndex, isEmpty, isUndefined } from 'lodash'
 import {
   FormControl,
-  LinearProgress,
   makeStyles,
   Paper,
   Table,
@@ -399,7 +398,6 @@ const FBATable = (props: FBAInputGridProps) => {
         <div className={classes.display} data-testid={props.testId}>
           <Paper className={classes.paper} elevation={1}>
             <TableContainer className={classes.tableContainer}>
-              {loading && <LinearProgress className={classes.stickyProgress} />}
               <Table size="small" stickyHeader aria-label="Fire Behaviour Analysis table">
                 <FBATableHead
                   toggleSorting={toggleSorting}
@@ -408,6 +406,7 @@ const FBATable = (props: FBAInputGridProps) => {
                   headerSelected={headerSelected}
                   setHeaderSelect={setHeaderSelect}
                   setSelected={setSelected}
+                  loading={loading}
                 />
                 <TableBody data-testid="fba-table-body">
                   {rows.map(row => {

--- a/web/src/features/fbaCalculator/components/FBATable.tsx
+++ b/web/src/features/fbaCalculator/components/FBATable.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { difference, filter, findIndex, isEmpty, isUndefined } from 'lodash'
 import {
-  Checkbox,
   FormControl,
   LinearProgress,
   makeStyles,
@@ -10,9 +9,7 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
-  TableRow,
-  TableSortLabel
+  TableRow
 } from '@material-ui/core'
 import GetAppIcon from '@material-ui/icons/GetApp'
 import { CsvBuilder } from 'filefy'
@@ -49,6 +46,7 @@ import ErrorAlert from 'features/fbaCalculator/components/ErrorAlert'
 import LoadingIndicatorCell from 'features/fbaCalculator/components/LoadingIndicatorCell'
 import SelectionCell from 'features/fbaCalculator/components/SelectionCell'
 import StickyCell from 'features/fbaCalculator/components/StickyCell'
+import FBATableHead from 'features/fbaCalculator/components/FBATableHead'
 
 export interface FBAInputGridProps {
   testId?: string
@@ -101,9 +99,6 @@ const useStyles = makeStyles(theme => ({
   grassCure: {
     width: 80
   },
-  windSpeed: {
-    width: 80
-  },
   paper: {
     width: '100%'
   },
@@ -120,8 +115,10 @@ const useStyles = makeStyles(theme => ({
     paddingLeft: '8px',
     paddingRight: '8px'
   },
-  tableHeaderRow: {
-    padding: '8px'
+  stickyProgress: {
+    left: 0,
+    position: 'sticky',
+    zIndex: theme.zIndex.appBar + 2
   }
 }))
 
@@ -402,319 +399,16 @@ const FBATable = (props: FBAInputGridProps) => {
         <div className={classes.display} data-testid={props.testId}>
           <Paper className={classes.paper} elevation={1}>
             <TableContainer className={classes.tableContainer}>
-              {loading && <LinearProgress />}
+              {loading && <LinearProgress className={classes.stickyProgress} />}
               <Table size="small" stickyHeader aria-label="Fire Behaviour Analysis table">
-                <TableHead>
-                  <TableRow>
-                    <StickyCell left={0} zIndexOffset={2}>
-                      <Checkbox
-                        data-testid="select-all"
-                        color="primary"
-                        checked={headerSelected}
-                        onClick={() => {
-                          if (headerSelected) {
-                            // Toggle off
-                            setSelected([])
-                            setHeaderSelect(false)
-                          } else {
-                            setSelected(
-                              rows.filter(row => !isUndefined(row)).map(row => row.id)
-                            )
-                            setHeaderSelect(true)
-                          }
-                        }}
-                      />
-                    </StickyCell>
-                    <TableCell key="header-zone" sortDirection={order}>
-                      <TableSortLabel
-                        className={classes.tableHeaderRow}
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.Zone)
-                        }}
-                      >
-                        Zone
-                      </TableSortLabel>
-                    </TableCell>
-                    <StickyCell left={50} zIndexOffset={2}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.Station)
-                        }}
-                      >
-                        Weather Station
-                      </TableSortLabel>
-                    </StickyCell>
-                    <TableCell key="header-elevation" sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.Elevation)
-                        }}
-                      >
-                        Elev.
-                        <br />
-                        (m)
-                      </TableSortLabel>
-                    </TableCell>
-                    <StickyCell left={280} zIndexOffset={2}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => toggleSorting(SortByColumn.FuelType)}
-                      >
-                        FBP Fuel Type
-                      </TableSortLabel>
-                    </StickyCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => toggleSorting(SortByColumn.GrassCure)}
-                      >
-                        Grass
-                        <br />
-                        Cure
-                        <br />
-                        (%)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.Status)
-                        }}
-                      >
-                        Status
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.Temperature)
-                        }}
-                      >
-                        Temp
-                        <br />
-                        (&deg;C)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.RelativeHumidity)
-                        }}
-                      >
-                        RH
-                        <br />
-                        (%)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.WindDirection)
-                        }}
-                      >
-                        Wind
-                        <br />
-                        Dir
-                        <br />
-                        (&deg;)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell className={classes.windSpeed} sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.WindSpeed)
-                        }}
-                      >
-                        Wind Speed (km/h)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.Precipitation)
-                        }}
-                      >
-                        Precip
-                        <br />
-                        (mm)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.FFMC)
-                        }}
-                      >
-                        FFMC
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.DMC)
-                        }}
-                      >
-                        DMC
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.DMC)
-                        }}
-                      >
-                        DC
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.ISI)
-                        }}
-                      >
-                        ISI
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.BUI)
-                        }}
-                      >
-                        BUI
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.BUI)
-                        }}
-                      >
-                        FWI
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.HFI)
-                        }}
-                      >
-                        HFI
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.CriticalHours4000)
-                        }}
-                      >
-                        Critical
-                        <br />
-                        Hours
-                        <br />
-                        (4000 kW/m)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.CriticalHours10000)
-                        }}
-                      >
-                        Critical
-                        <br />
-                        Hours
-                        <br />
-                        (10000 kW/m)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.ROS)
-                        }}
-                      >
-                        ROS
-                        <br />
-                        (m/min)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.FireType)
-                        }}
-                      >
-                        Fire Type
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.CFB)
-                        }}
-                      >
-                        CFB (%)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.FlameLength)
-                        }}
-                      >
-                        Flame <br />
-                        Length <br /> (m)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.ThirtyMinFireSize)
-                        }}
-                      >
-                        30 min <br />
-                        fire size <br />
-                        (hectares)
-                      </TableSortLabel>
-                    </TableCell>
-                    <TableCell sortDirection={order}>
-                      <TableSortLabel
-                        direction={order}
-                        onClick={() => {
-                          toggleSorting(SortByColumn.SixtyMinFireSize)
-                        }}
-                      >
-                        60 min <br />
-                        fire size <br />
-                        (hectares)
-                      </TableSortLabel>
-                    </TableCell>
-                  </TableRow>
-                </TableHead>
+                <FBATableHead
+                  toggleSorting={toggleSorting}
+                  order={order}
+                  rows={rows}
+                  headerSelected={headerSelected}
+                  setHeaderSelect={setHeaderSelect}
+                  setSelected={setSelected}
+                />
                 <TableBody data-testid="fba-table-body">
                   {rows.map(row => {
                     return (

--- a/web/src/features/fbaCalculator/components/FBATableHead.tsx
+++ b/web/src/features/fbaCalculator/components/FBATableHead.tsx
@@ -1,0 +1,356 @@
+import {
+  Checkbox,
+  makeStyles,
+  TableCell,
+  TableHead,
+  TableRow,
+  TableSortLabel
+} from '@material-ui/core'
+import StickyCell from 'features/fbaCalculator/components/StickyCell'
+import { FBATableRow, SortByColumn } from 'features/fbaCalculator/RowManager'
+import { isUndefined } from 'lodash'
+import React from 'react'
+import { Order } from 'utils/table'
+
+interface FBATableHeadProps {
+  toggleSorting: (selectedColumn: SortByColumn) => void
+  order: Order
+  rows: FBATableRow[]
+  headerSelected: boolean
+  setHeaderSelect: (value: React.SetStateAction<boolean>) => void
+  setSelected: (value: React.SetStateAction<number[]>) => void
+}
+
+const useStyles = makeStyles({
+  tableHeaderRow: {
+    padding: '8px'
+  },
+  windSpeed: {
+    width: 80
+  }
+})
+
+const FBATableHead = ({
+  toggleSorting,
+  order,
+  rows,
+  headerSelected,
+  setHeaderSelect,
+  setSelected
+}: FBATableHeadProps) => {
+  const classes = useStyles()
+
+  return (
+    <TableHead>
+      <TableRow>
+        <StickyCell left={0} zIndexOffset={2}>
+          <Checkbox
+            data-testid="select-all"
+            color="primary"
+            checked={headerSelected}
+            onClick={() => {
+              if (headerSelected) {
+                // Toggle off
+                setSelected([])
+                setHeaderSelect(false)
+              } else {
+                setSelected(rows.filter(row => !isUndefined(row)).map(row => row.id))
+                setHeaderSelect(true)
+              }
+            }}
+          />
+        </StickyCell>
+        <TableCell key="header-zone" sortDirection={order}>
+          <TableSortLabel
+            className={classes.tableHeaderRow}
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.Zone)
+            }}
+          >
+            Zone
+          </TableSortLabel>
+        </TableCell>
+        <StickyCell left={50} zIndexOffset={2}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.Station)
+            }}
+          >
+            Weather Station
+          </TableSortLabel>
+        </StickyCell>
+        <TableCell key="header-elevation" sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.Elevation)
+            }}
+          >
+            Elev.
+            <br />
+            (m)
+          </TableSortLabel>
+        </TableCell>
+        <StickyCell left={280} zIndexOffset={2}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => toggleSorting(SortByColumn.FuelType)}
+          >
+            FBP Fuel Type
+          </TableSortLabel>
+        </StickyCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => toggleSorting(SortByColumn.GrassCure)}
+          >
+            Grass
+            <br />
+            Cure
+            <br />
+            (%)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.Status)
+            }}
+          >
+            Status
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.Temperature)
+            }}
+          >
+            Temp
+            <br />
+            (&deg;C)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.RelativeHumidity)
+            }}
+          >
+            RH
+            <br />
+            (%)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.WindDirection)
+            }}
+          >
+            Wind
+            <br />
+            Dir
+            <br />
+            (&deg;)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell className={classes.windSpeed} sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.WindSpeed)
+            }}
+          >
+            Wind Speed (km/h)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.Precipitation)
+            }}
+          >
+            Precip
+            <br />
+            (mm)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.FFMC)
+            }}
+          >
+            FFMC
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.DMC)
+            }}
+          >
+            DMC
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.DMC)
+            }}
+          >
+            DC
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.ISI)
+            }}
+          >
+            ISI
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.BUI)
+            }}
+          >
+            BUI
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.BUI)
+            }}
+          >
+            FWI
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.HFI)
+            }}
+          >
+            HFI
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.CriticalHours4000)
+            }}
+          >
+            Critical
+            <br />
+            Hours
+            <br />
+            (4000 kW/m)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.CriticalHours10000)
+            }}
+          >
+            Critical
+            <br />
+            Hours
+            <br />
+            (10000 kW/m)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.ROS)
+            }}
+          >
+            ROS
+            <br />
+            (m/min)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.FireType)
+            }}
+          >
+            Fire Type
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.CFB)
+            }}
+          >
+            CFB (%)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.FlameLength)
+            }}
+          >
+            Flame <br />
+            Length <br /> (m)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.ThirtyMinFireSize)
+            }}
+          >
+            30 min <br />
+            fire size <br />
+            (hectares)
+          </TableSortLabel>
+        </TableCell>
+        <TableCell sortDirection={order}>
+          <TableSortLabel
+            direction={order}
+            onClick={() => {
+              toggleSorting(SortByColumn.SixtyMinFireSize)
+            }}
+          >
+            60 min <br />
+            fire size <br />
+            (hectares)
+          </TableSortLabel>
+        </TableCell>
+      </TableRow>
+    </TableHead>
+  )
+}
+
+export default React.memo(FBATableHead)

--- a/web/src/features/fbaCalculator/components/FBATableHead.tsx
+++ b/web/src/features/fbaCalculator/components/FBATableHead.tsx
@@ -35,6 +35,8 @@ const useStyles = makeStyles({
   }
 })
 
+const Z_INDEX_OFFSET = 2
+
 const FBATableHead = ({
   toggleSorting,
   order,
@@ -49,7 +51,7 @@ const FBATableHead = ({
   return (
     <TableHead>
       <TableRow>
-        <StickyCell left={0} zIndexOffset={2}>
+        <StickyCell left={0} zIndexOffset={Z_INDEX_OFFSET}>
           <Checkbox
             data-testid="select-all"
             color="primary"
@@ -77,7 +79,7 @@ const FBATableHead = ({
             Zone
           </TableSortLabel>
         </TableCell>
-        <StickyCell left={50} zIndexOffset={2}>
+        <StickyCell left={50} zIndexOffset={Z_INDEX_OFFSET}>
           <TableSortLabel
             direction={order}
             onClick={() => {
@@ -99,7 +101,7 @@ const FBATableHead = ({
             (m)
           </TableSortLabel>
         </TableCell>
-        <StickyCell left={280} zIndexOffset={2}>
+        <StickyCell left={280} zIndexOffset={Z_INDEX_OFFSET}>
           <TableSortLabel
             direction={order}
             onClick={() => toggleSorting(SortByColumn.FuelType)}
@@ -355,7 +357,7 @@ const FBATableHead = ({
           </TableSortLabel>
         </TableCell>
       </TableRow>
-      <FBAProgressRow loading={loading} />
+      <FBAProgressRow loading={loading} zIndexOffset={Z_INDEX_OFFSET} />
     </TableHead>
   )
 }

--- a/web/src/features/fbaCalculator/components/FBATableHead.tsx
+++ b/web/src/features/fbaCalculator/components/FBATableHead.tsx
@@ -6,6 +6,7 @@ import {
   TableRow,
   TableSortLabel
 } from '@material-ui/core'
+import FBAProgressRow from 'features/fbaCalculator/components/FBAProgressRow'
 import StickyCell from 'features/fbaCalculator/components/StickyCell'
 import { FBATableRow, SortByColumn } from 'features/fbaCalculator/RowManager'
 import { isUndefined } from 'lodash'
@@ -19,6 +20,7 @@ interface FBATableHeadProps {
   headerSelected: boolean
   setHeaderSelect: (value: React.SetStateAction<boolean>) => void
   setSelected: (value: React.SetStateAction<number[]>) => void
+  loading: boolean
 }
 
 const useStyles = makeStyles({
@@ -27,6 +29,9 @@ const useStyles = makeStyles({
   },
   windSpeed: {
     width: 80
+  },
+  progressBar: {
+    minWidth: 1900
   }
 })
 
@@ -36,7 +41,8 @@ const FBATableHead = ({
   rows,
   headerSelected,
   setHeaderSelect,
-  setSelected
+  setSelected,
+  loading
 }: FBATableHeadProps) => {
   const classes = useStyles()
 
@@ -349,6 +355,7 @@ const FBATableHead = ({
           </TableSortLabel>
         </TableCell>
       </TableRow>
+      <FBAProgressRow loading={loading} />
     </TableHead>
   )
 }

--- a/web/src/features/fbaCalculator/components/StickyCell.tsx
+++ b/web/src/features/fbaCalculator/components/StickyCell.tsx
@@ -10,7 +10,7 @@ interface StickyCellProps {
 
 const StickyCell = (props: StickyCellProps) => {
   const useStyles = makeStyles(theme => ({
-    head: {
+    sticky: {
       left: props.left,
       position: 'sticky',
       zIndex: theme.zIndex.appBar + props.zIndexOffset,
@@ -20,7 +20,7 @@ const StickyCell = (props: StickyCellProps) => {
   const classes = useStyles()
 
   return (
-    <TableCell data-testid={`stickyCell-fba`} className={classes.head}>
+    <TableCell data-testid={`stickyCell-fba`} className={classes.sticky}>
       {props.children}
     </TableCell>
   )

--- a/web/src/features/fbaCalculator/components/fbaProgressRow.test.tsx
+++ b/web/src/features/fbaCalculator/components/fbaProgressRow.test.tsx
@@ -1,0 +1,42 @@
+import { TableContainer, Table, TableHead } from '@material-ui/core'
+import { render } from '@testing-library/react'
+import { theme } from 'app/theme'
+import React from 'react'
+import FBAProgressRow from 'features/fbaCalculator/components/FBAProgressRow'
+
+describe('FBAProgressRow', () => {
+  it('should show a row with sticky position, left, zIndex set and a cell without padding', () => {
+    const zIndexOffset = 1
+    const { getByTestId } = render(
+      <TableContainer>
+        <Table>
+          <TableHead>
+            <FBAProgressRow loading={true} zIndexOffset={zIndexOffset} />
+          </TableHead>
+        </Table>
+      </TableContainer>
+    )
+    expect(getByTestId('progress-row-fba')).toHaveStyle({
+      position: 'sticky',
+      left: 0,
+      zIndex: theme.zIndex.appBar + zIndexOffset
+    })
+    expect(getByTestId('progress-row-cell-fba')).toHaveStyle({
+      padding: '0px'
+    })
+  })
+  it('should not show if loading is false', () => {
+    const zIndexOffset = 1
+    const { queryAllByTestId } = render(
+      <TableContainer>
+        <Table>
+          <TableHead>
+            <FBAProgressRow loading={false} zIndexOffset={zIndexOffset} />
+          </TableHead>
+        </Table>
+      </TableContainer>
+    )
+    expect(queryAllByTestId('progress-row-fba').length === 0)
+    expect(queryAllByTestId('progress-row-cell-fba').length === 0)
+  })
+})


### PR DESCRIPTION
Test: https://wps-pr-1293.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN

- Extracts all header columns into the `FBATableHead` component
- Implements `FBAProgressRow` to house the sticky progress bar when table is loading
- Progress bar migrates to top of header when you scroll, but I kinda like it, not sure the fix, it still adds value and acceptance criteria is met. Maybe a bug ticket if we really want it done.

Acceptance Criteria:
- [x] Given that one or many rows are loading, due to a new input or change, the linear loading indicator is always visible, even when I scroll down the table