### PR TITLE
Deploy to production using GitHub Actions

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -56,7 +56,7 @@ jobs:
           PROJ_TARGET=e1e498-prod CERTBOT_STAGING=false DRYRUN=false bash openshift/scripts/oc_provision_certbot_cronjob.sh prod apply
   set_deployment_status_success:
     name: Production deployment
-    needs: [deploy-prod]
+    needs: [deploy_to_production]
     runs-on: ubuntu-20.04
     steps:
       - name: Set status to deployed

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   deploy_to_production:
+    name: Deploy to production
     runs-on: ubuntu-20.04
     steps:
       - name: Find PR number
@@ -50,7 +51,7 @@ jobs:
           echo Configure
           PROJ_TARGET=e1e498-prod CERTBOT_STAGING=false DRYRUN=false bash openshift/scripts/oc_provision_certbot_cronjob.sh prod apply
   set_deployment_status_success:
-    name: Production deployment
+    name: Set production deployment successful
     needs: [deploy_to_production]
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -18,7 +18,7 @@ jobs:
           # reference used to figure out this part:
           # https://github.com/actions/github-script
           script: |
-            const ev = JSON.parse((0,external_fs_namespaceObject.readFileSync)(process.env.GITHUB_EVENT_PATH, "utf8"));
+            const ev = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"))
             const prNum = ev.pull_request.number;
             core.exportVariable('SUFFIX', `pr-${prNum}`);
       - uses: actions/checkout@v2

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -44,7 +44,7 @@ jobs:
           echo C-Haines
           PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_c_haines_cronjob.sh prod apply
           echo BC FireWeather cronjobs
-          echo Run forecast at 8h30 PDT and 16h30 PDT (so before and after noon)
+          echo "Run forecast at 8h30 PDT and 16h30 PDT (so before and after noon)"
           PROJ_TARGET=e1e498-prod SCHEDULE="30 15,23 * * *" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh prod apply
           PROJ_TARGET=e1e498-prod SCHEDULE="15 * * * *" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh prod apply
           echo Configure backups

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -31,29 +31,29 @@ jobs:
           echo Login
           oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_PROD_TOKEN }}"
           echo Promote
