### PR TITLE
Preload libstdc++ to mitigate import allocation errors

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,6 +105,7 @@ jobs:
         working-directory: ./api
         run: |
           export LD_LIBRARY_PATH=$(poetry run python -m rpy2.situation LD_LIBRARY_PATH):${LD_LIBRARY_PATH}
+          export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6:/$LD_PRELOAD
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATHpoetry
           export ORIGINS=testorigin
           poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings -vvv

--- a/.github/workflows/post_merge_integration.yml
+++ b/.github/workflows/post_merge_integration.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           source ~/.poetry/env
           export LD_LIBRARY_PATH=$(poetry run python -m rpy2.situation LD_LIBRARY_PATH):${LD_LIBRARY_PATH}
+          export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6:/$LD_PRELOAD
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATHpoetry
           export ORIGINS=testorigin
           poetry run coverage run --source=app -m pytest -o log_cli=true --disable-warnings -vvv


### PR DESCRIPTION
Preloads libstdc++ when running API unit tests -- GDAL imports started producing these errors:
```
ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: cannot allocate memory in static TLS block
```

See full workflow example: https://github.com/bcgov/wps/runs/4509127225?check_suite_focus=true

# Test Links:
[Percentile Calculator](https://wps-pr-1608.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1608.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1608.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1608.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1608.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1608.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1608.apps.silver.devops.gov.bc.ca/hfi-calculator)
