### PR TITLE
Story/hfi errors/1405

### DIFF
--- a/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
+++ b/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
@@ -27,7 +27,7 @@ export interface CalculatedCellsProps {
 }
 
 const CalculatedPlanningAreaCells = (props: CalculatedCellsProps) => {
-  const allDailies = props.planningAreaResult.dailyResults.flatMap(
+  const allPlanningAreaDailies = props.planningAreaResult.dailyResults.flatMap(
     result => result.dailies
   )
   return (
@@ -43,7 +43,7 @@ const CalculatedPlanningAreaCells = (props: CalculatedCellsProps) => {
             <TableCell colSpan={2} className={props.planningAreaClass}></TableCell>
             <MeanIntensityGroupRollup
               area={props.area}
-              dailies={allDailies ? allDailies : []}
+              dailies={allPlanningAreaDailies ? allPlanningAreaDailies : []}
               selectedStationCodes={props.selectedStationCodes}
               meanIntensityGroup={meanIntensityGroup}
             />
@@ -60,13 +60,14 @@ const CalculatedPlanningAreaCells = (props: CalculatedCellsProps) => {
 
       <MeanIntensityGroupRollup
         area={props.area}
-        dailies={allDailies}
+        dailies={allPlanningAreaDailies}
         selectedStationCodes={props.selectedStationCodes}
         meanIntensityGroup={props.planningAreaResult.highestDailyIntensityGroup}
       ></MeanIntensityGroupRollup>
       <MeanPrepLevelCell
         areaName={props.areaName}
         meanPrepLevel={props.planningAreaResult.meanPrepLevel}
+        emptyForecast={allPlanningAreaDailies.length === 0}
       />
     </React.Fragment>
   )

--- a/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
+++ b/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
@@ -67,7 +67,9 @@ const CalculatedPlanningAreaCells = (props: CalculatedCellsProps) => {
       <MeanPrepLevelCell
         areaName={props.areaName}
         meanPrepLevel={props.planningAreaResult.meanPrepLevel}
-        emptyForecast={allPlanningAreaDailies.length === 0}
+        emptyOrIncompleteForecast={
+          allPlanningAreaDailies.length === 0 || !props.planningAreaResult.allDailiesValid
+        }
       />
     </React.Fragment>
   )

--- a/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
+++ b/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
@@ -53,7 +53,12 @@ const CalculatedPlanningAreaCells = (props: CalculatedCellsProps) => {
               dayOffset={day}
               setFireStarts={props.setNewFireStarts}
             />
-            <PrepLevelCell prepLevel={prepLevel} />
+            <PrepLevelCell
+              toolTipText={
+                'Cannot calculate prep level. Please check the daily forecast using the tabs above.'
+              }
+              prepLevel={prepLevel}
+            />
           </React.Fragment>
         )
       })}

--- a/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
+++ b/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
@@ -53,11 +53,7 @@ const CalculatedPlanningAreaCells = (props: CalculatedCellsProps) => {
               dayOffset={day}
               setFireStarts={props.setNewFireStarts}
             />
-            <PrepLevelCell
-              toolTipText="Cannot calculate prep level. Please check the daily forecast using the tabs above."
-              valid={props.planningAreaResult.allDailiesValid}
-              prepLevel={prepLevel}
-            />
+            <PrepLevelCell prepLevel={prepLevel} />
           </React.Fragment>
         )
       })}

--- a/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
+++ b/web/src/features/hfiCalculator/components/CalculatedPlanningAreaCells.tsx
@@ -53,7 +53,11 @@ const CalculatedPlanningAreaCells = (props: CalculatedCellsProps) => {
               dayOffset={day}
               setFireStarts={props.setNewFireStarts}
             />
-            <PrepLevelCell prepLevel={prepLevel} />
+            <PrepLevelCell
+              toolTipText="Cannot calculate prep level. Please check the daily forecast using the tabs above."
+              valid={props.planningAreaResult.allDailiesValid}
+              prepLevel={prepLevel}
+            />
           </React.Fragment>
         )
       })}