-          # bash openshift/scripts/oc_promote.sh ${SUFFIX} apply
-          # bash openshift/scripts/oc_promote_ubuntu.sh ${SUFFIX} apply
-          # echo Provision database
-          # CPU_REQUEST=75m CPU_LIMIT=2000m MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi PVC_SIZE=45Gi PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_db.sh prod apply
-          # echo Deploy API
-          # CPU_REQUEST=50m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=3Gi REPLICAS=3 PROJ_TARGET=e1e498-prod bash VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca ./openshift/scripts/oc_deploy.sh prod apply
-          # echo Env Canada Subscriber
-          # PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_gdps_cronjob.sh prod apply
-          # PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh prod apply
-          # PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_rdps_cronjob.sh prod apply
-          # echo C-Haines
-          # PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_c_haines_cronjob.sh prod apply
-          # echo BC FireWeather cronjobs
-          # echo Run forecast at 8h30 PDT and 16h30 PDT (so before and after noon)
-          # PROJ_TARGET=e1e498-prod SCHEDULE=\"30 15,23 * * *\" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh prod apply
-          # PROJ_TARGET=e1e498-prod SCHEDULE=\"15 * * * *\" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh prod apply
-          # echo Configure backups
-          # PROJ_TARGET=e1e498-prod BACKUP_VOLUME_SIZE=50Gi CPU_REQUEST=1000m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_backup_postgres.sh prod apply
-          # PROJ_TARGET=e1e498-prod CPU_REQUEST=1000m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_backup_postgres_cronjob.sh prod apply
-          # PROJ_TARGET=e1e498-prod CPU_REQUEST=50m CPU_LIMIT=500m BACKUP_VOLUME_SIZE=3Gi bash openshift/scripts/oc_provision_backup_mariadb.sh prod apply
-          # PROJ_TARGET=e1e498-prod CPU_REQUEST=50m CPU_LIMIT=500m bash openshift/scripts/oc_provision_backup_mariadb_cronjob.sh prod apply
-          # echo Configure
-          # PROJ_TARGET=e1e498-prod CERTBOT_STAGING=false DRYRUN=false bash openshift/scripts/oc_provision_certbot_cronjob.sh prod apply
+          bash openshift/scripts/oc_promote.sh ${SUFFIX} apply
+          bash openshift/scripts/oc_promote_ubuntu.sh ${SUFFIX} apply
+          echo Provision database
+          CPU_REQUEST=75m CPU_LIMIT=2000m MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi PVC_SIZE=45Gi PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_db.sh prod apply
+          echo Deploy API
+          CPU_REQUEST=50m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=3Gi REPLICAS=3 PROJ_TARGET=e1e498-prod bash VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca ./openshift/scripts/oc_deploy.sh prod apply
+          echo Env Canada Subscriber
+          PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_gdps_cronjob.sh prod apply
+          PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh prod apply
+          PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_rdps_cronjob.sh prod apply
+          echo C-Haines
+          PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_c_haines_cronjob.sh prod apply
+          echo BC FireWeather cronjobs
+          echo Run forecast at 8h30 PDT and 16h30 PDT (so before and after noon)
+          PROJ_TARGET=e1e498-prod SCHEDULE=\"30 15,23 * * *\" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh prod apply
+          PROJ_TARGET=e1e498-prod SCHEDULE=\"15 * * * *\" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh prod apply
+          echo Configure backups
+          PROJ_TARGET=e1e498-prod BACKUP_VOLUME_SIZE=50Gi CPU_REQUEST=1000m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_backup_postgres.sh prod apply
+          PROJ_TARGET=e1e498-prod CPU_REQUEST=1000m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_backup_postgres_cronjob.sh prod apply
+          PROJ_TARGET=e1e498-prod CPU_REQUEST=50m CPU_LIMIT=500m BACKUP_VOLUME_SIZE=3Gi bash openshift/scripts/oc_provision_backup_mariadb.sh prod apply
+          PROJ_TARGET=e1e498-prod CPU_REQUEST=50m CPU_LIMIT=500m bash openshift/scripts/oc_provision_backup_mariadb_cronjob.sh prod apply
+          echo Configure
+          PROJ_TARGET=e1e498-prod CERTBOT_STAGING=false DRYRUN=false bash openshift/scripts/oc_provision_certbot_cronjob.sh prod apply
   set_deployment_status_success:
     name: Production deployment
     needs: [deploy-prod]

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,12 +19,9 @@ jobs:
           # https://octokit.github.io/rest.js/v18#pulls
           # https://github.com/actions/github-script
           script: |
-            // get pull requests relating to this commit hash
-            const pulls = (await github.repos.listPullRequestsAssociatedWithCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha }))
-            console.log(pulls)
-            // find an open PR (potentially problematic if you have multiple PR's open!)
-            const pr = pulls.data.find( ({state}) => state === 'open')
-            core.exportVariable('SUFFIX', `pr-${pr.number}`);
+            const ev = JSON.parse((0,external_fs_namespaceObject.readFileSync)(process.env.GITHUB_EVENT_PATH, "utf8"));
+            const prNum = ev.pull_request.number;
+            core.exportVariable('SUFFIX', `pr-${prNum}`);
       - uses: actions/checkout@v2
       - name: Provision to production
         run: |

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,6 +1,6 @@
 name: Production
 
-# trigger this deployment running:
+# trigger this deployment by running:
 # gh api repos/bcgov/wps/deployments -f ref="[your branch]"
 on:
   # reference used to figure this part out:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,8 +15,6 @@ jobs:
         uses: actions/github-script@v4
         with:
           # reference used to figure out this part:
