### PR TITLE
Update fix renovate config

### DIFF
--- a/.github/workflows/renovate.json
+++ b/.github/workflows/renovate.json
@@ -1,23 +1,31 @@
 {
-    "packageRules": [
-      {
-        "matchPackagePatterns": [
-          "*"
-        ],
-        "matchUpdateTypes": [
-          "minor",
-          "patch"
-        ],
-        "groupName": "all non-major dependencies",
-        "groupSlug": "all-minor-patch"
-      }
-    ],
-    "docker": {
-      "enabled": false
+  "onboardingConfig": { "extends": ["config:base"] },
+  "logLevel": "debug",
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch", "lockFileMaintenance"],
+      "groupName": "npm all non-major dependencies",
+      "groupSlug": "npm all-minor-patch"
     },
-    "docker-compose": {
-      "enabled": false
+    {
+      "matchManagers": ["poetry"],
+      "matchUpdateTypes": ["minor", "patch", "lockFileMaintenance"],
+      "groupName": "poetry all non-major dependencies",
+      "groupSlug": "poetry all-minor-patch"
     },
-    "autodiscover": true,
-    "autodiscoverFilter": "bcgov/wps"
-  }
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github actions all non-major dependencies",
+      "groupSlug": "github actions all-minor-patch"
+    },
+    {
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "enabled": "false"
+    }
+  ],
+  "lockFileMaintenance": { "enabled": true },
+  "autodiscover": true,
+  "autodiscoverFilter": "bcgov/wps"
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v27.18.0
+        uses: renovatebot/github-action@v27.31.10
         with:
           configurationFile: .github/workflows/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
- Use latest renovate bot github action
- Define minor/patch update groups for npm, poetry and github actions
- Turn on lockfile maintenance
- Disable docker, dockercompose updates since our images are pinned to old versions for compatibility.
- enable debug level logging in action output

Tested locally with `act` tool, will need to merge and test against main branch to account for any environment differences.

# Test Links:
[Percentile Calculator](https://wps-pr-1462.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1462.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1462.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1462.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1462.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[HFI Calculator](https://wps-pr-1462.apps.silver.devops.gov.bc.ca/hfi-calculator)
