### PR TITLE
Load CFFDRS on startup

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -15,7 +15,7 @@ from app import health
 from app import hourlies
 from app.frontend import frontend
 from app.routers import fba, forecasts, fwi_calc, weather_models, c_haines, stations, hfi_calc, fba_calc
-# from app.utils.cffdrs import CFFDRS
+from app.utils.cffdrs import CFFDRS
 
 
 configure_logging()
@@ -58,6 +58,21 @@ API_INFO = '''
     has been specifically advised of the possibility of such damages.'''
 
 
+async def startup_event():
+    """ Startup event handler for the app.
+    https://www.starlette.io/events/
+    """
+    # Instantiate the CFFDRS singleton. Binding to R can take quite some time, doing this when our thread
+    # starts up will save us some time on requests. On my local machine, it takes about 3 seconds to start
+    # up R.
+    # The downside to this is that we're increasing the memory footprint of the app.
+    cffdrs_start = perf_counter()
+    # TODO: Fix in next PR.
+    CFFDRS.instance()  # pylint: disable=no-member
+    cffdrs_end = perf_counter()
+    logger.info('saved %f seconds by starting CFFDRS now', cffdrs_end - cffdrs_start)
+
+
 # This is the api app.
 api = FastAPI(
     title="Predictive Services API",
@@ -67,7 +82,7 @@ api = FastAPI(
 
 # This is our base starlette app - it doesn't do much except glue together
 # the api and the front end.
-app = Starlette()
+app = Starlette(on_startup=[startup_event])
 
 
 # The order here is important:
@@ -96,22 +111,6 @@ api.include_router(hfi_calc.router)
 api.include_router(fba_calc.router)
 api.include_router(fba.router)
 api.include_router(fwi_calc.router)
-
-
-@api.on_event("startup")
-async def startup_event():
-    """ Startup event handler for API
-    https://fastapi.tiangolo.com/advanced/events/#startup-event
-    """
-    # Instantiate the CFFDRS singleton. Binding to R can take quite some time, doing this when our thread
-    # starts up will save us some time on requests. On my local machine, it takes about 3 seconds to start
-    # up R.
-    # The downside to this is that we're increasing the memory footprint of the app.
-    cffdrs_start = perf_counter()
-    # TODO: Fix in next PR.
-    # CFFDRS.instance()  # pylint: disable=no-member
-    cffdrs_end = perf_counter()
-    logger.info('saved %f seconds by starting CFFDRS now', cffdrs_end - cffdrs_start)
 
 
 @api.get('/ready')

--- a/openshift/templates/deploy.dc.yaml
+++ b/openshift/templates/deploy.dc.yaml
@@ -104,6 +104,11 @@ objects:
                   value: "8080"
                 - name: WORKERS_PER_CORE # The number of worker per code (used by fastapi docker image)
                   value: "0.25"
+                - name: "TIMEOUT" # https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker#timeout
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ${NAME}-global
+                      key: env.gunicorn.timeout
                 - name: USE_WFWX
                   value: ${USE_WFWX}
                 - name: WFWX_MAX_PAGE_SIZE

--- a/openshift/templates/global.config.yaml
+++ b/openshift/templates/global.config.yaml
@@ -111,7 +111,7 @@ parameters:
   - name: GUNICORN_TIMEOUT
     description: Workers silent for more than this many seconds are killed and restarted. (https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker#timeout)
     required: True
-    value: "120"
+    value: "180"
 objects:
   - kind: ConfigMap
     apiVersion: v1

--- a/openshift/templates/global.config.yaml
+++ b/openshift/templates/global.config.yaml
@@ -108,6 +108,10 @@ parameters:
     description: How long to cache env canada downloads for.
     required: True
     value: "21600"
+  - name: GUNICORN_TIMEOUT
+    description: Workers silent for more than this many seconds are killed and restarted. (https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker#timeout)
+    required: True
+    value: "120"
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -138,6 +142,7 @@ objects:
       env.redis-hourlies-by-station-code-cache-expiry: ${REDIS_HOURLIES_BY_STATION_CODE_CACHE_EXPIRY}
       env.redis-cache-env-canada: ${REDIS_CACHE_ENV_CANADA}
       env.redis-env-canada-cache-expiry: ${REDIS_ENV_CANADA_CACHE_EXPIRY}
+      env.gunicorn.timeout: ${GUNICORN_TIMEOUT}
 
   - kind: Secret
     apiVersion: v1


### PR DESCRIPTION
- Added config for guvicorn timeout
- Added CFFDRS into startup
# Test Links:
[Percentile Calculator](https://wps-pr-1757.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1757.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1757.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1757.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1757.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1757.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1757.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1757.apps.silver.devops.gov.bc.ca/fwi-calculator)