-          # https://docs.github.com/en/rest/reference/pulls#list-pull-requests
-          # https://octokit.github.io/rest.js/v18#pulls
           # https://github.com/actions/github-script
           script: |
             const ev = JSON.parse((0,external_fs_namespaceObject.readFileSync)(process.env.GITHUB_EVENT_PATH, "utf8"));

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,12 +15,16 @@ jobs:
         uses: actions/github-script@v4
         with:
           # reference used to figure out this part:
+          # https://docs.github.com/en/rest/reference/pulls#list-pull-requests
+          # https://octokit.github.io/rest.js/v18#pulls
           # https://github.com/actions/github-script
           script: |
-            const fs = require("fs")
-            const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"))
-            const prNum = ev.pull_request.number;
-            core.exportVariable('SUFFIX', `pr-${prNum}`);
+            // get pull requests relating to this commit hash
+            const pulls = (await github.repos.listPullRequestsAssociatedWithCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha }))
+            console.log(pulls)
+            // find an open PR (potentially problematic if you have multiple PR's on the same hash open!)
+            const pr = pulls.data.find( ({state}) => state === 'open')
+            core.exportVariable('SUFFIX', `pr-${pr.number}`);
       - uses: actions/checkout@v2
       - name: Provision to production
         run: |

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,72 @@
+name: Production
+
+# trigger this deployment running:
+# gh api repos/bcgov/wps/deployments -f ref="[your branch]"
+on:
+  # reference used to figure this part out:
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#deployment
+  deployment:
+
+jobs:
+  deploy_to_production:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Find PR number
+        uses: actions/github-script@v4
+        with:
+          # reference used to figure out this part:
+          # https://docs.github.com/en/rest/reference/pulls#list-pull-requests
+          # https://octokit.github.io/rest.js/v18#pulls
+          # https://github.com/actions/github-script
+          script: |
+            // get pull requests relating to this commit hash
+            const pulls = (await github.repos.listPullRequestsAssociatedWithCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha }))
+            console.log(pulls)
+            // find an open PR (potentially problematic if you have multiple PR's open!)
+            const pr = pulls.data.find( ({state}) => state === 'open')
+            core.exportVariable('SUFFIX', `pr-${pr.number}`);
+      - uses: actions/checkout@v2
+      - name: Provision to production
+        run: |
+          echo Login
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_PROD_TOKEN }}"
+          echo Promote
+          # bash openshift/scripts/oc_promote.sh ${SUFFIX} apply
+          # bash openshift/scripts/oc_promote_ubuntu.sh ${SUFFIX} apply
+          # echo Provision database
+          # CPU_REQUEST=75m CPU_LIMIT=2000m MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi PVC_SIZE=45Gi PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_db.sh prod apply
+          # echo Deploy API
+          # CPU_REQUEST=50m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=3Gi REPLICAS=3 PROJ_TARGET=e1e498-prod bash VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca ./openshift/scripts/oc_deploy.sh prod apply
+          # echo Env Canada Subscriber
+          # PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_gdps_cronjob.sh prod apply
+          # PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh prod apply
+          # PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_rdps_cronjob.sh prod apply
+          # echo C-Haines
+          # PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_c_haines_cronjob.sh prod apply
+          # echo BC FireWeather cronjobs
+          # echo Run forecast at 8h30 PDT and 16h30 PDT (so before and after noon)
+          # PROJ_TARGET=e1e498-prod SCHEDULE=\"30 15,23 * * *\" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh prod apply
+          # PROJ_TARGET=e1e498-prod SCHEDULE=\"15 * * * *\" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh prod apply
+          # echo Configure backups
+          # PROJ_TARGET=e1e498-prod BACKUP_VOLUME_SIZE=50Gi CPU_REQUEST=1000m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_backup_postgres.sh prod apply
+          # PROJ_TARGET=e1e498-prod CPU_REQUEST=1000m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_backup_postgres_cronjob.sh prod apply
+          # PROJ_TARGET=e1e498-prod CPU_REQUEST=50m CPU_LIMIT=500m BACKUP_VOLUME_SIZE=3Gi bash openshift/scripts/oc_provision_backup_mariadb.sh prod apply
+          # PROJ_TARGET=e1e498-prod CPU_REQUEST=50m CPU_LIMIT=500m bash openshift/scripts/oc_provision_backup_mariadb_cronjob.sh prod apply
+          # echo Configure
+          # PROJ_TARGET=e1e498-prod CERTBOT_STAGING=false DRYRUN=false bash openshift/scripts/oc_provision_certbot_cronjob.sh prod apply
+  set_deployment_status_success:
+    name: Production deployment
+    needs: [deploy-prod]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set status to deployed
+        uses: actions/github-script@v4
+        with:
+          # reference used to figure out how to set the deployment status:
+          # https://docs.github.com/en/rest/reference/repos#deployments
+          # https://github.com/actions/github-script
+          # https://octokit.github.io/rest.js/v18#repos-create-deployment-status
+          script: |
+            console.log(context.payload)
+            const status = (await github.repos.createDeploymentStatus({owner: context.repo.owner, repo: context.repo.repo, deployment_id: context.payload.deployment.id, state: 'success'}))
+            console.log(status)

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -36,7 +36,7 @@ jobs:
           echo Provision database
           CPU_REQUEST=75m CPU_LIMIT=2000m MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi PVC_SIZE=45Gi PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_db.sh prod apply
           echo Deploy API
