### PR TITLE
react-scripts as dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi8/nodejs-14 as static
 USER 0
 
 ADD web .
-RUN npm i yarn && yarn install --production
+RUN npm i yarn && yarn install
 RUN yarn run build
 
 # Switch back to default user

--- a/web/package.json
+++ b/web/package.json
@@ -48,7 +48,6 @@
     "react-plotly.js": "^2.5.1",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "^4.0.3",
     "typescript": "^4.4"
   },
   "scripts": {
@@ -90,7 +89,8 @@
     "cypress": "^8.4.1",
     "eslint": "^7.32.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "start-server-and-test": "^1.11.4"
+    "start-server-and-test": "^1.11.4",
+    "react-scripts": "^4.0.3"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Dependabot complains about `react-scripts` dependencies: https://github.com/bcgov/wps/security/dependabot

`react-scripts` maintainer says it's a build tool and should live in dev dependencies: https://github.com/facebook/create-react-app/issues/11174
# Test Links:
[Percentile Calculator](https://wps-pr-1513.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1513.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1513.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1513.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1513.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1513.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1513.apps.silver.devops.gov.bc.ca/hfi-calculator)