--- a/web/src/features/hfiCalculator/components/DailyViewTable.tsx
+++ b/web/src/features/hfiCalculator/components/DailyViewTable.tsx
@@ -376,7 +376,7 @@ export const DailyViewTable = (props: Props): JSX.Element => {
                               dailyKey={'temperature'}
                               daily={daily}
                               errorToolTipText={
-                                'Temperature cannot be null. Cannot calculate indices.'
+                                'Temperature cannot be null. Impacts DMC, BUI, ROS, HFI, FIG, Prep calculations.'
                               }
                             />
                             <RequiredDataCell
@@ -384,7 +384,7 @@ export const DailyViewTable = (props: Props): JSX.Element => {
                               dailyKey={'relative_humidity'}
                               daily={daily}
                               errorToolTipText={
-                                'Relative humidity cannot be null. Cannot calculate indices.'
+                                'RH cannot be null. Impacts FFMC, ISI, ROS, HFI, FIG, Prep calculations.'
                               }
                             />
                             <TableCell className={classNameForRow}>
@@ -395,7 +395,7 @@ export const DailyViewTable = (props: Props): JSX.Element => {
                               dailyKey={'wind_speed'}
                               daily={daily}
                               errorToolTipText={
-                                'Wind speed cannot be null. Cannot calculate indices.'
+                                'Wind speed cannot be null. Impacts FFMC, ISI, ROS, HFI, FIG, Prep calculations.'
                               }
                             />
                             <RequiredDataCell
@@ -403,7 +403,7 @@ export const DailyViewTable = (props: Props): JSX.Element => {
                               dailyKey={'precipitation'}
                               daily={daily}
                               errorToolTipText={
-                                'Precipitation cannot be null. Cannot calculate indices.'
+                                'Precipitation cannot be null. Impacts DC, BUI, ROS, HFI, FIG, Prep calculations.'
                               }
                             />
                             <GrassCureCell

--- a/web/src/features/hfiCalculator/components/DailyViewTable.tsx
+++ b/web/src/features/hfiCalculator/components/DailyViewTable.tsx
@@ -342,6 +342,7 @@ export const DailyViewTable = (props: Props): JSX.Element => {
                       />
                       <PrepLevelCell
                         testid={`daily-prep-level-${areaName}`}
+                        toolTipText=" Incomplete data from WFWX for one or more stations. Please exclude station(s) displaying errors."
                         prepLevel={dailyResult?.prepLevel}
                       />
                     </TableRow>

--- a/web/src/features/hfiCalculator/components/DailyViewTable.tsx
+++ b/web/src/features/hfiCalculator/components/DailyViewTable.tsx
@@ -297,7 +297,6 @@ export const DailyViewTable = (props: Props): JSX.Element => {
               )
               .map(([areaName, area]) => {
                 const dailyResult = getDailyResult(planningAreaHFIResults[area.name])
-                const validDailies = planningAreaHFIResults[area.name].allDailiesValid
                 return (
                   <React.Fragment key={`zone-${areaName}`}>
                     <TableRow>
@@ -343,8 +342,6 @@ export const DailyViewTable = (props: Props): JSX.Element => {
                       />
                       <PrepLevelCell
                         testid={`daily-prep-level-${areaName}`}
-                        toolTipText="Incomplete data from WFWX for one or more stations. Please exclude station(s) displaying errors."
-                        valid={validDailies}
                         prepLevel={dailyResult?.prepLevel}
                       />
                     </TableRow>

--- a/web/src/features/hfiCalculator/components/DailyViewTable.tsx
+++ b/web/src/features/hfiCalculator/components/DailyViewTable.tsx
@@ -297,6 +297,7 @@ export const DailyViewTable = (props: Props): JSX.Element => {
               )
               .map(([areaName, area]) => {
                 const dailyResult = getDailyResult(planningAreaHFIResults[area.name])
+                const validDailies = planningAreaHFIResults[area.name].allDailiesValid
                 return (
                   <React.Fragment key={`zone-${areaName}`}>
                     <TableRow>
@@ -342,6 +343,8 @@ export const DailyViewTable = (props: Props): JSX.Element => {
                       />
                       <PrepLevelCell
                         testid={`daily-prep-level-${areaName}`}
+                        toolTipText="Incomplete data from WFWX for one or more stations. Please exclude station(s) displaying errors."
+                        valid={validDailies}
                         prepLevel={dailyResult?.prepLevel}
                       />
                     </TableRow>

--- a/web/src/features/hfiCalculator/components/DailyViewTable.tsx
+++ b/web/src/features/hfiCalculator/components/DailyViewTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactFragment } from 'react'
+import React from 'react'
 import {
   Table,
   TableBody,
@@ -7,12 +7,10 @@ import {
   TableRow,
   Tooltip
 } from '@material-ui/core'
-import { createTheme, makeStyles, ThemeProvider } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
 import { useSelector } from 'react-redux'
-import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline'
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined'
 import { FireCentre } from 'api/hfiCalcAPI'
-import { StationDaily } from 'api/hfiCalculatorAPI'
 import GrassCureCell from 'features/hfiCalculator/components/GrassCureCell'
 import { isGrassFuelType, isValidGrassCure } from 'features/hfiCalculator/validation'
 import MeanIntensityGroupRollup from 'features/hfiCalculator/components/MeanIntensityGroupRollup'
@@ -33,12 +31,14 @@ import CalculatedCell from 'features/hfiCalculator/components/CalculatedCell'
 import IntensityGroupCell from 'features/hfiCalculator/components/IntensityGroupCell'
 import {
   DailyResult,
-  PlanningAreaResult
+  PlanningAreaResult,
+  ValidatedStationDaily
 } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
+import { RequiredDataCell } from 'features/hfiCalculator/components/RequiredDataCell'
 
 export interface Props {
   fireCentre: FireCentre | undefined
-  dailies: StationDaily[]
+  dailies: ValidatedStationDaily[]
   setSelected: (selected: number[]) => void
   testId?: string
 }
@@ -80,7 +80,7 @@ export const DailyViewTable = (props: Props): JSX.Element => {
   const { planningAreaHFIResults, selectedStationCodes, numPrepDays, selectedPrepDate } =
     useSelector(selectHFICalculatorState)
 
-  const getDailyForDay = (stationCode: number): StationDaily => {
+  const getDailyForDay = (stationCode: number): ValidatedStationDaily | undefined => {
     const dailiesForStation = getDailiesByStationCode(
       numPrepDays,
       props.dailies,
@@ -125,25 +125,6 @@ export const DailyViewTable = (props: Props): JSX.Element => {
       selectedSet.add(code)
     }
     props.setSelected(Array.from(selectedSet))
-  }
-
-  const errorIconTheme = createTheme({
-    overrides: {
-      MuiSvgIcon: {
-        root: {
-          fill: '#D8292F'
-        }
-      }
-    }
-  })
-  const toolTipSecondLine = 'Please check WFWX or contact the forecaster.'
-  const createToolTipElement = (toolTipFirstLine: string): ReactFragment => {
-    return (
-      <div>
-        {toolTipFirstLine} <br />
-        {toolTipSecondLine}
-      </div>
-    )
   }
 
   const typeToolTipFirstLine = 'SUR = Surface Type'
@@ -388,41 +369,43 @@ export const DailyViewTable = (props: Props): JSX.Element => {
                               toggleSelectedStation={toggleSelectedStation}
                               isDailyTable={true}
                             />
-                            {daily?.observation_valid === false ? (
-                              <TableCell className={classNameForRow}>
-                                <ThemeProvider theme={errorIconTheme}>
-                                  <Tooltip
-                                    title={createToolTipElement(
-                                      daily?.observation_valid_comment
-                                    )}
-                                  >
-                                    <ErrorOutlineIcon
-                                      data-testid={`status-error`}
-                                    ></ErrorOutlineIcon>
-                                  </Tooltip>
-                                </ThemeProvider>
-                              </TableCell>
-                            ) : (
-                              <StatusCell
-                                className={classNameForRow}
-                                value={daily?.status}
-                              />
-                            )}
-                            <TableCell className={classNameForRow}>
-                              {daily?.temperature}
-                            </TableCell>
-                            <TableCell className={classNameForRow}>
-                              {daily?.relative_humidity}
-                            </TableCell>
+
+                            <StatusCell daily={daily} className={classNameForRow} />
+                            <RequiredDataCell
+                              classNameForRow={classNameForRow}
+                              dailyKey={'temperature'}
+                              daily={daily}
+                              errorToolTipText={
+                                'Temperature cannot be null. Cannot calculate indices.'
+                              }
+                            />
+                            <RequiredDataCell
+                              classNameForRow={classNameForRow}
+                              dailyKey={'relative_humidity'}
+                              daily={daily}
+                              errorToolTipText={
+                                'Relative humidity cannot be null. Cannot calculate indices.'
+                              }
+                            />
                             <TableCell className={classNameForRow}>
                               {daily?.wind_direction?.toFixed(0).padStart(3, '0')}
                             </TableCell>
-                            <TableCell className={classNameForRow}>
-                              {daily?.wind_speed}
-                            </TableCell>
-                            <TableCell className={classNameForRow}>
-                              {daily?.precipitation}
-                            </TableCell>
+                            <RequiredDataCell
+                              classNameForRow={classNameForRow}
+                              dailyKey={'wind_speed'}
+                              daily={daily}
+                              errorToolTipText={
+                                'Wind speed cannot be null. Cannot calculate indices.'
+                              }
+                            />
+                            <RequiredDataCell
+                              classNameForRow={classNameForRow}
+                              dailyKey={'precipitation'}
+                              daily={daily}
+                              errorToolTipText={
+                                'Precipitation cannot be null. Cannot calculate indices.'
+                              }
+                            />
                             <GrassCureCell
                               value={daily?.grass_cure_percentage}
                               isGrassFuelType={isGrassFuelType(station.station_props)}

--- a/web/src/features/hfiCalculator/components/EmptyStaticCells.tsx
+++ b/web/src/features/hfiCalculator/components/EmptyStaticCells.tsx
@@ -1,18 +1,25 @@
 import { TableCell } from '@material-ui/core'
+import WeeklyROSCell from 'features/hfiCalculator/components/WeeklyROSCell'
 import React, { ReactElement } from 'react'
 
 export interface EmptyStaticCellsProps {
   rowId: number
+  isRowSelected: boolean
   classNameForRow: string | undefined
 }
 
 export const EmptyStaticCells = ({
   rowId,
+  isRowSelected,
   classNameForRow
 }: EmptyStaticCellsProps): ReactElement => {
   return (
     <React.Fragment key={`empty-row-${rowId}`}>
-      <TableCell data-testid={`empty-ros-${rowId}`} className={classNameForRow} />
+      <WeeklyROSCell
+        data-testid={`empty-ros-${rowId}`}
+        isRowSelected={isRowSelected}
+        error={true}
+      />
       <TableCell data-testid={`empty-hfi-${rowId}`} className={classNameForRow} />
       <TableCell
         data-testid={`empty-intensity-group-${rowId}`}

--- a/web/src/features/hfiCalculator/components/EmptyStaticCells.tsx
+++ b/web/src/features/hfiCalculator/components/EmptyStaticCells.tsx
@@ -1,0 +1,27 @@
+import { TableCell } from '@material-ui/core'
+import React, { ReactElement } from 'react'
+
+export interface EmptyStaticCellsProps {
+  rowId: number
+  classNameForRow: string | undefined
+}
+
+export const EmptyStaticCells = ({
+  rowId,
+  classNameForRow
+}: EmptyStaticCellsProps): ReactElement => {
+  return (
+    <React.Fragment key={`empty-row-${rowId}`}>
+      <TableCell data-testid={`empty-ros-${rowId}`} className={classNameForRow} />
+      <TableCell data-testid={`empty-hfi-${rowId}`} className={classNameForRow} />
+      <TableCell
+        data-testid={`empty-intensity-group-${rowId}`}
+        className={classNameForRow}
+      />
+      <TableCell data-testid={`empty-fire-starts-${rowId}`} className={classNameForRow} />
+      <TableCell data-testid={`empty-prep-level-${rowId}`} className={classNameForRow} />
+    </React.Fragment>
+  )
+}
+
+export default React.memo(EmptyStaticCells)

--- a/web/src/features/hfiCalculator/components/ErrorIconWithTooltip.tsx
+++ b/web/src/features/hfiCalculator/components/ErrorIconWithTooltip.tsx
@@ -29,6 +29,11 @@ const errorIconTheme = createTheme({
       root: {
         fill: '#D8292F'
       }
+    },
+    MuiTooltip: {
+      tooltip: {
+        fontSize: 14
+      }
     }
   }
 })

--- a/web/src/features/hfiCalculator/components/ErrorIconWithTooltip.tsx
+++ b/web/src/features/hfiCalculator/components/ErrorIconWithTooltip.tsx
@@ -1,0 +1,46 @@
+import { createTheme, makeStyles, ThemeProvider, Tooltip } from '@material-ui/core'
+import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline'
+import { fireTableStyles } from 'app/theme'
+import React from 'react'
+
+export interface ErrorIconWithTooltipProps {
+  testId?: string
+  tooltipElement: JSX.Element
+  tooltipAriaText: string[]
+}
+
+const useStyles = makeStyles({
+  alignErrorIcon: {
+    ...fireTableStyles.planningArea,
+    paddingTop: '10px',
+    textAlign: 'center'
+  }
+})
+
+const errorIconTheme = createTheme({
+  overrides: {
+    MuiSvgIcon: {
+      root: {
+        fill: '#D8292F'
+      }
+    }
+  }
+})
+
+const ErrorIconWithTooltip = (props: ErrorIconWithTooltipProps) => {
+  const classes = useStyles()
+  return (
+    <ThemeProvider theme={errorIconTheme}>
+      <Tooltip
+        title={props.tooltipElement}
+        aria-label={`${props.tooltipAriaText.join('\n')}`}
+      >
+        <div className={classes.alignErrorIcon}>
+          <ErrorOutlineIcon data-testid={props.testId}></ErrorOutlineIcon>
+        </div>
+      </Tooltip>
+    </ThemeProvider>
+  )
+}
+
+export default React.memo(ErrorIconWithTooltip)

--- a/web/src/features/hfiCalculator/components/ErrorIconWithTooltip.tsx
+++ b/web/src/features/hfiCalculator/components/ErrorIconWithTooltip.tsx
@@ -1,17 +1,23 @@
 import { createTheme, makeStyles, ThemeProvider, Tooltip } from '@material-ui/core'
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline'
 import { fireTableStyles } from 'app/theme'
+import { isUndefined } from 'lodash'
 import React from 'react'
 
 export interface ErrorIconWithTooltipProps {
   testId?: string
   tooltipElement: JSX.Element
   tooltipAriaText: string[]
+  isDataCell?: boolean
 }
 
 const useStyles = makeStyles({
-  alignErrorIcon: {
+  planningAreaIcon: {
     ...fireTableStyles.planningArea,
+    paddingTop: '10px',
+    textAlign: 'center'
+  },
+  dataCellIcon: {
     paddingTop: '10px',
     textAlign: 'center'
   }
@@ -35,7 +41,13 @@ const ErrorIconWithTooltip = (props: ErrorIconWithTooltipProps) => {
         title={props.tooltipElement}
         aria-label={`${props.tooltipAriaText.join('\n')}`}
       >
-        <div className={classes.alignErrorIcon}>
+        <div
+          className={
+            !props.isDataCell || isUndefined(props.isDataCell)
+              ? classes.planningAreaIcon
+              : classes.dataCellIcon
+          }
+        >
           <ErrorOutlineIcon data-testid={props.testId}></ErrorOutlineIcon>
         </div>
       </Tooltip>

--- a/web/src/features/hfiCalculator/components/GrassCureCell.tsx
+++ b/web/src/features/hfiCalculator/components/GrassCureCell.tsx
@@ -1,9 +1,9 @@
-import { TableCell, Tooltip } from '@material-ui/core'
-import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline'
-import { createTheme, makeStyles, ThemeProvider } from '@material-ui/core/styles'
+import { TableCell } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
 import React from 'react'
 import { isNull } from 'lodash'
 import { fireTableStyles } from 'app/theme'
+import ErrorIconWithTooltip from 'features/hfiCalculator/components/ErrorIconWithTooltip'
 
 export interface GrassCureCellProps {
   value: number | null | undefined
@@ -11,16 +11,6 @@ export interface GrassCureCellProps {
   className: string | undefined
   selected: boolean
 }
-
-const errorIconTheme = createTheme({
-  overrides: {
-    MuiSvgIcon: {
-      root: {
-        fill: '#D8292F'
-      }
-    }
-  }
-})
 
 const useStyles = makeStyles({
   unselectedStation: { ...fireTableStyles.unselectedStation }
@@ -39,14 +29,12 @@ const GrassCureProps = (props: GrassCureCellProps) => {
   const classes = useStyles()
   return isNull(props.value) && props.isGrassFuelType ? (
     <TableCell className={props.className}>
-      <ThemeProvider theme={errorIconTheme}>
-        <Tooltip
-          title={toolTipElement}
-          aria-label={`${toolTipFirstLine} \n ${toolTipSecondLine}`}
-        >
-          <ErrorOutlineIcon data-testid={`grass-cure-error`}></ErrorOutlineIcon>
-        </Tooltip>
-      </ThemeProvider>
+      <ErrorIconWithTooltip
+        testId={`grass-cure-error`}
+        isDataCell={true}
+        tooltipElement={toolTipElement}
+        tooltipAriaText={[toolTipFirstLine, toolTipSecondLine]}
+      />
     </TableCell>
   ) : (
     <TableCell

--- a/web/src/features/hfiCalculator/components/HFIErrorAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFIErrorAlert.tsx
@@ -1,0 +1,63 @@
+import { Collapse, IconButton } from '@material-ui/core'
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
+import { Alert } from '@material-ui/lab'
+import CloseIcon from '@material-ui/icons/Close'
+import React from 'react'
+
+export interface HFIErrorAlert {
+  hfiDailiesError: string | null
+  fireCentresError: string | null
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      '& > * + *': {
+        marginTop: theme.spacing(2)
+      },
+      marginBottom: theme.spacing(2)
+    }
+  })
+)
+
+const HFIErrorAlert = ({ hfiDailiesError, fireCentresError }: HFIErrorAlert) => {
+  const classes = useStyles()
+  const [open, setOpen] = React.useState(true)
+
+  return (
+    <div className={classes.root}>
+      <Collapse in={open}>
+        <Alert
+          severity="error"
+          action={
+            <IconButton
+              aria-label="close"
+              size="small"
+              onClick={() => {
+                setOpen(false)
+              }}
+            >
+              <CloseIcon fontSize="inherit" />
+            </IconButton>
+          }
+        >
+          The following errors have occurred. Please refresh the page. If the problem
+          persists, please&nbsp;
+          <a
+            id="contact-hfi-error"
+            href={`mailto:bcws.predictiveservices@gov.bc.ca?subject=Predictive Services Unit - HFI Error`}
+          >
+            contact us
+          </a>
+          :
+          <br />
+          {hfiDailiesError ? ` - ${hfiDailiesError}` : ''}
+          {fireCentresError ? <br /> + ` - ${fireCentresError}` : ''}
+        </Alert>
+      </Collapse>
+    </div>
+  )
+}
+
+export default React.memo(HFIErrorAlert)

--- a/web/src/features/hfiCalculator/components/HFIErrorAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFIErrorAlert.tsx
@@ -4,7 +4,7 @@ import { Alert } from '@material-ui/lab'
 import CloseIcon from '@material-ui/icons/Close'
 import React from 'react'
 
-export interface HFIErrorAlert {
+export interface HFIErrorAlertProps {
   hfiDailiesError: string | null
   fireCentresError: string | null
 }
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 )
 
-const HFIErrorAlert = ({ hfiDailiesError, fireCentresError }: HFIErrorAlert) => {
+const HFIErrorAlert = ({ hfiDailiesError, fireCentresError }: HFIErrorAlertProps) => {
   const classes = useStyles()
   const [open, setOpen] = React.useState(true)
 

--- a/web/src/features/hfiCalculator/components/HighestDailyFIGCell.tsx
+++ b/web/src/features/hfiCalculator/components/HighestDailyFIGCell.tsx
@@ -1,0 +1,30 @@
+import { TableCell } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import { fireTableStyles, UNSELECTED_STATION_COLOR } from 'app/theme'
+import React from 'react'
+
+export interface WeeklyROSCellProps {
+  testId?: string
+  isRowSelected: boolean
+}
+
+const useStyles = makeStyles({
+  ...fireTableStyles,
+  unselectedStation: {
+    ...fireTableStyles.sectionSeparatorBorder,
+    color: UNSELECTED_STATION_COLOR
+  }
+})
+const HighestDailyFIGCell = ({ testId, isRowSelected }: WeeklyROSCellProps) => {
+  const classes = useStyles()
+  return (
+    <TableCell
+      data-testid={testId}
+      className={
+        isRowSelected ? classes.sectionSeparatorBorder : classes.unselectedStation
+      }
+    />
+  )
+}
+
+export default React.memo(HighestDailyFIGCell)

--- a/web/src/features/hfiCalculator/components/MeanIntensityGroupRollup.tsx
+++ b/web/src/features/hfiCalculator/components/MeanIntensityGroupRollup.tsx
@@ -1,11 +1,12 @@
-import { TableCell, Tooltip } from '@material-ui/core'
-import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline'
-import { createTheme, makeStyles, ThemeProvider } from '@material-ui/core/styles'
+import { TableCell } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import { isUndefined } from 'lodash'
 import React from 'react'
 import { PlanningArea } from 'api/hfiCalcAPI'
 import { isValidGrassCure } from 'features/hfiCalculator/validation'
 import { fireTableStyles } from 'app/theme'
 import { StationDaily } from 'api/hfiCalculatorAPI'
+import ErrorIconWithTooltip from 'features/hfiCalculator/components/ErrorIconWithTooltip'
 
 export interface MeanIntensityGroupRollupProps {
   area: PlanningArea
@@ -17,21 +18,6 @@ export interface MeanIntensityGroupRollupProps {
 const useStyles = makeStyles({
   intensityGroup: {
     ...fireTableStyles.calculatedPlanningCell
-  },
-  alignErrorIcon: {
-    ...fireTableStyles.planningArea,
-    paddingTop: '10px',
-    textAlign: 'center'
-  }
-})
-
-const errorIconTheme = createTheme({
-  overrides: {
-    MuiSvgIcon: {
-      root: {
-        fill: '#D8292F'
-      }
-    }
   }
 })
 
@@ -75,45 +61,38 @@ const MeanIntensityGroupRollup = (props: MeanIntensityGroupRollupProps) => {
   if (grassCureError) {
     return (
       <TableCell>
-        <ThemeProvider theme={errorIconTheme}>
-          <Tooltip
-            title={grassCureErrorToolTipElement}
-            aria-label={`${grassCureToolTipFirstLine} \n ${toolTipSecondLine}`}
-          >
-            <div className={classes.alignErrorIcon}>
-              <ErrorOutlineIcon
-                data-testid={`zone-${props.area.id}-mig-error`}
-              ></ErrorOutlineIcon>
-            </div>
-          </Tooltip>
-        </ThemeProvider>
+        <ErrorIconWithTooltip
+          testId={`zone-${props.area.id}-mig-error`}
+          tooltipElement={grassCureErrorToolTipElement}
+          tooltipAriaText={[grassCureToolTipFirstLine, toolTipSecondLine]}
+        />
       </TableCell>
     )
   }
   if (genericError) {
     return (
       <TableCell>
-        <ThemeProvider theme={errorIconTheme}>
-          <Tooltip
-            title={genericErrorToolTipElement}
-            aria-label={`${genericErrorToolTipFirstLine} ${toolTipSecondLine}`}
-          >
-            <div className={classes.alignErrorIcon}>
-              <ErrorOutlineIcon
-                data-testid={`zone-${props.area.id}-mig-error`}
-              ></ErrorOutlineIcon>
-            </div>
-          </Tooltip>
-        </ThemeProvider>
+        <ErrorIconWithTooltip
+          testId={`zone-${props.area.id}-mig-error`}
+          tooltipElement={genericErrorToolTipElement}
+          tooltipAriaText={[genericErrorToolTipFirstLine, toolTipSecondLine]}
+        />
       </TableCell>
     )
   }
+  const validatedMig =
+    isUndefined(props.meanIntensityGroup) ||
+    isNaN(props.meanIntensityGroup) ||
+    props.meanIntensityGroup === Infinity ||
+    props.meanIntensityGroup === -Infinity
+      ? ''
+      : props.meanIntensityGroup
   return (
     <TableCell
       className={classes.intensityGroup}
       data-testid={`zone-${props.area.id}-mean-intensity`}
     >
-      {props.meanIntensityGroup}
+      {validatedMig}
     </TableCell>
   )
 }

--- a/web/src/features/hfiCalculator/components/MeanPrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/MeanPrepLevelCell.tsx
@@ -8,7 +8,7 @@ export interface MeanPrepLevelCellProps {
   testid?: string
   areaName: string
   meanPrepLevel?: number
-  emptyForecast: boolean
+  emptyOrIncompleteForecast: boolean
 }
 
 const prepLevelColours: { [description: string]: string } = {
@@ -81,7 +81,7 @@ const MeanPrepLevelCell = (props: MeanPrepLevelCellProps) => {
     <TableCell className={formatPrepLevelByValue()} data-testid={props.testid}>
       {isUndefined(props.meanPrepLevel) ||
       isNaN(props.meanPrepLevel) ||
-      props.emptyForecast === true ? (
+      props.emptyOrIncompleteForecast === true ? (
         <ErrorIconWithTooltip
           tooltipElement={prepLevelErrorTooltipElement}
           tooltipAriaText={[prepLevelTooltipText]}

--- a/web/src/features/hfiCalculator/components/MeanPrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/MeanPrepLevelCell.tsx
@@ -1,11 +1,14 @@
 import { makeStyles, TableCell } from '@material-ui/core'
 import { fireTableStyles } from 'app/theme'
+import ErrorIconWithTooltip from 'features/hfiCalculator/components/ErrorIconWithTooltip'
+import { isUndefined } from 'lodash'
 import React from 'react'
 
 export interface MeanPrepLevelCellProps {
   testid?: string
   areaName: string
   meanPrepLevel?: number
+  emptyForecast: boolean
 }
 
 const prepLevelColours: { [description: string]: string } = {
@@ -69,11 +72,23 @@ const MeanPrepLevelCell = (props: MeanPrepLevelCellProps) => {
     }
   }
 
+  const prepLevelTooltipText =
+    'Cannot calculate prep level. Please exclude station(s) displaying errors.'
+
+  const prepLevelErrorTooltipElement = <div>{prepLevelTooltipText}</div>
+
   return (
     <TableCell className={formatPrepLevelByValue()} data-testid={props.testid}>
-      {props.meanPrepLevel === undefined || isNaN(props.meanPrepLevel)
-        ? ''
-        : props.meanPrepLevel}
+      {isUndefined(props.meanPrepLevel) ||
+      isNaN(props.meanPrepLevel) ||
+      props.emptyForecast === true ? (
+        <ErrorIconWithTooltip
+          tooltipElement={prepLevelErrorTooltipElement}
+          tooltipAriaText={[prepLevelTooltipText]}
+        />
+      ) : (
+        props.meanPrepLevel
+      )}
     </TableCell>
   )
 }

--- a/web/src/features/hfiCalculator/components/MeanPrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/MeanPrepLevelCell.tsx
@@ -73,7 +73,7 @@ const MeanPrepLevelCell = (props: MeanPrepLevelCellProps) => {
   }
 
   const prepLevelTooltipText =
-    'Cannot calculate prep level. Please exclude station(s) displaying errors.'
+    'Cannot calculate prep level. Please check the daily forecast using the tabs above.'
 
   const prepLevelErrorTooltipElement = <div>{prepLevelTooltipText}</div>
 

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.test.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.test.tsx
@@ -11,6 +11,7 @@ const renderPrepLevel = (prepLevel: number | undefined) => {
           <TableRow>
             <PrepLevelCell
               testid={'weekly-prep-level-afton'}
+              toolTipText="test"
               prepLevel={prepLevel}
             ></PrepLevelCell>
           </TableRow>

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.test.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import PrepLevelCell from 'features/hfiCalculator/components/PrepLevelCell'
 import React from 'react'
 
-const renderPrepLevel = (prepLevel: number | undefined, valid = true) => {
+const renderPrepLevel = (prepLevel: number | undefined) => {
   return render(
     <TableContainer>
       <Table>
@@ -11,8 +11,6 @@ const renderPrepLevel = (prepLevel: number | undefined, valid = true) => {
           <TableRow>
             <PrepLevelCell
               testid={'weekly-prep-level-afton'}
-              toolTipText="Test"
-              valid={valid}
               prepLevel={prepLevel}
             ></PrepLevelCell>
           </TableRow>
@@ -60,7 +58,7 @@ describe('PrepLevelCell', () => {
     expect(cell.innerHTML).toBe('6')
   })
   it('should return a cell with a classname of defaultBackground and a text prep level undefined', () => {
-    const { getByTestId } = renderPrepLevel(undefined, false)
+    const { getByTestId } = renderPrepLevel(undefined)
     const cell = getByTestId('weekly-prep-level-afton')
     expect(cell.className).toMatch(/makeStyles-defaultBackground-/)
     const errorIcon = getByTestId('prep-level-error')

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.test.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import PrepLevelCell from 'features/hfiCalculator/components/PrepLevelCell'
 import React from 'react'
 
-const renderPrepLevel = (prepLevel: number | undefined) => {
+const renderPrepLevel = (prepLevel: number | undefined, valid = true) => {
   return render(
     <TableContainer>
       <Table>
@@ -11,6 +11,8 @@ const renderPrepLevel = (prepLevel: number | undefined) => {
           <TableRow>
             <PrepLevelCell
               testid={'weekly-prep-level-afton'}
+              toolTipText="Test"
+              valid={valid}
               prepLevel={prepLevel}
             ></PrepLevelCell>
           </TableRow>
@@ -58,7 +60,7 @@ describe('PrepLevelCell', () => {
     expect(cell.innerHTML).toBe('6')
   })
   it('should return a cell with a classname of defaultBackground and a text prep level undefined', () => {
-    const { getByTestId } = renderPrepLevel(undefined)
+    const { getByTestId } = renderPrepLevel(undefined, false)
     const cell = getByTestId('weekly-prep-level-afton')
     expect(cell.className).toMatch(/makeStyles-defaultBackground-/)
     const errorIcon = getByTestId('prep-level-error')

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.test.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.test.tsx
@@ -61,6 +61,7 @@ describe('PrepLevelCell', () => {
     const { getByTestId } = renderPrepLevel(undefined)
     const cell = getByTestId('weekly-prep-level-afton')
     expect(cell.className).toMatch(/makeStyles-defaultBackground-/)
-    expect(cell.innerHTML).toBe('')
+    const errorIcon = getByTestId('prep-level-error')
+    expect(errorIcon).toBeDefined()
   })
 })

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
@@ -1,12 +1,11 @@
 import { makeStyles, TableCell } from '@material-ui/core'
 import { fireTableStyles } from 'app/theme'
 import ErrorIconWithTooltip from 'features/hfiCalculator/components/ErrorIconWithTooltip'
+import { isUndefined } from 'lodash'
 import React from 'react'
 
 export interface PrepLevelCellProps {
   testid?: string
-  toolTipText: string
-  valid: boolean
   prepLevel: number | undefined
 }
 
@@ -77,15 +76,18 @@ const PrepLevelCell = (props: PrepLevelCellProps) => {
     }
   }
 
-  const prepLevelErrorTooltipElement = (toolTipText: string) => <div>{toolTipText}</div>
+  const prepLevelTooltipText =
+    'Cannot calculate prep level. Please check the daily forecast using the tabs above.'
+
+  const prepLevelErrorTooltipElement = <div>{prepLevelTooltipText}</div>
 
   return (
     <TableCell className={formatPrepLevelByValue()} data-testid={props.testid}>
-      {!props.valid ? (
+      {isUndefined(props.prepLevel) ? (
         <ErrorIconWithTooltip
           testId="prep-level-error"
-          tooltipElement={prepLevelErrorTooltipElement(props.toolTipText)}
-          tooltipAriaText={[props.toolTipText]}
+          tooltipElement={prepLevelErrorTooltipElement}
+          tooltipAriaText={[prepLevelTooltipText]}
         />
       ) : (
         props.prepLevel

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
@@ -85,6 +85,7 @@ const PrepLevelCell = (props: PrepLevelCellProps) => {
     <TableCell className={formatPrepLevelByValue()} data-testid={props.testid}>
       {isUndefined(props.prepLevel) ? (
         <ErrorIconWithTooltip
+          testId="prep-level-error"
           tooltipElement={prepLevelErrorTooltipElement}
           tooltipAriaText={[prepLevelTooltipText]}
         />

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
@@ -77,7 +77,7 @@ const PrepLevelCell = (props: PrepLevelCellProps) => {
   }
 
   const prepLevelTooltipText =
-    'Cannot calculate prep level. Please exclude station(s) displaying errors.'
+    'Cannot calculate prep level. Please check the daily forecast using the tabs above.'
 
   const prepLevelErrorTooltipElement = <div>{prepLevelTooltipText}</div>
 

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 
 export interface PrepLevelCellProps {
   testid?: string
+  toolTipText: string
   prepLevel: number | undefined
 }
 
@@ -76,18 +77,15 @@ const PrepLevelCell = (props: PrepLevelCellProps) => {
     }
   }
 
-  const prepLevelTooltipText =
-    'Cannot calculate prep level. Please check the daily forecast using the tabs above.'
-
-  const prepLevelErrorTooltipElement = <div>{prepLevelTooltipText}</div>
+  const prepLevelErrorTooltipElement = (toolTipText: string) => <div>{toolTipText}</div>
 
   return (
     <TableCell className={formatPrepLevelByValue()} data-testid={props.testid}>
       {isUndefined(props.prepLevel) ? (
         <ErrorIconWithTooltip
           testId="prep-level-error"
-          tooltipElement={prepLevelErrorTooltipElement}
-          tooltipAriaText={[prepLevelTooltipText]}
+          tooltipElement={prepLevelErrorTooltipElement(props.toolTipText)}
+          tooltipAriaText={[props.toolTipText]}
         />
       ) : (
         props.prepLevel

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
@@ -1,11 +1,12 @@
 import { makeStyles, TableCell } from '@material-ui/core'
 import { fireTableStyles } from 'app/theme'
 import ErrorIconWithTooltip from 'features/hfiCalculator/components/ErrorIconWithTooltip'
-import { isUndefined } from 'lodash'
 import React from 'react'
 
 export interface PrepLevelCellProps {
   testid?: string
+  toolTipText: string
+  valid: boolean
   prepLevel: number | undefined
 }
 
@@ -76,18 +77,15 @@ const PrepLevelCell = (props: PrepLevelCellProps) => {
     }
   }
 
-  const prepLevelTooltipText =
-    'Cannot calculate prep level. Please check the daily forecast using the tabs above.'
-
-  const prepLevelErrorTooltipElement = <div>{prepLevelTooltipText}</div>
+  const prepLevelErrorTooltipElement = (toolTipText: string) => <div>{toolTipText}</div>
 
   return (
     <TableCell className={formatPrepLevelByValue()} data-testid={props.testid}>
-      {isUndefined(props.prepLevel) ? (
+      {!props.valid ? (
         <ErrorIconWithTooltip
           testId="prep-level-error"
-          tooltipElement={prepLevelErrorTooltipElement}
-          tooltipAriaText={[prepLevelTooltipText]}
+          tooltipElement={prepLevelErrorTooltipElement(props.toolTipText)}
+          tooltipAriaText={[props.toolTipText]}
         />
       ) : (
         props.prepLevel

--- a/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
+++ b/web/src/features/hfiCalculator/components/PrepLevelCell.tsx
@@ -1,5 +1,7 @@
 import { makeStyles, TableCell } from '@material-ui/core'
 import { fireTableStyles } from 'app/theme'
+import ErrorIconWithTooltip from 'features/hfiCalculator/components/ErrorIconWithTooltip'
+import { isUndefined } from 'lodash'
 import React from 'react'
 
 export interface PrepLevelCellProps {
@@ -74,9 +76,21 @@ const PrepLevelCell = (props: PrepLevelCellProps) => {
     }
   }
 
+  const prepLevelTooltipText =
+    'Cannot calculate prep level. Please exclude station(s) displaying errors.'
+
+  const prepLevelErrorTooltipElement = <div>{prepLevelTooltipText}</div>
+
   return (
     <TableCell className={formatPrepLevelByValue()} data-testid={props.testid}>
-      {props.prepLevel}
+      {isUndefined(props.prepLevel) ? (
+        <ErrorIconWithTooltip
+          tooltipElement={prepLevelErrorTooltipElement}
+          tooltipAriaText={[prepLevelTooltipText]}
+        />
+      ) : (
+        props.prepLevel
+      )}
     </TableCell>
   )
 }

--- a/web/src/features/hfiCalculator/components/RequiredDataCell.tsx
+++ b/web/src/features/hfiCalculator/components/RequiredDataCell.tsx
@@ -1,0 +1,42 @@
+import { TableCell } from '@material-ui/core'
+import ErrorIconWithTooltip from 'features/hfiCalculator/components/ErrorIconWithTooltip'
+import { DECIMAL_PLACES } from 'features/hfiCalculator/constants'
+import { ValidatedStationDaily } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
+import { isNull, isUndefined } from 'lodash'
+import React, { ReactElement } from 'react'
+
+export interface RequiredDataCellProps {
+  testId?: string
+  classNameForRow?: string
+  daily: ValidatedStationDaily | undefined
+  dailyKey: keyof ValidatedStationDaily
+  errorToolTipText: string
+}
+
+export const RequiredDataCell = ({
+  testId,
+  classNameForRow,
+  daily,
+  dailyKey,
+  errorToolTipText
+}: RequiredDataCellProps): ReactElement => {
+  return (
+    <React.Fragment>
+      {(daily && isUndefined(daily[dailyKey])) || (daily && isNull(daily[dailyKey])) ? (
+        <TableCell data-testId={testId}>
+          <ErrorIconWithTooltip
+            isDataCell={true}
+            tooltipElement={<div>{errorToolTipText}</div>}
+            tooltipAriaText={[errorToolTipText]}
+          />
+        </TableCell>
+      ) : (
+        <TableCell className={classNameForRow}>
+          {daily ? Number(daily[dailyKey])?.toFixed(DECIMAL_PLACES) : ''}
+        </TableCell>
+      )}
+    </React.Fragment>
+  )
+}
+
+export default React.memo(RequiredDataCell)

--- a/web/src/features/hfiCalculator/components/RequiredDataCell.tsx
+++ b/web/src/features/hfiCalculator/components/RequiredDataCell.tsx
@@ -20,6 +20,8 @@ export const RequiredDataCell = ({
   dailyKey,
   errorToolTipText
 }: RequiredDataCellProps): ReactElement => {
+  const dataValue = daily ? Number(daily[dailyKey])?.toFixed(DECIMAL_PLACES) : ''
+
   return (
     <React.Fragment>
       {(daily && isUndefined(daily[dailyKey])) || (daily && isNull(daily[dailyKey])) ? (
@@ -31,9 +33,7 @@ export const RequiredDataCell = ({
           />
         </TableCell>
       ) : (
-        <TableCell className={classNameForRow}>
-          {daily ? Number(daily[dailyKey])?.toFixed(DECIMAL_PLACES) : ''}
-        </TableCell>
+        <TableCell className={classNameForRow}>{dataValue}</TableCell>
       )}
     </React.Fragment>
   )

--- a/web/src/features/hfiCalculator/components/StaticCells.tsx
+++ b/web/src/features/hfiCalculator/components/StaticCells.tsx
@@ -28,6 +28,7 @@ export const StaticCells = ({
   const staticCells = range(numPrepDays).map(dailyIndex => {
     const daily = dailies?.at(dailyIndex)
     const error = !isValidGrassCure(daily, station.station_props)
+    const hfiValue = error ? undefined : daily?.hfi?.toFixed(DECIMAL_PLACES)
     return isUndefined(daily) ? (
       <EmptyStaticCells
         rowId={dailyIndex}
@@ -43,7 +44,7 @@ export const StaticCells = ({
           isRowSelected={isRowSelected}
         />
         <TableCell data-testid={`${daily.code}-hfi`} className={classNameForRow}>
-          {error ? undefined : daily.hfi?.toFixed(DECIMAL_PLACES)}
+          {hfiValue}
         </TableCell>
         <IntensityGroupCell
           testid={`${daily.code}-intensity-group`}

--- a/web/src/features/hfiCalculator/components/StaticCells.tsx
+++ b/web/src/features/hfiCalculator/components/StaticCells.tsx
@@ -1,13 +1,16 @@
 import { TableCell } from '@material-ui/core'
 import { WeatherStation } from 'api/hfiCalcAPI'
 import { StationDaily } from 'api/hfiCalculatorAPI'
+import EmptyStaticCells from 'features/hfiCalculator/components/EmptyStaticCells'
 import IntensityGroupCell from 'features/hfiCalculator/components/IntensityGroupCell'
 import WeeklyROSCell from 'features/hfiCalculator/components/WeeklyROSCell'
 import { DECIMAL_PLACES } from 'features/hfiCalculator/constants'
 import { isValidGrassCure } from 'features/hfiCalculator/validation'
+import { isUndefined, range } from 'lodash'
 import React, { ReactElement } from 'react'
 
 export interface StaticCellsProps {
+  numPrepDays: number
   dailies: StationDaily[] | undefined
   station: WeatherStation
   classNameForRow: string | undefined
@@ -15,14 +18,18 @@ export interface StaticCellsProps {
 }
 
 export const StaticCells = ({
+  numPrepDays,
   dailies,
   station,
   classNameForRow,
   isRowSelected
 }: StaticCellsProps): ReactElement => {
-  const staticCells = dailies?.map(daily => {
+  const staticCells = range(numPrepDays).map(dailyIndex => {
+    const daily = dailies?.at(dailyIndex)
     const error = !isValidGrassCure(daily, station.station_props)
-    return (
+    return isUndefined(daily) ? (
+      <EmptyStaticCells rowId={dailyIndex} classNameForRow={classNameForRow} />
+    ) : (
       <React.Fragment key={`${station.code}-${daily.date}`}>
         <WeeklyROSCell
           daily={daily}

--- a/web/src/features/hfiCalculator/components/StaticCells.tsx
+++ b/web/src/features/hfiCalculator/components/StaticCells.tsx
@@ -2,6 +2,7 @@ import { TableCell } from '@material-ui/core'
 import { WeatherStation } from 'api/hfiCalcAPI'
 import { StationDaily } from 'api/hfiCalculatorAPI'
 import EmptyStaticCells from 'features/hfiCalculator/components/EmptyStaticCells'
+import HighestDailyFIGCell from 'features/hfiCalculator/components/HighestDailyFIGCell'
 import IntensityGroupCell from 'features/hfiCalculator/components/IntensityGroupCell'
 import WeeklyROSCell from 'features/hfiCalculator/components/WeeklyROSCell'
 import { DECIMAL_PLACES } from 'features/hfiCalculator/constants'
@@ -63,7 +64,14 @@ export const StaticCells = ({
       </React.Fragment>
     )
   })
-  return <React.Fragment>{staticCells}</React.Fragment>
+  return (
+    <React.Fragment>
+      {staticCells}
+      <HighestDailyFIGCell isRowSelected={isRowSelected} />
+      {/* Calc. Prep */}
+      <TableCell data-testid={`calc-prep`} className={classNameForRow}></TableCell>
+    </React.Fragment>
+  )
 }
 
 export default React.memo(StaticCells)

--- a/web/src/features/hfiCalculator/components/StaticCells.tsx
+++ b/web/src/features/hfiCalculator/components/StaticCells.tsx
@@ -28,12 +28,16 @@ export const StaticCells = ({
     const daily = dailies?.at(dailyIndex)
     const error = !isValidGrassCure(daily, station.station_props)
     return isUndefined(daily) ? (
-      <EmptyStaticCells rowId={dailyIndex} classNameForRow={classNameForRow} />
+      <EmptyStaticCells
+        rowId={dailyIndex}
+        isRowSelected={isRowSelected}
+        classNameForRow={classNameForRow}
+      />
     ) : (
       <React.Fragment key={`${station.code}-${daily.date}`}>
         <WeeklyROSCell
           daily={daily}
-          station={station}
+          testId={`${station.code}-ros`}
           error={error}
           isRowSelected={isRowSelected}
         />

--- a/web/src/features/hfiCalculator/components/StatusCell.tsx
+++ b/web/src/features/hfiCalculator/components/StatusCell.tsx
@@ -1,15 +1,50 @@
 import { TableCell } from '@material-ui/core'
+import ErrorIconWithTooltip from 'features/hfiCalculator/components/ErrorIconWithTooltip'
+import { ValidatedStationDaily } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
+import { isUndefined } from 'lodash'
 import React from 'react'
 
 export interface StatusCellProps {
-  value: string | undefined
+  daily: ValidatedStationDaily | undefined
   className: string | undefined
 }
 
+const noForecastText =
+  'Forecast not available. Please check WFWX or contact a Forecaster.'
+const noForecastElement = <div>{noForecastText}</div>
+
+const observationValidCommentElement = (daily: ValidatedStationDaily) => (
+  <div>{daily.observation_valid_comment}</div>
+)
+
 const StatusCell = (props: StatusCellProps) => {
+  if (isUndefined(props.daily)) {
+    return (
+      <TableCell data-testid={'status-cell'}>
+        <ErrorIconWithTooltip
+          testId="daily-status-no-forecast"
+          isDataCell={true}
+          tooltipElement={noForecastElement}
+          tooltipAriaText={[noForecastText]}
+        />
+      </TableCell>
+    )
+  }
+  if (props.daily.observation_valid === false) {
+    return (
+      <TableCell data-testid={'status-cell'}>
+        <ErrorIconWithTooltip
+          testId="daily-status-obs-invalid"
+          isDataCell={true}
+          tooltipElement={observationValidCommentElement(props.daily)}
+          tooltipAriaText={[props.daily.observation_valid_comment]}
+        />
+      </TableCell>
+    )
+  }
   return (
     <TableCell data-testid={'status-cell'} className={props.className}>
-      {props.value ? props.value : 'N/A'}
+      {props.daily.status}
     </TableCell>
   )
 }

--- a/web/src/features/hfiCalculator/components/ViewSwitcher.tsx
+++ b/web/src/features/hfiCalculator/components/ViewSwitcher.tsx
@@ -1,13 +1,15 @@
 import { FireCentre } from 'api/hfiCalcAPI'
-import { StationDaily } from 'api/hfiCalculatorAPI'
 import { DailyViewTable } from 'features/hfiCalculator/components/DailyViewTable'
 import WeeklyViewTable from 'features/hfiCalculator/components/WeeklyViewTable'
-import { FireStarts } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
+import {
+  FireStarts,
+  ValidatedStationDaily
+} from 'features/hfiCalculator/slices/hfiCalculatorSlice'
 import React from 'react'
 
 export interface ViewSwitcherProps {
   testId?: string
-  dailies: StationDaily[]
+  dailies: ValidatedStationDaily[]
   dateOfInterest: string
   setSelected: (selected: number[]) => void
   setNewFireStarts: (

--- a/web/src/features/hfiCalculator/components/WeeklyROSCell.tsx
+++ b/web/src/features/hfiCalculator/components/WeeklyROSCell.tsx
@@ -20,6 +20,8 @@ const useStyles = makeStyles({
   }
 })
 const WeeklyROSCell = ({ daily, testId, isRowSelected, error }: WeeklyROSCellProps) => {
+  const dataValue = error ? '' : daily?.rate_of_spread?.toFixed(DECIMAL_PLACES)
+
   const classes = useStyles()
   return (
     <TableCell
@@ -28,7 +30,7 @@ const WeeklyROSCell = ({ daily, testId, isRowSelected, error }: WeeklyROSCellPro
         isRowSelected ? classes.sectionSeparatorBorder : classes.unselectedStation
       }
     >
-      {error ? '' : daily?.rate_of_spread?.toFixed(DECIMAL_PLACES)}
+      {dataValue}
     </TableCell>
   )
 }

--- a/web/src/features/hfiCalculator/components/WeeklyROSCell.tsx
+++ b/web/src/features/hfiCalculator/components/WeeklyROSCell.tsx
@@ -1,14 +1,13 @@
 import { TableCell } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
-import { WeatherStation } from 'api/hfiCalcAPI'
 import { StationDaily } from 'api/hfiCalculatorAPI'
 import { fireTableStyles, UNSELECTED_STATION_COLOR } from 'app/theme'
 import { DECIMAL_PLACES } from 'features/hfiCalculator/constants'
 import React from 'react'
 
 export interface WeeklyROSCellProps {
-  daily: StationDaily
-  station: WeatherStation
+  daily?: StationDaily
+  testId?: string
   error: boolean
   isRowSelected: boolean
 }
@@ -20,11 +19,11 @@ const useStyles = makeStyles({
     color: UNSELECTED_STATION_COLOR
   }
 })
-const WeeklyROSCell = ({ daily, station, isRowSelected, error }: WeeklyROSCellProps) => {
+const WeeklyROSCell = ({ daily, testId, isRowSelected, error }: WeeklyROSCellProps) => {
   const classes = useStyles()
   return (
     <TableCell
-      data-testid={`${station.code}-ros`}
+      data-testid={testId}
       className={
         isRowSelected ? classes.sectionSeparatorBorder : classes.unselectedStation
       }

--- a/web/src/features/hfiCalculator/components/WeeklyViewTable.tsx
+++ b/web/src/features/hfiCalculator/components/WeeklyViewTable.tsx
@@ -13,18 +13,20 @@ import GrassCureCell from 'features/hfiCalculator/components/GrassCureCell'
 import { isGrassFuelType } from 'features/hfiCalculator/validation'
 import { BACKGROUND_COLOR, fireTableStyles } from 'app/theme'
 import { isEmpty, isUndefined } from 'lodash'
-import { StationDaily } from 'api/hfiCalculatorAPI'
 import { getDailiesByStationCode } from 'features/hfiCalculator/util'
 import StickyCell from 'components/StickyCell'
 import FireCentreCell from 'features/hfiCalculator/components/FireCentreCell'
 import { selectHFICalculatorState } from 'app/rootReducer'
 import { useSelector } from 'react-redux'
-import { FireStarts } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
+import {
+  FireStarts,
+  ValidatedStationDaily
+} from 'features/hfiCalculator/slices/hfiCalculatorSlice'
 
 export interface Props {
   fireCentre: FireCentre | undefined
   testId?: string
-  dailies: StationDaily[]
+  dailies: ValidatedStationDaily[]
   currentDay: string
   setSelected: (selected: number[]) => void
   setNewFireStarts: (

--- a/web/src/features/hfiCalculator/components/WeeklyViewTable.tsx
+++ b/web/src/features/hfiCalculator/components/WeeklyViewTable.tsx
@@ -302,6 +302,7 @@ export const WeeklyViewTable = (props: Props): JSX.Element => {
                               </StickyCell>
 
                               <StaticCells
+                                numPrepDays={numPrepDays}
                                 dailies={dailiesForStation}
                                 station={station}
                                 classNameForRow={classNameForRow}

--- a/web/src/features/hfiCalculator/components/meanIntensityGroupRollup.test.tsx
+++ b/web/src/features/hfiCalculator/components/meanIntensityGroupRollup.test.tsx
@@ -7,7 +7,8 @@ describe('Mean Intensity Group Rollup', () => {
   const planningArea: PlanningArea = {
     id: 1,
     name: 'Test Area',
-    stations: []
+    stations: [],
+    order_of_appearance_in_list: 0
   }
 
   it('should return nothing in cell when dailies are empty', () => {

--- a/web/src/features/hfiCalculator/components/statusCell.test.tsx
+++ b/web/src/features/hfiCalculator/components/statusCell.test.tsx
@@ -1,15 +1,49 @@
 import { TableContainer, Table, TableRow, TableBody } from '@material-ui/core'
 import { render } from '@testing-library/react'
 import StatusCell from 'features/hfiCalculator/components/StatusCell'
+import { ValidatedStationDaily } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
+import { DateTime } from 'luxon'
 import React from 'react'
 describe('StatusCell', () => {
-  const renderStatusCell = (status: string | undefined) => {
+  const validDaily: ValidatedStationDaily = {
+    code: 1,
+    status: 'ACTUAL',
+    temperature: 1,
+    relative_humidity: 1,
+    wind_speed: 1,
+    wind_direction: 1,
+    grass_cure_percentage: 1,
+    precipitation: 1,
+    ffmc: 1,
+    dmc: 1,
+    dc: 1,
+    isi: 1,
+    bui: 1,
+    fwi: 1,
+    danger_class: 1,
+    rate_of_spread: 1,
+    hfi: 1,
+    observation_valid: true,
+    observation_valid_comment: '',
+    intensity_group: 1,
+    sixty_minute_fire_size: 1,
+    fire_type: '',
+    date: DateTime.fromObject({ year: 2021, month: 1, day: 1 }),
+    valid: true
+  }
+
+  const invalidDaily: ValidatedStationDaily = {
+    ...validDaily,
+    observation_valid: false,
+    valid: false
+  }
+  const renderStatusCell = (daily: ValidatedStationDaily | undefined) => {
     return render(
       <TableContainer>
         <Table>
           <TableBody>
             <TableRow>
-              <StatusCell value={status} className={''} />
+              <StatusCell daily={daily} className={''} />
             </TableRow>
           </TableBody>
         </Table>
@@ -18,11 +52,15 @@ describe('StatusCell', () => {
   }
 
   it('should render the status if it is defined', () => {
-    const { getByTestId } = renderStatusCell('ACTUAL')
-    expect(getByTestId('status-cell').innerHTML).toBe('ACTUAL')
+    const { getByTestId } = renderStatusCell(validDaily)
+    expect(getByTestId('status-cell').innerHTML).toBe(validDaily.status)
   })
-  it('should render N/A if status is undefined', () => {
+  it('should render error with tooltip if daily is undefined', () => {
     const { getByTestId } = renderStatusCell(undefined)
-    expect(getByTestId('status-cell').innerHTML).toBe('N/A')
+    expect(getByTestId('daily-status-no-forecast')).toBeDefined()
+  })
+  it('should render error with tooltip if daily is invalid', () => {
+    const { getByTestId } = renderStatusCell(invalidDaily)
+    expect(getByTestId('daily-status-obs-invalid')).toBeDefined()
   })
 })

--- a/web/src/features/hfiCalculator/components/weeklyRosCell.test.tsx
+++ b/web/src/features/hfiCalculator/components/weeklyRosCell.test.tsx
@@ -1,17 +1,13 @@
 import { Table, TableBody, TableContainer, TableRow } from '@material-ui/core'
 import { render } from '@testing-library/react'
-import { WeatherStation } from 'api/hfiCalcAPI'
 import { StationDaily } from 'api/hfiCalculatorAPI'
 import WeeklyROSCell from 'features/hfiCalculator/components/WeeklyROSCell'
-import {
-  buildStation,
-  buildStationDaily
-} from 'features/hfiCalculator/components/testHelpers'
+import { buildStationDaily } from 'features/hfiCalculator/components/testHelpers'
 import React from 'react'
 
 const renderWeeklyRos = (
   daily: StationDaily,
-  station: WeatherStation,
+  testId: string,
   error: boolean,
   isRowSelected: boolean
 ) => {
@@ -21,8 +17,8 @@ const renderWeeklyRos = (
         <TableBody>
           <TableRow>
             <WeeklyROSCell
+              testId={testId}
               daily={daily}
-              station={station}
               error={error}
               isRowSelected={isRowSelected}
             ></WeeklyROSCell>
@@ -35,53 +31,54 @@ const renderWeeklyRos = (
 
 describe('WeeklyROSCell', () => {
   const stationCode = 1
+  const testId = `${stationCode}-ros`
   const separatorClassRegExp = /makeStyles-sectionSeparatorBorder-/
   const unselectedClassRegExp = /makeStyles-unselectedStation/
   it('should return a WeeklyROSCell with left border seperator class and formatted value of 1.0', () => {
     const { getByTestId } = renderWeeklyRos(
       buildStationDaily(stationCode),
-      buildStation(stationCode),
+      testId,
       false,
       true
     )
 
-    const cell = getByTestId(`${stationCode}-ros`)
+    const cell = getByTestId(testId)
     expect(cell.className).toMatch(separatorClassRegExp)
     expect(cell.innerHTML).toBe('1.0')
   })
   it('should return a WeeklyROSCell with empty value when there is an error and it is selected', () => {
     const { getByTestId } = renderWeeklyRos(
       buildStationDaily(stationCode),
-      buildStation(stationCode),
+      testId,
       true,
       true
     )
 
-    const cell = getByTestId(`${stationCode}-ros`)
+    const cell = getByTestId(testId)
     expect(cell.className).toMatch(separatorClassRegExp)
     expect(cell.innerHTML).toBe('')
   })
   it('should return a WeeklyROSCell with empty value when there is an error and it is not selected', () => {
     const { getByTestId } = renderWeeklyRos(
       buildStationDaily(stationCode),
-      buildStation(stationCode),
+      testId,
       true,
       false
     )
 
-    const cell = getByTestId(`${stationCode}-ros`)
+    const cell = getByTestId(testId)
     expect(cell.className).toMatch(unselectedClassRegExp)
     expect(cell.innerHTML).toBe('')
   })
   it('should return a WeeklyROSCell with formatted value when there is and it is not selected', () => {
     const { getByTestId } = renderWeeklyRos(
       buildStationDaily(stationCode),
-      buildStation(stationCode),
+      testId,
       false,
       false
     )
 
-    const cell = getByTestId(`${stationCode}-ros`)
+    const cell = getByTestId(testId)
     expect(cell.className).toMatch(unselectedClassRegExp)
     expect(cell.innerHTML).toBe('1.0')
   })

--- a/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
+++ b/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
@@ -37,7 +37,6 @@ import DatePicker from 'components/DatePicker'
 import { FireCentre } from 'api/hfiCalcAPI'
 import { isUndefined, union } from 'lodash'
 import FireCentreDropdown from 'features/hfiCalculator/components/FireCentreDropdown'
-import HFIErrorAlert from 'features/hfiCalculator/components/HFIErrorAlert'
 
 const useStyles = makeStyles(() => ({
   ...formControlStyles,
@@ -75,8 +74,8 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
   const classes = useStyles()
 
   const dispatch = useDispatch()
-  const { dailies, loading, error: hfiDailiesError } = useSelector(selectHFIDailies)
-  const { fireCentres, error: fireCentresError } = useSelector(selectHFIStations)
+  const { dailies, loading } = useSelector(selectHFIDailies)
+  const { fireCentres } = useSelector(selectHFIStations)
   const stationDataLoading = useSelector(selectHFIStationsLoading)
   const {
     numPrepDays,
@@ -278,13 +277,13 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
         </Container>
       ) : (
         <Container maxWidth={'xl'}>
-          {hfiDailiesError ||
+          {/* {hfiDailiesError ||
             (fireCentresError && (
               <HFIErrorAlert
                 hfiDailiesError={hfiDailiesError}
                 fireCentresError={fireCentresError}
               />
-            ))}
+            ))} */}
           <FormControl className={classes.prepDays}>
             <PrepDaysDropdown days={numPrepDays} setNumPrepDays={setNumPrepDays} />
           </FormControl>

--- a/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
+++ b/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
@@ -37,6 +37,7 @@ import DatePicker from 'components/DatePicker'
 import { FireCentre } from 'api/hfiCalcAPI'
 import { isUndefined, union } from 'lodash'
 import FireCentreDropdown from 'features/hfiCalculator/components/FireCentreDropdown'
+import HFIErrorAlert from 'features/hfiCalculator/components/HFIErrorAlert'
 
 const useStyles = makeStyles(() => ({
   ...formControlStyles,
@@ -74,8 +75,8 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
   const classes = useStyles()
 
   const dispatch = useDispatch()
-  const { dailies, loading } = useSelector(selectHFIDailies)
-  const { fireCentres } = useSelector(selectHFIStations)
+  const { dailies, loading, error: hfiDailiesError } = useSelector(selectHFIDailies)
+  const { fireCentres, error: fireCentresError } = useSelector(selectHFIStations)
   const stationDataLoading = useSelector(selectHFIStationsLoading)
   const {
     numPrepDays,
@@ -277,6 +278,13 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
         </Container>
       ) : (
         <Container maxWidth={'xl'}>
+          {hfiDailiesError ||
+            (fireCentresError && (
+              <HFIErrorAlert
+                hfiDailiesError={hfiDailiesError}
+                fireCentresError={fireCentresError}
+              />
+            ))}
           <FormControl className={classes.prepDays}>
             <PrepDaysDropdown days={numPrepDays} setNumPrepDays={setNumPrepDays} />
           </FormControl>

--- a/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
+++ b/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
@@ -277,13 +277,6 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
         </Container>
       ) : (
         <Container maxWidth={'xl'}>
-          {/* {hfiDailiesError ||
-            (fireCentresError && (
-              <HFIErrorAlert
-                hfiDailiesError={hfiDailiesError}
-                fireCentresError={fireCentresError}
-              />
-            ))} */}
           <FormControl className={classes.prepDays}>
             <PrepDaysDropdown days={numPrepDays} setNumPrepDays={setNumPrepDays} />
           </FormControl>

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.test.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.test.ts
@@ -7,8 +7,11 @@ import {
   highestFireStarts,
   lowestFireStarts,
   one2TwoStarts,
+  requiredFields,
   three2SixStarts,
-  two2ThreeStarts
+  two2ThreeStarts,
+  ValidatedStationDaily,
+  validateStationDaily
 } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
 import { buildStationDaily } from 'features/hfiCalculator/components/testHelpers'
 describe('hfiCalculatorSlice', () => {
@@ -67,6 +70,23 @@ describe('hfiCalculatorSlice', () => {
       expect(calculatePrepLevel(3, highestFireStarts)).toBe(6)
       expect(calculatePrepLevel(4, highestFireStarts)).toBe(6)
       expect(calculatePrepLevel(5, highestFireStarts)).toBe(6)
+    })
+  })
+  describe('daily validation', () => {
+    it('should not validate daily if any required field is missing', () => {
+      requiredFields.forEach(field => {
+        const invalidDaily: ValidatedStationDaily = validateStationDaily({
+          ...buildStationDaily(1),
+          [field]: null
+        })
+        expect(invalidDaily.valid).toBe(false)
+      })
+    })
+    it('should validate daily if all required fields are set', () => {
+      const validDaily: ValidatedStationDaily = validateStationDaily({
+        ...buildStationDaily(1)
+      })
+      expect(validDaily.valid).toBe(true)
     })
   })
 })

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -99,8 +99,7 @@ const requiredFields: RequiredValidField[] = [
   'relative_humidity',
   'wind_speed',
   'wind_direction',
-  'precipitation',
-  'intensity_group'
+  'precipitation'
 ]
 
 export const validateStationDaily = (daily: StationDaily): ValidatedStationDaily => {

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -94,7 +94,7 @@ const initialState: HFICalculatorState = {
 }
 
 type RequiredValidField = keyof StationDaily
-const requiredFields: RequiredValidField[] = [
+export const requiredFields: RequiredValidField[] = [
   'temperature',
   'relative_humidity',
   'wind_speed',

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -3,7 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { AppThunk } from 'app/store'
 import { logError } from 'utils/error'
 import { getDailies, StationDaily } from 'api/hfiCalculatorAPI'
-import { groupBy, isUndefined, range, chain, flatten, take } from 'lodash'
+import { groupBy, isUndefined, range, chain, flatten, take, isNull } from 'lodash'
 import { NUM_WEEK_DAYS } from 'features/hfiCalculator/constants'
 import { FireCentre } from 'api/hfiCalcAPI'
 
@@ -15,13 +15,14 @@ export interface FireStarts {
 
 export interface DailyResult {
   dateISO: string
-  dailies: StationDaily[]
+  dailies: ValidatedStationDaily[]
   fireStarts: FireStarts
   meanIntensityGroup: number | undefined
   prepLevel: number | undefined
 }
 
 export interface PlanningAreaResult {
+  allDailiesValid: boolean
   highestDailyIntensityGroup: number
   meanPrepLevel: number | undefined
   dailyResults: DailyResult[]
@@ -30,7 +31,7 @@ export interface PlanningAreaResult {
 export interface HFICalculatorState {
   loading: boolean
   error: string | null
-  dailies: StationDaily[]
+  dailies: ValidatedStationDaily[]
   numPrepDays: number
   selectedStationCodes: number[]
   selectedPrepDate: string
@@ -38,6 +39,13 @@ export interface HFICalculatorState {
   planningAreaFireStarts: { [key: string]: FireStarts[] }
   planningAreaHFIResults: { [key: string]: PlanningAreaResult }
   selectedFireCentre: FireCentre | undefined
+}
+
+export interface ValidatedStationDaily extends StationDaily {
+  validDetails: {
+    valid: boolean
+    missingFields: RequiredValidField[]
+  }
 }
 
 // Encodes lookup tables for each fire starts range from workbook
@@ -86,6 +94,38 @@ const initialState: HFICalculatorState = {
   planningAreaFireStarts: {},
   planningAreaHFIResults: {},
   selectedFireCentre: undefined
+}
+
+type RequiredValidField = keyof StationDaily
+const requiredFields: RequiredValidField[] = [
+  'temperature',
+  'relative_humidity',
+  'wind_speed',
+  'wind_direction',
+  'precipitation',
+  'intensity_group'
+]
+
+export const validateStationDaily = (daily: StationDaily): ValidatedStationDaily => {
+  const missingRequiredFields: RequiredValidField[] = []
+  const requiredFieldsPresent = Object.keys(daily)
+    .map(key => {
+      if (requiredFields.includes(key as keyof StationDaily)) {
+        const includesRequiredField =
+          !isUndefined(daily[key as keyof StationDaily]) &&
+          !isNull(daily[key as keyof StationDaily])
+        if (!includesRequiredField) {
+          missingRequiredFields.push(key as RequiredValidField)
+        }
+        return includesRequiredField
+      }
+      return true
+    })
+    .reduce((prev, curr) => prev && curr, true)
+  return {
+    ...daily,
+    validDetails: { valid: requiredFieldsPresent, missingFields: missingRequiredFields }
+  }
 }
 
 export const calculateMeanIntensity = (dailies: StationDaily[]): number | undefined =>
@@ -210,9 +250,12 @@ const calculateHFIResults = (
         const dailyFireStarts = planningAreaFireStarts[area.name][index]
         const meanIntensityGroup = calculateMeanIntensity(resultDailies)
         const prepLevel = calculatePrepLevel(meanIntensityGroup, dailyFireStarts)
+        const validatedDailies: ValidatedStationDaily[] = resultDailies.map(daily =>
+          validateStationDaily(daily)
+        )
         return {
           dateISO: resultDailies[0].date.toISO(),
-          dailies: resultDailies,
+          dailies: validatedDailies,
           fireStarts: dailyFireStarts,
           meanIntensityGroup,
           prepLevel
@@ -228,7 +271,14 @@ const calculateHFIResults = (
       dailyResults.map(result => result.prepLevel)
     )
 
+    const allDailiesValid = dailyResults
+      .flatMap(result =>
+        result.dailies.every(validatedDaily => validatedDaily.validDetails.valid === true)
+      )
+      .reduce((prev, curr) => prev && curr, true)
+
     planningAreaToDailies[area.name] = {
+      allDailiesValid,
       dailyResults,
       highestDailyIntensityGroup,
       meanPrepLevel
@@ -257,7 +307,7 @@ const dailiesSlice = createSlice({
       }>
     ) {
       state.error = null
-      state.dailies = action.payload.dailies
+      state.dailies = action.payload.dailies.map(daily => validateStationDaily(daily))
       state.selectedFireCentre = action.payload.fireCentre
       state.selectedStationCodes = action.payload.selectedStationCodes
       state.planningAreaHFIResults = calculateHFIResults(

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -42,10 +42,7 @@ export interface HFICalculatorState {
 }
 
 export interface ValidatedStationDaily extends StationDaily {
-  validDetails: {
-    valid: boolean
-    missingFields: RequiredValidField[]
-  }
+  valid: boolean
 }
 
 // Encodes lookup tables for each fire starts range from workbook
@@ -107,16 +104,12 @@ const requiredFields: RequiredValidField[] = [
 ]
 
 export const validateStationDaily = (daily: StationDaily): ValidatedStationDaily => {
-  const missingRequiredFields: RequiredValidField[] = []
   const requiredFieldsPresent = Object.keys(daily)
     .map(key => {
       if (requiredFields.includes(key as keyof StationDaily)) {
         const includesRequiredField =
           !isUndefined(daily[key as keyof StationDaily]) &&
           !isNull(daily[key as keyof StationDaily])
-        if (!includesRequiredField) {
-          missingRequiredFields.push(key as RequiredValidField)
-        }
         return includesRequiredField
       }
       return true
@@ -124,7 +117,7 @@ export const validateStationDaily = (daily: StationDaily): ValidatedStationDaily
     .reduce((prev, curr) => prev && curr, true)
   return {
     ...daily,
-    validDetails: { valid: requiredFieldsPresent, missingFields: missingRequiredFields }
+    valid: requiredFieldsPresent
   }
 }
 
@@ -273,7 +266,7 @@ const calculateHFIResults = (
 
     const allDailiesValid = dailyResults
       .flatMap(result =>
-        result.dailies.every(validatedDaily => validatedDaily.validDetails.valid === true)
+        result.dailies.every(validatedDaily => validatedDaily.valid === true)
       )
       .reduce((prev, curr) => prev && curr, true)
 

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -107,10 +107,10 @@ export const validateStationDaily = (daily: StationDaily): ValidatedStationDaily
   const requiredFieldsPresent = Object.keys(daily)
     .map(key => {
       if (requiredFields.includes(key as keyof StationDaily)) {
-        const includesRequiredField =
+        return (
           !isUndefined(daily[key as keyof StationDaily]) &&
           !isNull(daily[key as keyof StationDaily])
-        return includesRequiredField
+        )
       }
       return true
     })

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -99,7 +99,8 @@ const requiredFields: RequiredValidField[] = [
   'relative_humidity',
   'wind_speed',
   'wind_direction',
-  'precipitation'
+  'precipitation',
+  'intensity_group'
 ]
 
 export const validateStationDaily = (daily: StationDaily): ValidatedStationDaily => {

--- a/web/src/features/hfiCalculator/util.ts
+++ b/web/src/features/hfiCalculator/util.ts
@@ -1,5 +1,6 @@
 import { PlanningArea } from 'api/hfiCalcAPI'
 import { StationDaily } from 'api/hfiCalculatorAPI'
+import { ValidatedStationDaily } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
 import { groupBy, sortBy, take } from 'lodash'
 
 export const getDailiesForArea = (
@@ -21,11 +22,11 @@ export const getZoneFromAreaName = (areaName: string): string => {
 
 export const getDailiesByStationCode = (
   numPrepDays: number,
-  dailies: StationDaily[],
+  dailies: ValidatedStationDaily[],
   stationCode: number
-): StationDaily[] => {
+): ValidatedStationDaily[] => {
   const stationCodeDict = groupBy(dailies, 'code')
-  const dailiesByCode = new Map<number, StationDaily[]>()
+  const dailiesByCode = new Map<number, ValidatedStationDaily[]>()
 
   Object.keys(stationCodeDict).forEach(key => {
     dailiesByCode.set(Number(key), stationCodeDict[key])


### PR DESCRIPTION
Adds error handling for the cases below:

Scenario 1: no forecast
- [x] Given I am using the HFI Calculator **daily** view, When there is no (zero) forecast data, Then an error icon is displayed in status column
  - hover copy on the error icon reads: _Forecast not available. Please check WFWX or contact a Forecaster._
- [x] Given I am using the HFI Calculator **daily** view, When there is no (zero) forecast data, Then an error icon is displayed in M/FIG column (planning area row)
  - hover copy on the error icon reads: _Forecast not available for one or more stations. Please exclude station(s) displaying errors._   
- [x] Given I am using the HFI Calculator **daily** view, When there is no (zero) forecast data, Then an error icon is displayed in Prep column
  - hover copy on the error icon reads: _Forecast not available for one or more stations. Please exclude station(s) displaying errors._   
- [x] Given I am using the HFI Calculator **weekly** view, When there is no (zero) forecast data, Then the cells are empty (no data) but row and column borders are still displayed — see Figma
- [x] Given I am using the HFI Calculator **weekly** view, When there is no (zero) forecast data, Then an error icon is displayed in the Prep column for affected day(s)
  - hover copy on the error icon reads: _Cannot calculate prep level. Please exclude station(s) displaying errors._
- [x] Given I am using the HFI Calculator **weekly** view, When there is no (zero) forecast data, Then an error icon is displayed in the Final Calculated Prep column 
  - hover copy on the error icon reads: _Cannot calculate prep level. Please exclude station(s) displaying errors._
- [x] Given I am using the HFI Calculator **weekly** view, When there is no (zero) forecast data for 1+ days, Then  display the highest daily FIG, understanding that it is excluding the days with errors/no data

Scenario 3: incomplete forecast (e.g. grass cure missing, temp missing)
- [x] Given I am using the HFI Calculator **daily** view, When there is partial forecast data - meaning one or more but not all indices are missing, Then we display the data we can, and display an error icon in column(s) with missing data
  - Hover copy on the error icon reads: _[index], [index] cannot be null. Cannot calculate [impacted fire behaviour indices]_
- [x] Given I am using the HFI Calculator **daily** view, When there is partial forecast data - meaning one or more but not all indices are missing, Then an error icon is displayed in the Mean FIG column 
  - Hover copy on the error icon reads: _Incomplete data from WFWX for one or more stations. Please exclude station(s) displaying errors._    
- [x] Given I am using the HFI Calculator **daily** view, When there is partial forecast data - meaning one or more but not all indices are missing, Then an error icon is displayed in the Prep column 
  - Hover copy on the error icon reads: _Incomplete data from WFWX for one or more stations. Please exclude station(s) displaying errors._   
- [x] Given I am using the HFI Calculator **weekly** view, When there is partial forecast data - meaning one or more but not all indices are missing, Then an error icon is displayed in the daily and final Prep column(s) 
  - Hover copy on the error icon reads: _Cannot calculate prep level. Please check the daily forecast using the tabs above._
  
# Test Links:
[Percentile Calculator](https://wps-pr-1681.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1681.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1681.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1681.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1681.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1681.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1681.apps.silver.devops.gov.bc.ca/hfi-calculator)