-          CPU_REQUEST=50m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=3Gi REPLICAS=3 PROJ_TARGET=e1e498-prod bash VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca ./openshift/scripts/oc_deploy.sh prod apply
+          CPU_REQUEST=50m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=3Gi REPLICAS=3 PROJ_TARGET=e1e498-prod VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca bash ./openshift/scripts/oc_deploy.sh prod apply
           echo Env Canada Subscriber
           PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_gdps_cronjob.sh prod apply
           PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh prod apply

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,10 +2,9 @@ name: Production
 
 # trigger this deployment by running:
 # gh api repos/bcgov/wps/deployments -f ref="[your branch]"
-on:
-  # reference used to figure this part out:
-  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#deployment
-  deployment:
+# reference used to figure this part out:
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows#deployment
+on: deployment
 
 jobs:
   deploy_to_production:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -45,8 +45,8 @@ jobs:
           PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_c_haines_cronjob.sh prod apply
           echo BC FireWeather cronjobs
           echo Run forecast at 8h30 PDT and 16h30 PDT (so before and after noon)
-          PROJ_TARGET=e1e498-prod SCHEDULE=\"30 15,23 * * *\" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh prod apply
-          PROJ_TARGET=e1e498-prod SCHEDULE=\"15 * * * *\" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh prod apply
+          PROJ_TARGET=e1e498-prod SCHEDULE="30 15,23 * * *" bash openshift/scripts/oc_provision_bcfw_p1_forecasts_cronjob.sh prod apply
+          PROJ_TARGET=e1e498-prod SCHEDULE="15 * * * *" bash openshift/scripts/oc_provision_bcfw_p1_hourly_actuals_cronjob.sh prod apply
           echo Configure backups
           PROJ_TARGET=e1e498-prod BACKUP_VOLUME_SIZE=50Gi CPU_REQUEST=1000m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_backup_postgres.sh prod apply
           PROJ_TARGET=e1e498-prod CPU_REQUEST=1000m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_backup_postgres_cronjob.sh prod apply

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -18,7 +18,8 @@ jobs:
           # reference used to figure out this part:
           # https://github.com/actions/github-script
           script: |
-            const ev = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"))
+            const fs = require("fs")
+            const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"))
             const prNum = ev.pull_request.number;
             core.exportVariable('SUFFIX', `pr-${prNum}`);
       - uses: actions/checkout@v2


### PR DESCRIPTION
Using a workflow triggered by a deployment allows us to get rid of Jenkins, and aligns us better with introducing something like chatops.

Currently, to trigger deploy, you have to use the github api:

`gh api repos/bcgov/wps/deployments -f ref="[branch name]"`