### PR TITLE
Eco divisions are slow

### DIFF
--- a/api/app/data/ecodivision_seasons.py
+++ b/api/app/data/ecodivision_seasons.py
@@ -3,9 +3,10 @@ import os
 import json
 import logging
 import geopandas
+from typing import Dict
 from shapely.geometry import Point
+from app.utils.redis import create_redis
 
-from app.utils.singleton import Singleton
 
 dirname = os.path.dirname(__file__)
 core_season_file_path = os.path.join(
@@ -16,25 +17,40 @@ ecodiv_shape_file_path = os.path.join(
 logger = logging.getLogger(__name__)
 
 
-@Singleton
 class EcodivisionSeasons:
     """ Singleton that loads ecodivision data once and keeps it in memory for reuse.
         No mutators, data loaded is immutable."""
 
-    def __init__(self):
+    def __init__(self, key: str, use_cache: bool = True):
         with open(core_season_file_path, encoding="utf-8") as file_handle:
             core_seasons = json.load(file_handle)
         self.core_seasons = core_seasons
         self.ecodivisions = geopandas.read_file(ecodiv_shape_file_path)
+        self.name_lookup: Dict[str, str] = None
+        if use_cache:
+            self.redis_key = f'ecodivision_names:{key}'
+            self.cache = create_redis()
+            self.name_lookup = self.cache.get(self.redis_key)
+            if self.name_lookup is None:
+                self.name_lookup = {}
+                self.update_cache = True
+            else:
+                self.update_cache = False
+                self.name_lookup = json.loads(self.name_lookup)
+        else:
+            self.update_cache = False
+
+    def cache_ecodivision_names(self):
+        """ Caches ecodivision names in redis """
+        if self.update_cache:
+            # cache the result for a day
+            self.cache.set(self.redis_key, json.dumps(self.name_lookup), ex=86400)
 
     def get_core_seasons(self):
         """Returns core seasons"""
         return self.core_seasons
 
-    def get_ecodivision_name(self, station_code: str,  latitude: str, longitude: str):
-        """ Returns the ecodivision name for a given lat/long coordinate """
-        # if station's latitude >= 60 (approx.), it's in the Yukon, so it won't be captured
-        # in the shapefile, but it's considered to be part of the SUB-ARCTIC HIGHLANDS ecodivision.
+    def _calculate_ecodivision_name(self, station_code: str, latitude: float, longitude: float) -> str:
         if latitude >= 60:
             return 'SUB-ARCTIC HIGHLANDS'
         station_coord = Point(float(longitude), float(latitude))
@@ -47,3 +63,14 @@ class EcodivisionSeasons:
         logger.error('Ecodivision not found for station code %s at lat %f long %f',
                      station_code, latitude, longitude)
         return "DEFAULT"
+
+    def get_ecodivision_name(self, station_code: str, latitude: float, longitude: float):
+        """ Returns the ecodivision name for a given lat/long coordinate """
+        # if station's latitude >= 60 (approx.), it's in the Yukon, so it won't be captured
+        # in the shapefile, but it's considered to be part of the SUB-ARCTIC HIGHLANDS ecodivision.
+        key = f'{station_code}:{latitude}:{longitude}'
+        value = self.name_lookup.get(key, None)
+        if value is None:
+            value = self._calculate_ecodivision_name(station_code, latitude, longitude)
+            self.name_lookup[key] = value
+        return value

--- a/api/app/data/ecodivision_seasons.py
+++ b/api/app/data/ecodivision_seasons.py
@@ -1,9 +1,9 @@
 """ Defines singleton class that keeps ecodivisions in memory for reuse """
 import os
 import json
+from typing import Dict
 import logging
 import geopandas
-from typing import Dict
 from shapely.geometry import Point
 from app.utils.redis import create_redis
 
@@ -35,6 +35,7 @@ class EcodivisionSeasons:
         self.ecodivisions = geopandas.read_file(ecodiv_shape_file_path)
         self.name_lookup: Dict[str, str] = {}
         self.cache_key = cache_key
+        self.cache = None
         self.update_cache_on_exit = False
 
     def __enter__(self):
@@ -52,9 +53,9 @@ class EcodivisionSeasons:
                 self.name_lookup = json.loads(self.name_lookup)
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_val, exc_tb):
         """ Caches ecodivision names in redis """
-        if self.cache_key and self.update_cache_on_exit:
+        if self.cache and self.cache_key and self.update_cache_on_exit:
             # cache the result for a day
             self.cache.set(self.cache_key, json.dumps(self.name_lookup), ex=86400)
 

--- a/api/app/wildfire_one/schema_parsers.py
+++ b/api/app/wildfire_one/schema_parsers.py
@@ -110,12 +110,12 @@ def construct_zone_code(station: any):
     return zone_code
 
 
-def parse_station(station) -> WeatherStation:
+def parse_station(station, eco_division: EcodivisionSeasons) -> WeatherStation:
     """ Transform from the json object returned by wf1, to our station object.
     """
     # pylint: disable=no-member
-    core_seasons = EcodivisionSeasons.instance().get_core_seasons()
-    ecodiv_name = EcodivisionSeasons.instance().get_ecodivision_name(
+    core_seasons = eco_division.get_core_seasons()
+    ecodiv_name = eco_division.get_ecodivision_name(
         station['stationCode'], station['latitude'], station['longitude'])
     return WeatherStation(
         zone_code=construct_zone_code(station),

--- a/api/app/wildfire_one/wfwx_api.py
+++ b/api/app/wildfire_one/wfwx_api.py
@@ -57,25 +57,24 @@ async def get_auth_header(session: ClientSession) -> dict:
 async def get_stations_by_codes(station_codes: List[int]) -> List[WeatherStation]:
     """ Get a list of stations by code, from WFWX Fireweather API. """
     logger.info('Using WFWX to retrieve stations by code')
-    eco_division = EcodivisionSeasons(','.join([str(code) for code in station_codes]))
-    async with ClientSession() as session:
-        header = await get_auth_header(session)
-        stations = []
-        # 1 week seems a reasonable period to cache stations for.
-        redis_station_cache_expiry: Final = int(config.get('REDIS_STATION_CACHE_EXPIRY', 604800))
-        # Iterate through "raw" station data.
-        iterator = fetch_paged_response_generator(session,
-                                                  header,
-                                                  BuildQueryByStationCode(station_codes), 'stations',
-                                                  use_cache=True,
-                                                  cache_expiry_seconds=redis_station_cache_expiry)
-        async for raw_station in iterator:
-            # If the station is valid, add it to our list of stations.
-            if is_station_valid(raw_station):
-                stations.append(parse_station(raw_station, eco_division))
-        logger.debug('total stations: %d', len(stations))
-        eco_division.cache_ecodivision_names()
-        return stations
+    with EcodivisionSeasons(','.join([str(code) for code in station_codes])) as eco_division:
+        async with ClientSession() as session:
+            header = await get_auth_header(session)
+            stations = []
+            # 1 week seems a reasonable period to cache stations for.
+            redis_station_cache_expiry: Final = int(config.get('REDIS_STATION_CACHE_EXPIRY', 604800))
+            # Iterate through "raw" station data.
+            iterator = fetch_paged_response_generator(session,
+                                                      header,
+                                                      BuildQueryByStationCode(station_codes), 'stations',
+                                                      use_cache=True,
+                                                      cache_expiry_seconds=redis_station_cache_expiry)
+            async for raw_station in iterator:
+                # If the station is valid, add it to our list of stations.
+                if is_station_valid(raw_station):
+                    stations.append(parse_station(raw_station, eco_division))
+            logger.debug('total stations: %d', len(stations))
+            return stations
 
 
 async def get_station_data(session: ClientSession,
@@ -164,15 +163,25 @@ async def get_hourly_readings(
                                               'stations',
                                               True,
                                               redis_station_cache_expiry)
+    raw_stations = []
+    eco_division_key = ''
+    # not ideal - we iterate through the stations twice. 1'st time to get the list of station codes,
+    # so that we can do an eco division lookup in redis.
     async for raw_station in iterator:
-        task = asyncio.create_task(
-            fetch_hourlies(session,
-                           raw_station,
-                           header,
-                           start_timestamp,
-                           end_timestamp,
-                           use_cache))
-        tasks.append(task)
+        raw_stations.append(raw_station)
+        station_code = raw_station.get('stationCode')
+        eco_division_key = eco_division_key.join(f'{station_code},')
+    with EcodivisionSeasons(eco_division_key) as eco_division:
+        for raw_station in raw_stations:
+            task = asyncio.create_task(
+                fetch_hourlies(session,
+                               raw_station,
+                               header,
+                               start_timestamp,
+                               end_timestamp,
+                               use_cache,
+                               eco_division))
+            tasks.append(task)
 
     # Run the tasks concurrently, waiting for them all to complete.
     return await asyncio.gather(*tasks)

--- a/api/app/wildfire_one/wfwx_api.py
+++ b/api/app/wildfire_one/wfwx_api.py
@@ -168,10 +168,11 @@ async def get_hourly_readings(
     eco_division_key = ''
     # not ideal - we iterate through the stations twice. 1'st time to get the list of station codes,
     # so that we can do an eco division lookup in redis.
+    station_codes = set()
     async for raw_station in iterator:
         raw_stations.append(raw_station)
-        station_code = raw_station.get('stationCode')
-        eco_division_key = eco_division_key.join(f'{station_code},')
+        station_codes.add(raw_station.get('stationCode'))
+    eco_division_key = ','.join(str(code) for code in station_codes)
     with EcodivisionSeasons(eco_division_key) as eco_division:
         for raw_station in raw_stations:
             task = asyncio.create_task(

--- a/api/app/wildfire_one/wildfire_fetchers.py
+++ b/api/app/wildfire_one/wildfire_fetchers.py
@@ -6,6 +6,7 @@ from typing import Dict, Generator, Tuple, Final
 import json
 from urllib.parse import urlencode
 from aiohttp.client import ClientSession, BasicAuth
+from app.data.ecodivision_seasons import EcodivisionSeasons
 from app.schemas.observations import WeatherStationHourlyReadings
 from app.schemas.stations import (DetailedWeatherStationProperties,
                                   GeoJsonDetailedWeatherStation,
@@ -209,7 +210,11 @@ async def fetch_hourlies(
     logger.debug('fetched %d hourlies for %s(%s)', len(
         hourlies), raw_station['displayLabel'], raw_station['stationCode'])
 
-    return WeatherStationHourlyReadings(values=hourlies, station=parse_station(raw_station))
+    return WeatherStationHourlyReadings(values=hourlies,
+                                        station=parse_station(
+                                            raw_station,
+                                            EcodivisionSeasons(raw_station.get('stationCode'),
+                                                               use_cache=False)))
 
 
 async def fetch_access_token(session: ClientSession) -> dict:

--- a/api/app/wildfire_one/wildfire_fetchers.py
+++ b/api/app/wildfire_one/wildfire_fetchers.py
@@ -184,7 +184,8 @@ async def fetch_hourlies(
         headers: dict,
         start_timestamp: datetime,
         end_timestamp: datetime,
-        use_cache: bool = False) -> WeatherStationHourlyReadings:
+        use_cache: bool,
+        eco_division: EcodivisionSeasons) -> WeatherStationHourlyReadings:
     """ Fetch hourly weather readings for the specified time range for a give station """
     logger.debug('fetching hourlies for %s(%s)',
                  raw_station['displayLabel'], raw_station['stationCode'])
@@ -212,9 +213,7 @@ async def fetch_hourlies(
 
     return WeatherStationHourlyReadings(values=hourlies,
                                         station=parse_station(
-                                            raw_station,
-                                            EcodivisionSeasons(raw_station.get('stationCode'),
-                                                               use_cache=False)))
+                                            raw_station, eco_division))
 
 
 async def fetch_access_token(session: ClientSession) -> dict:


### PR DESCRIPTION
This has been bothering me - it takes 2 seconds to generate the fire centers for HFI. One idea is caching the eco divisions in redis - arguably easier to just cache the fire centre - but this way at least we share the cache with everyone?

- Changed ecodivision class from singleton to context manager (where the context would be a list of station codes).
- Added redis backing to the ecodivision class, caching data for a set of stations.

# Test Links:
[Percentile Calculator](https://wps-pr-1721.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1721.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1721.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1721.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1721.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1721.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1721.apps.silver.devops.gov.bc.ca/hfi-calculator)
