### PR TITLE
Adds HFI Error Banner

### DIFF
--- a/web/src/features/hfiCalculator/components/HFIErrorAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFIErrorAlert.tsx
@@ -29,6 +29,7 @@ const HFIErrorAlert = ({ hfiDailiesError, fireCentresError }: HFIErrorAlertProps
     <div className={classes.root}>
       <Collapse in={open}>
         <Alert
+          data-testid="hfi-error-alert"
           severity="error"
           action={
             <IconButton

--- a/web/src/features/hfiCalculator/components/hfiErrorAlert.test.tsx
+++ b/web/src/features/hfiCalculator/components/hfiErrorAlert.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react'
+import HFIErrorAlert from 'features/hfiCalculator/components/HFIErrorAlert'
+import React from 'react'
+
+describe('HFIErrorAlert', () => {
+  it('should render an alert', () => {
+    const { getByRole } = render(
+      <HFIErrorAlert
+        hfiDailiesError={'500 - no dailies'}
+        fireCentresError={'500 - no fire centres'}
+      />
+    )
+    const alertLink = getByRole('link')
+    expect(alertLink).toBeDefined()
+    expect(alertLink).toHaveAttribute(
+      'href',
+      'mailto:bcws.predictiveservices@gov.bc.ca?subject=Predictive Services Unit - HFI Error'
+    )
+  })
+})

--- a/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
+++ b/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
@@ -35,8 +35,9 @@ import { PST_UTC_OFFSET } from 'utils/constants'
 import PrepDaysDropdown from 'features/hfiCalculator/components/PrepDaysDropdown'
 import DatePicker from 'components/DatePicker'
 import { FireCentre } from 'api/hfiCalcAPI'
-import { isUndefined, union } from 'lodash'
+import { isNull, isUndefined, union } from 'lodash'
 import FireCentreDropdown from 'features/hfiCalculator/components/FireCentreDropdown'
+import HFIErrorAlert from 'features/hfiCalculator/components/HFIErrorAlert'
 
 const useStyles = makeStyles(() => ({
   ...formControlStyles,
@@ -74,8 +75,8 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
   const classes = useStyles()
 
   const dispatch = useDispatch()
-  const { dailies, loading } = useSelector(selectHFIDailies)
-  const { fireCentres } = useSelector(selectHFIStations)
+  const { dailies, loading, error: hfiDailiesError } = useSelector(selectHFIDailies)
+  const { fireCentres, error: fireCentresError } = useSelector(selectHFIStations)
   const stationDataLoading = useSelector(selectHFIStationsLoading)
   const {
     numPrepDays,
@@ -276,71 +277,80 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
           <CircularProgress />
         </Container>
       ) : (
-        <Container maxWidth={'xl'}>
-          <FormControl className={classes.prepDays}>
-            <PrepDaysDropdown days={numPrepDays} setNumPrepDays={setNumPrepDays} />
-          </FormControl>
-          <FormControl className={classes.formControl}>
-            <FireCentreDropdown
-              fireCentres={fireCentres}
-              selectedValue={
-                isUndefined(selectedFireCentre)
-                  ? null
-                  : { name: selectedFireCentre?.name }
-              }
-              onChange={selectNewFireCentre}
-            />
-          </FormControl>
-
-          <FormControl className={classes.formControl}>
-            <DatePicker date={dateOfInterest} updateDate={updateDate} />
-          </FormControl>
-          <FormControl className={classes.formControl}>
-            <ViewSwitcherToggles dateOfInterest={dateOfInterest} />
-          </FormControl>
-          <FormControl className={classes.formControl}>
-            {isCopied ? (
-              <Button>
-                <CheckOutlined />
-                Copied!
-              </Button>
-            ) : (
-              <Button onClick={copyTable}>
-                <FileCopyOutlined className={classes.clipboardIcon} />
-                Copy Data to Clipboard
-                <Tooltip
-                  title={
-                    'You can paste all table data in Excel. To format: go to the Data tab, use Text to Columns > Delimited > Comma.'
-                  }
-                >
-                  <InfoOutlined className={classes.copyToClipboardInfoIcon} />
-                </Tooltip>
-              </Button>
+        <React.Fragment>
+          <Container maxWidth={'xl'}>
+            {(!isNull(hfiDailiesError) || !isNull(fireCentresError)) && (
+              <HFIErrorAlert
+                hfiDailiesError={hfiDailiesError}
+                fireCentresError={fireCentresError}
+              />
             )}
-          </FormControl>
 
-          <FormControl className={classes.positionStyler}>
-            <Button onClick={openAboutModal}>
-              <HelpOutlineOutlined className={classes.helpIcon}></HelpOutlineOutlined>
-              <p className={classes.aboutButtonText}>About this data</p>
-            </Button>
-          </FormControl>
-          <AboutDataModal
-            modalOpen={modalOpen}
-            setModalOpen={setModalOpen}
-          ></AboutDataModal>
+            <FormControl className={classes.prepDays}>
+              <PrepDaysDropdown days={numPrepDays} setNumPrepDays={setNumPrepDays} />
+            </FormControl>
+            <FormControl className={classes.formControl}>
+              <FireCentreDropdown
+                fireCentres={fireCentres}
+                selectedValue={
+                  isUndefined(selectedFireCentre)
+                    ? null
+                    : { name: selectedFireCentre?.name }
+                }
+                onChange={selectNewFireCentre}
+              />
+            </FormControl>
 
-          <ErrorBoundary>
-            <ViewSwitcher
-              selectedFireCentre={selectedFireCentre}
-              dailies={dailies}
-              dateOfInterest={dateOfInterest}
-              setSelected={setSelected}
-              setNewFireStarts={setNewFireStarts}
-              selectedPrepDay={selectedPrepDate}
-            />
-          </ErrorBoundary>
-        </Container>
+            <FormControl className={classes.formControl}>
+              <DatePicker date={dateOfInterest} updateDate={updateDate} />
+            </FormControl>
+            <FormControl className={classes.formControl}>
+              <ViewSwitcherToggles dateOfInterest={dateOfInterest} />
+            </FormControl>
+            <FormControl className={classes.formControl}>
+              {isCopied ? (
+                <Button>
+                  <CheckOutlined />
+                  Copied!
+                </Button>
+              ) : (
+                <Button onClick={copyTable}>
+                  <FileCopyOutlined className={classes.clipboardIcon} />
+                  Copy Data to Clipboard
+                  <Tooltip
+                    title={
+                      'You can paste all table data in Excel. To format: go to the Data tab, use Text to Columns > Delimited > Comma.'
+                    }
+                  >
+                    <InfoOutlined className={classes.copyToClipboardInfoIcon} />
+                  </Tooltip>
+                </Button>
+              )}
+            </FormControl>
+
+            <FormControl className={classes.positionStyler}>
+              <Button onClick={openAboutModal}>
+                <HelpOutlineOutlined className={classes.helpIcon}></HelpOutlineOutlined>
+                <p className={classes.aboutButtonText}>About this data</p>
+              </Button>
+            </FormControl>
+            <AboutDataModal
+              modalOpen={modalOpen}
+              setModalOpen={setModalOpen}
+            ></AboutDataModal>
+
+            <ErrorBoundary>
+              <ViewSwitcher
+                selectedFireCentre={selectedFireCentre}
+                dailies={dailies}
+                dateOfInterest={dateOfInterest}
+                setSelected={setSelected}
+                setNewFireStarts={setNewFireStarts}
+                selectedPrepDay={selectedPrepDate}
+              />
+            </ErrorBoundary>
+          </Container>
+        </React.Fragment>
       )}
     </main>
   )


### PR DESCRIPTION
- Subscribes to redux errors and shows banner if they are not null
- To test, open HFI page, let it load, open dev tools -> network, set to offline, change the date of interest, see error

 
![Screen Shot 2022-02-03 at 2 38 38 PM](https://user-images.githubusercontent.com/1447136/152441410-d883047c-38a2-4054-b455-870cd0861ebb.png)


# Test Links:
[Percentile Calculator](https://wps-pr-1690.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1690.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1690.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1690.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1690.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1690.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1690.apps.silver.devops.gov.bc.ca/hfi-calculator)
