### PR TITLE
Prep period fix + unit test with data for all days

### DIFF
--- a/api/app/routers/hfi_calc.py
+++ b/api/app/routers/hfi_calc.py
@@ -177,10 +177,11 @@ async def get_hfi_results(request: HFIResultRequest,
             async for station_daily in dailies_generator:
                 dailies.append(station_daily)
 
-            prep_delta = valid_end_date - valid_start_date  # num prep days is inclusive
+            prep_delta = valid_end_date - valid_start_date
+            prep_days = prep_delta.days + 1  # num prep days is inclusive
 
             results = calculate_hfi_results(request.planning_area_fire_starts,
-                                            dailies, prep_delta.days,
+                                            dailies, prep_days,
                                             request.selected_station_code_ids,
                                             area_station_map,
                                             valid_start_date)

--- a/api/app/tests/fixtures/wf1/lookup.json
+++ b/api/app/tests/fixtures/wf1/lookup.json
@@ -92,6 +92,9 @@
          "{'size': '1000', 'page': 0, 'startingTimestamp': 1590091200000, 'endingTimestamp': 1590523200000, 'stationIds': ['bfe0a6e2-e27e-0210-e053-259e228e58c7']}": {
             "None": "wfwx/v1/dailies/search__startingTimestamp_1590091200000_endingTimestamp_1590523200000_station_230_page_0_size_1000.json"
          },
+         "{'size': '1000', 'page': 0, 'startingTimestamp': 1590091200000, 'endingTimestamp': 1590264000000, 'stationIds': ['bfe0a6e2-e27e-0210-e053-259e228e58c7', 'bfe0a6e2-e286-0210-e053-259e228e58c7']}": {
+            "None": "wfwx/v1/dailies/search__startingTimestamp_1590091200000_endingTimestamp_1590264000000_station_230_239_page_0_size_1000.json"
+         },
          "{'size': '1000', 'page': 0, 'startingTimestamp': 1590091200000, 'endingTimestamp': 1590523200000, 'stationIds': ['bfe0a6e2-e27e-0210-e053-259e228e58c7', 'bfe0a6e2-e286-0210-e053-259e228e58c7']}": {
             "None": "wfwx/v1/dailies/search__startingTimestamp_1590091200000_endingTimestamp_1590523200000_station_230_239_page_0_size_1000.json"
          },

--- a/api/app/tests/fixtures/wf1/wfwx/v1/dailies/search__startingTimestamp_1590091200000_endingTimestamp_1590264000000_station_230_239_page_0_size_1000.json
+++ b/api/app/tests/fixtures/wf1/wfwx/v1/dailies/search__startingTimestamp_1590091200000_endingTimestamp_1590264000000_station_230_239_page_0_size_1000.json
@@ -1,0 +1,341 @@
+{
+    "_embedded": {
+        "dailies": [
+            {
+                "id": "dae7f61d-fa45-4f3f-b88e-25d8bb996fc0",
+                "createdBy": "SYBRAND",
+                "lastEntityUpdateTimestamp": 1590192000000,
+                "updateDate": "2020-05-22T17:00:00.000+0000",
+                "lastModifiedBy": "CVANEATO",
+                "archive": false,
+                "startIndices": false,
+                "station": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "stationId": "bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "weatherTimestamp": 1590091200000,
+                "temperature": 23.0,
+                "temperatureMin": null,
+                "temperatureMax": null,
+                "relativeHumidity": 36.0,
+                "relativeHumidityMin": null,
+                "relativeHumidityMax": null,
+                "windSpeed": 7.0,
+                "precipitation": 1.8,
+                "dangerForest": 3,
+                "dangerGrassland": 1,
+                "dangerScrub": 5,
+                "recordType": {
+                    "id": "FORECAST",
+                    "displayLabel": "Forecast",
+                    "displayOrder": 2,
+                    "createdBy": "DATA_LOAD",
+                    "lastModifiedBy": "DATA_LOAD"
+                },
+                "windDirection": 300.0,
+                "fineFuelMoistureCode": 84.294,
+                "duffMoistureCode": 79.937,
+                "droughtCode": 463.498,
+                "initialSpreadIndex": 2.724,
+                "buildUpIndex": 111.71,
+                "fireWeatherIndex": 12.966,
+                "dailySeverityRating": null,
+                "grasslandCuring": null,
+                "observationValidInd": true,
+                "observationValidComment": null,
+                "missingHourlyData": null,
+                "previousState": null,
+                "businessKey": "1627329600000-bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "_links": {
+                    "self": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "daily": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "station": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7"
+                    }
+                }
+            },
+            {
+                "id": "dae7f61d-fa45-4f3f-b88e-25d8bb996fc0",
+                "createdBy": "SYBRAND",
+                "lastEntityUpdateTimestamp": 1590192000000,
+                "updateDate": "2020-05-22T17:00:00.000+0000",
+                "lastModifiedBy": "CVANEATO",
+                "archive": false,
+                "startIndices": false,
+                "station": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "stationId": "bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "weatherTimestamp": 1590177600000,
+                "temperature": 25.0,
+                "temperatureMin": null,
+                "temperatureMax": null,
+                "relativeHumidity": 38.0,
+                "relativeHumidityMin": null,
+                "relativeHumidityMax": null,
+                "windSpeed": 9.0,
+                "precipitation": 2.8,
+                "dangerForest": 5,
+                "dangerGrassland": 3,
+                "dangerScrub": 3,
+                "recordType": {
+                    "id": "FORECAST",
+                    "displayLabel": "Forecast",
+                    "displayOrder": 2,
+                    "createdBy": "DATA_LOAD",
+                    "lastModifiedBy": "DATA_LOAD"
+                },
+                "windDirection": 310.0,
+                "fineFuelMoistureCode": 91.294,
+                "duffMoistureCode": 78.937,
+                "droughtCode": 400.498,
+                "initialSpreadIndex": 1.724,
+                "buildUpIndex": 110.71,
+                "fireWeatherIndex": 11.966,
+                "dailySeverityRating": null,
+                "grasslandCuring": null,
+                "observationValidInd": true,
+                "observationValidComment": null,
+                "missingHourlyData": null,
+                "previousState": null,
+                "businessKey": "1627329600000-bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "_links": {
+                    "self": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "daily": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "station": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7"
+                    }
+                }
+            },
+            {
+                "id": "dae7f61d-fa45-4f3f-b88e-25d8bb996fc0",
+                "createdBy": "SYBRAND",
+                "lastEntityUpdateTimestamp": 1590192000000,
+                "updateDate": "2020-05-22T17:00:00.000+0000",
+                "lastModifiedBy": "CVANEATO",
+                "archive": false,
+                "startIndices": false,
+                "station": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "stationId": "bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "weatherTimestamp": 1590264000000,
+                "temperature": 21.0,
+                "temperatureMin": null,
+                "temperatureMax": null,
+                "relativeHumidity": 34.0,
+                "relativeHumidityMin": null,
+                "relativeHumidityMax": null,
+                "windSpeed": 5.0,
+                "precipitation": 0.8,
+                "dangerForest": 2,
+                "dangerGrassland": 0,
+                "dangerScrub": 4,
+                "recordType": {
+                    "id": "FORECAST",
+                    "displayLabel": "Forecast",
+                    "displayOrder": 2,
+                    "createdBy": "DATA_LOAD",
+                    "lastModifiedBy": "DATA_LOAD"
+                },
+                "windDirection": 200.0,
+                "fineFuelMoistureCode": 54.294,
+                "duffMoistureCode": 59.937,
+                "droughtCode": 363.498,
+                "initialSpreadIndex": 1.724,
+                "buildUpIndex": 11.71,
+                "fireWeatherIndex": 2.966,
+                "dailySeverityRating": null,
+                "grasslandCuring": null,
+                "observationValidInd": true,
+                "observationValidComment": null,
+                "missingHourlyData": null,
+                "previousState": null,
+                "businessKey": "1627329600000-bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "_links": {
+                    "self": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "daily": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "station": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7"
+                    }
+                }
+            },
+            {
+                "id": "aae7f61d-fa45-4f3f-b88e-25d8bb996fc0",
+                "createdBy": "SYBRAND",
+                "lastEntityUpdateTimestamp": 1590192000000,
+                "updateDate": "2020-05-22T17:00:00.000+0000",
+                "lastModifiedBy": "CVANEATO",
+                "archive": false,
+                "startIndices": false,
+                "station": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "stationId": "bfe0a6e2-e286-0210-e053-259e228e58c7",
+                "weatherTimestamp": 1590091200000,
+                "temperature": 23.0,
+                "temperatureMin": null,
+                "temperatureMax": null,
+                "relativeHumidity": 36.0,
+                "relativeHumidityMin": null,
+                "relativeHumidityMax": null,
+                "windSpeed": 7.0,
+                "precipitation": 1.8,
+                "dangerForest": 3,
+                "dangerGrassland": 1,
+                "dangerScrub": 5,
+                "recordType": {
+                    "id": "FORECAST",
+                    "displayLabel": "Forecast",
+                    "displayOrder": 2,
+                    "createdBy": "DATA_LOAD",
+                    "lastModifiedBy": "DATA_LOAD"
+                },
+                "windDirection": 300.0,
+                "fineFuelMoistureCode": 84.294,
+                "duffMoistureCode": 79.937,
+                "droughtCode": 463.498,
+                "initialSpreadIndex": 2.724,
+                "buildUpIndex": 111.71,
+                "fireWeatherIndex": 12.966,
+                "dailySeverityRating": null,
+                "grasslandCuring": null,
+                "observationValidInd": true,
+                "observationValidComment": null,
+                "missingHourlyData": null,
+                "previousState": null,
+                "businessKey": "1627329600000-bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "_links": {
+                    "self": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "daily": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "station": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7"
+                    }
+                }
+            },
+            {
+                "id": "aae7f61d-fa45-4f3f-b88e-25d8bb996fc0",
+                "createdBy": "SYBRAND",
+                "lastEntityUpdateTimestamp": 1590192000000,
+                "updateDate": "2020-05-22T17:00:00.000+0000",
+                "lastModifiedBy": "CVANEATO",
+                "archive": false,
+                "startIndices": false,
+                "station": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "stationId": "bfe0a6e2-e286-0210-e053-259e228e58c7",
+                "weatherTimestamp": 1590177600000,
+                "temperature": 3.0,
+                "temperatureMin": null,
+                "temperatureMax": null,
+                "relativeHumidity": 6.0,
+                "relativeHumidityMin": null,
+                "relativeHumidityMax": null,
+                "windSpeed": 1.0,
+                "precipitation": 0.8,
+                "dangerForest": 2,
+                "dangerGrassland": 2,
+                "dangerScrub": 2,
+                "recordType": {
+                    "id": "FORECAST",
+                    "displayLabel": "Forecast",
+                    "displayOrder": 2,
+                    "createdBy": "DATA_LOAD",
+                    "lastModifiedBy": "DATA_LOAD"
+                },
+                "windDirection": 320.0,
+                "fineFuelMoistureCode": 94.294,
+                "duffMoistureCode": 89.937,
+                "droughtCode": 473.498,
+                "initialSpreadIndex": 3.724,
+                "buildUpIndex": 121.71,
+                "fireWeatherIndex": 13.866,
+                "dailySeverityRating": null,
+                "grasslandCuring": null,
+                "observationValidInd": true,
+                "observationValidComment": null,
+                "missingHourlyData": null,
+                "previousState": null,
+                "businessKey": "1627329600000-bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "_links": {
+                    "self": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "daily": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "station": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7"
+                    }
+                }
+            },
+            {
+                "id": "aae7f61d-fa45-4f3f-b88e-25d8bb996fc0",
+                "createdBy": "SYBRAND",
+                "lastEntityUpdateTimestamp": 1590192000000,
+                "updateDate": "2020-05-22T17:00:00.000+0000",
+                "lastModifiedBy": "CVANEATO",
+                "archive": false,
+                "startIndices": false,
+                "station": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "stationId": "bfe0a6e2-e286-0210-e053-259e228e58c7",
+                "weatherTimestamp": 1590264000000,
+                "temperature": 13.0,
+                "temperatureMin": null,
+                "temperatureMax": null,
+                "relativeHumidity": 13.0,
+                "relativeHumidityMin": null,
+                "relativeHumidityMax": null,
+                "windSpeed": 2.3,
+                "precipitation": 0.2,
+                "dangerForest": 2,
+                "dangerGrassland": 2,
+                "dangerScrub": 3,
+                "recordType": {
+                    "id": "FORECAST",
+                    "displayLabel": "Forecast",
+                    "displayOrder": 2,
+                    "createdBy": "DATA_LOAD",
+                    "lastModifiedBy": "DATA_LOAD"
+                },
+                "windDirection": 120.0,
+                "fineFuelMoistureCode": 14.294,
+                "duffMoistureCode": 39.937,
+                "droughtCode": 233.498,
+                "initialSpreadIndex": 1.123,
+                "buildUpIndex": 101.71,
+                "fireWeatherIndex": 10.966,
+                "dailySeverityRating": null,
+                "grasslandCuring": null,
+                "observationValidInd": true,
+                "observationValidComment": null,
+                "missingHourlyData": null,
+                "previousState": null,
+                "businessKey": "1627329600000-bfe0a6e2-e27e-0210-e053-259e228e58c7",
+                "_links": {
+                    "self": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "daily": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/dae7f61d-fa45-4f3f-b88e-25d8bb996fc0"
+                    },
+                    "station": {
+                        "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/stations/bfe0a6e2-e27e-0210-e053-259e228e58c7"
+                    }
+                }
+            }
+        ]
+    },
+    "_links": {
+        "self": {
+            "href": "https://bcwsapi.nrs.gov.bc.ca/wfwx-fireweather-api/v1/dailies/search/findDailiesByStationIdIsInAndWeatherTimestampBetweenOrderByStationIdAscWeatherTimestampAsc?startingTimestamp=1627329600000&endingTimestamp=1627329600000&stationIds=bfe0a6e2-e27e-0210-e053-259e228e58c7&page=0&size=10"
+        }
+    }
+}

--- a/api/app/tests/hfi/test_hfi_endpoint_request.feature
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.feature
@@ -1,0 +1,16 @@
+Feature: /hfi/
+
+    # NOTE: When writing requests, we already have stubs in place for the following station combinations:
+    # (230,),
+    # NOTE: These combinations exist, but not for the mock dates:
+    # (146,230), (322,346,335)
+
+    Scenario: HFI - request
+        # In this scenario, we expect a request to be loaded from the database - but there isn't one.
+        Given I received a <request_json>
+        Then the response status code is <status_code>
+        And the response is <response_json>
+
+        Examples:
+            | request_json                   | status_code | response_json                   |
+            | test_hfi_endpoint_request.json | 200         | test_hfi_endpoint_response.json |

--- a/api/app/tests/hfi/test_hfi_endpoint_request.feature
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.feature
@@ -1,10 +1,5 @@
 Feature: /hfi/
 
-    # NOTE: When writing requests, we already have stubs in place for the following station combinations:
-    # (230,),
-    # NOTE: These combinations exist, but not for the mock dates:
-    # (146,230), (322,346,335)
-
     Scenario: HFI - request
         # In this scenario, we expect a request to be loaded from the database - but there isn't one.
         Given I received a <request_json>
@@ -13,4 +8,7 @@ Feature: /hfi/
 
         Examples:
             | request_json                   | status_code | response_json                   |
+            # Test perfect scenario, we have 2 stations, they're both selected, and they have data for all days.
             | test_hfi_endpoint_request.json | 200         | test_hfi_endpoint_response.json |
+# Test scenario where we have 1 station selected, one station deselected, and data for all days.
+# Test less than ideal scenario, we have 2 stations, they're both selected, one of them is missing data for some days.

--- a/api/app/tests/hfi/test_hfi_endpoint_request.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.json
@@ -1,6 +1,6 @@
 {
   "start_date": "2020-05-21",
-  "end_date": "2020-05-26",
+  "end_date": "2020-05-23",
   "planning_area_station_info": {
     "1": [
       {
@@ -8,10 +8,18 @@
         "selected": true,
         "fuel_type_id": 1
       }
+    ],
+    "2": [
+      {
+        "station_code": 239,
+        "selected": true,
+        "fuel_type_id": 2
+      }
     ]
   },
   "selected_station_code_ids": [
-    230
+    230,
+    239
   ],
   "selected_fire_center_id": 1,
   "planning_area_fire_starts": {},

--- a/api/app/tests/hfi/test_hfi_endpoint_request.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.json
@@ -1,0 +1,19 @@
+{
+  "start_date": "2020-05-21",
+  "end_date": "2020-05-26",
+  "planning_area_station_info": {
+    "1": [
+      {
+        "station_code": 230,
+        "selected": true,
+        "fuel_type_id": 1
+      }
+    ]
+  },
+  "selected_station_code_ids": [
+    230
+  ],
+  "selected_fire_center_id": 1,
+  "planning_area_fire_starts": {},
+  "persist_request": true
+}

--- a/api/app/tests/hfi/test_hfi_endpoint_request.py
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.py
@@ -1,4 +1,3 @@
-
 from typing import Tuple
 from distutils.util import strtobool
 import pytest

--- a/api/app/tests/hfi/test_hfi_endpoint_request.py
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.py
@@ -1,0 +1,42 @@
+
+from typing import Tuple
+from distutils.util import strtobool
+import pytest
+from pytest_bdd import scenario, given
+from fastapi.testclient import TestClient
+from aiohttp import ClientSession
+from pytest_mock import MockFixture
+import app.main
+from app.tests.common import default_mock_client_get
+from app.tests import load_json_file, load_json_file_with_name
+from app.tests.hfi import mock_station_crud
+
+
+@pytest.mark.usefixtures('mock_jwt_decode')
+@scenario('test_hfi_endpoint_request.feature', 'HFI - request',
+          example_converters=dict(request_json=load_json_file_with_name(__file__),
+                                  status_code=int,
+                                  response_json=load_json_file(__file__),
+                                  request_saved=strtobool))
+def test_fire_behaviour_calculator_scenario_no_request_stored():
+    """ BDD Scenario. """
+    pass
+
+
+@given("I received a <request_json>", target_fixture='result')
+def given_request_none_stored(monkeypatch: pytest.MonkeyPatch, mocker: MockFixture, request_json: Tuple[dict, str]):
+    """ Handle request
+    """
+    # mock anything that uses aiohttp.ClientSession::get
+    monkeypatch.setattr(ClientSession, 'get', default_mock_client_get)
+
+    # mock out database calls:
+    mock_station_crud(monkeypatch)
+
+    client = TestClient(app.main.app)
+    headers = {'Content-Type': 'application/json',
+               'Authorization': 'Bearer token'}
+    return {
+        'response': client.post('/api/hfi-calc/', headers=headers, json=request_json[0]),
+        'filename': request_json[1]
+    }

--- a/api/app/tests/hfi/test_hfi_endpoint_request_not_stored.feature
+++ b/api/app/tests/hfi/test_hfi_endpoint_request_not_stored.feature
@@ -1,10 +1,5 @@
 Feature: /hfi/
 
-    # NOTE: When writing requests, we already have stubs in place for the following station combinations:
-    # (230,),
-    # NOTE: These combinations exist, but not for the mock dates:
-    # (146,230), (322,346,335)
-
     Scenario: HFI - load request, no request stored
         # In this scenario, we expect a request to be loaded from the database - but there isn't one.
         Given I received a <request_json>, but don't have one stored

--- a/api/app/tests/hfi/test_hfi_endpoint_request_stored.feature
+++ b/api/app/tests/hfi/test_hfi_endpoint_request_stored.feature
@@ -1,10 +1,5 @@
 Feature: /hfi/
 
-    # NOTE: When writing requests, we already have stubs in place for the following station combinations:
-    # (230,),
-    # NOTE: These combinations exist, but not for the mock dates:
-    # (146,230), (322,346,335)
-
     Scenario: HFI - load request, request stored
         # In this scenario, we expect a request to be loaded from the database - and it's possible.
         Given I received a <request_json>, and have one stored <stored_request_json>

--- a/api/app/tests/hfi/test_hfi_endpoint_response.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_response.json
@@ -25,7 +25,7 @@
   "planning_area_hfi_results": [
     {
       "planning_area_id": 1,
-      "all_dailies_valid": true,
+      "all_dailies_valid": false,
       "highest_daily_intensity_group": 1.0,
       "mean_prep_level": 1.0,
       "daily_results": [
@@ -188,12 +188,103 @@
           },
           "mean_intensity_group": 1.0,
           "prep_level": 1.0
+        },
+        {
+          "date": "2020-05-23",
+          "dailies": [
+            {
+              "daily": {
+                "code": 230,
+                "status": "FORECAST",
+                "temperature": 21.0,
+                "relative_humidity": 34.0,
+                "wind_speed": 5.0,
+                "wind_direction": 200.0,
+                "grass_cure_percentage": null,
+                "precipitation": 0.8,
+                "ffmc": 54.294,
+                "dmc": 59.937,
+                "dc": 363.498,
+                "isi": 1.724,
+                "bui": 11.71,
+                "fwi": 2.966,
+                "danger_class": null,
+                "observation_valid": true,
+                "observation_valid_comment": null,
+                "rate_of_spread": 0.016251491463702528,
+                "hfi": 0.48964862244025137,
+                "intensity_group": 1,
+                "sixty_minute_fire_size": 4.874001890658782e-05,
+                "fire_type": "SUR",
+                "error": true,
+                "error_message": null,
+                "date": "2020-05-23T20:00:00+00:00",
+                "last_updated": "2020-05-23T00:00:00+00:00"
+              },
+              "valid": true
+            },
+            {
+              "daily": {
+                "code": 239,
+                "status": "FORECAST",
+                "temperature": 13.0,
+                "relative_humidity": 13.0,
+                "wind_speed": 2.3,
+                "wind_direction": 120.0,
+                "grass_cure_percentage": null,
+                "precipitation": 0.2,
+                "ffmc": 14.294,
+                "dmc": 39.937,
+                "dc": 233.498,
+                "isi": 1.123,
+                "bui": 101.71,
+                "fwi": 10.966,
+                "danger_class": null,
+                "observation_valid": true,
+                "observation_valid_comment": null,
+                "rate_of_spread": null,
+                "hfi": null,
+                "intensity_group": null,
+                "sixty_minute_fire_size": null,
+                "fire_type": null,
+                "error": true,
+                "error_message": null,
+                "date": "2020-05-23T20:00:00+00:00",
+                "last_updated": "2020-05-23T00:00:00+00:00"
+              },
+              "valid": false
+            }
+          ],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": 1.0,
+          "prep_level": 1.0
         }
       ]
     }
   ],
   "planning_area_fire_starts": {
     "1": [
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
       {
         "label": "0-1",
         "value": 1,

--- a/api/app/tests/hfi/test_hfi_endpoint_response.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_response.json
@@ -1,0 +1,204 @@
+{
+  "start_date": "2020-05-21",
+  "end_date": "2020-05-26",
+  "selected_station_code_ids": [
+    230
+  ],
+  "planning_area_station_info": {
+    "1": [
+      {
+        "station_code": 230,
+        "selected": true,
+        "fuel_type_id": 1
+      }
+    ]
+  },
+  "selected_fire_center_id": 1,
+  "planning_area_hfi_results": [
+    {
+      "planning_area_id": 1,
+      "all_dailies_valid": true,
+      "highest_daily_intensity_group": 1.0,
+      "mean_prep_level": null,
+      "daily_results": [
+        {
+          "date": "2020-05-21",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
+        },
+        {
+          "date": "2020-05-22",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
+        },
+        {
+          "date": "2020-05-23",
+          "dailies": [
+            {
+              "daily": {
+                "code": 230,
+                "status": "FORECAST",
+                "temperature": 23.0,
+                "relative_humidity": 36.0,
+                "wind_speed": 7.0,
+                "wind_direction": 300.0,
+                "grass_cure_percentage": null,
+                "precipitation": 1.8,
+                "ffmc": 84.294,
+                "dmc": 79.937,
+                "dc": 463.498,
+                "isi": 2.724,
+                "bui": 111.71,
+                "fwi": 12.966,
+                "danger_class": null,
+                "observation_valid": true,
+                "observation_valid_comment": null,
+                "rate_of_spread": 0.18030340382396534,
+                "hfi": 182.97053672131358,
+                "intensity_group": 1,
+                "sixty_minute_fire_size": 0.006935706342019749,
+                "fire_type": "SUR",
+                "error": true,
+                "error_message": null,
+                "date": "2020-05-23T20:00:00+00:00",
+                "last_updated": "2020-05-23T00:00:00+00:00"
+              },
+              "valid": true
+            }
+          ],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": 1.0,
+          "prep_level": 1.0
+        },
+        {
+          "date": "2020-05-24",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
+        },
+        {
+          "date": "2020-05-25",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
+        }
+      ]
+    }
+  ],
+  "planning_area_fire_starts": {
+    "1": [
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      }
+    ]
+  },
+  "request_persist_success": true
+}

--- a/api/app/tests/hfi/test_hfi_endpoint_response.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_response.json
@@ -1,8 +1,9 @@
 {
   "start_date": "2020-05-21",
-  "end_date": "2020-05-26",
+  "end_date": "2020-05-23",
   "selected_station_code_ids": [
-    230
+    230,
+    239
   ],
   "planning_area_station_info": {
     "1": [
@@ -10,6 +11,13 @@
         "station_code": 230,
         "selected": true,
         "fuel_type_id": 1
+      }
+    ],
+    "2": [
+      {
+        "station_code": 239,
+        "selected": true,
+        "fuel_type_id": 2
       }
     ]
   },
@@ -19,44 +27,10 @@
       "planning_area_id": 1,
       "all_dailies_valid": true,
       "highest_daily_intensity_group": 1.0,
-      "mean_prep_level": null,
+      "mean_prep_level": 1.0,
       "daily_results": [
         {
           "date": "2020-05-21",
-          "dailies": [],
-          "fire_starts": {
-            "label": "0-1",
-            "value": 1,
-            "lookup_table": {
-              "1": 1,
-              "2": 1,
-              "3": 2,
-              "4": 3,
-              "5": 4
-            }
-          },
-          "mean_intensity_group": null,
-          "prep_level": null
-        },
-        {
-          "date": "2020-05-22",
-          "dailies": [],
-          "fire_starts": {
-            "label": "0-1",
-            "value": 1,
-            "lookup_table": {
-              "1": 1,
-              "2": 1,
-              "3": 2,
-              "4": 3,
-              "5": 4
-            }
-          },
-          "mean_intensity_group": null,
-          "prep_level": null
-        },
-        {
-          "date": "2020-05-23",
           "dailies": [
             {
               "daily": {
@@ -84,10 +58,41 @@
                 "fire_type": "SUR",
                 "error": true,
                 "error_message": null,
-                "date": "2020-05-23T20:00:00+00:00",
+                "date": "2020-05-21T20:00:00+00:00",
                 "last_updated": "2020-05-23T00:00:00+00:00"
               },
               "valid": true
+            },
+            {
+              "daily": {
+                "code": 239,
+                "status": "FORECAST",
+                "temperature": 23.0,
+                "relative_humidity": 36.0,
+                "wind_speed": 7.0,
+                "wind_direction": 300.0,
+                "grass_cure_percentage": null,
+                "precipitation": 1.8,
+                "ffmc": 84.294,
+                "dmc": 79.937,
+                "dc": 463.498,
+                "isi": 2.724,
+                "bui": 111.71,
+                "fwi": 12.966,
+                "danger_class": null,
+                "observation_valid": true,
+                "observation_valid_comment": null,
+                "rate_of_spread": null,
+                "hfi": null,
+                "intensity_group": null,
+                "sixty_minute_fire_size": null,
+                "fire_type": null,
+                "error": true,
+                "error_message": null,
+                "date": "2020-05-21T20:00:00+00:00",
+                "last_updated": "2020-05-23T00:00:00+00:00"
+              },
+              "valid": false
             }
           ],
           "fire_starts": {
@@ -105,8 +110,71 @@
           "prep_level": 1.0
         },
         {
-          "date": "2020-05-24",
-          "dailies": [],
+          "date": "2020-05-22",
+          "dailies": [
+            {
+              "daily": {
+                "code": 230,
+                "status": "FORECAST",
+                "temperature": 25.0,
+                "relative_humidity": 38.0,
+                "wind_speed": 9.0,
+                "wind_direction": 310.0,
+                "grass_cure_percentage": null,
+                "precipitation": 2.8,
+                "ffmc": 91.294,
+                "dmc": 78.937,
+                "dc": 400.498,
+                "isi": 1.724,
+                "bui": 110.71,
+                "fwi": 11.966,
+                "danger_class": null,
+                "observation_valid": true,
+                "observation_valid_comment": null,
+                "rate_of_spread": 0.04874581788128311,
+                "hfi": 49.118357580890226,
+                "intensity_group": 1,
+                "sixty_minute_fire_size": 0.01834085021894554,
+                "fire_type": "SUR",
+                "error": true,
+                "error_message": null,
+                "date": "2020-05-22T20:00:00+00:00",
+                "last_updated": "2020-05-23T00:00:00+00:00"
+              },
+              "valid": true
+            },
+            {
+              "daily": {
+                "code": 239,
+                "status": "FORECAST",
+                "temperature": 3.0,
+                "relative_humidity": 6.0,
+                "wind_speed": 1.0,
+                "wind_direction": 320.0,
+                "grass_cure_percentage": null,
+                "precipitation": 0.8,
+                "ffmc": 94.294,
+                "dmc": 89.937,
+                "dc": 473.498,
+                "isi": 3.724,
+                "bui": 121.71,
+                "fwi": 13.866,
+                "danger_class": null,
+                "observation_valid": true,
+                "observation_valid_comment": null,
+                "rate_of_spread": null,
+                "hfi": null,
+                "intensity_group": null,
+                "sixty_minute_fire_size": null,
+                "fire_type": null,
+                "error": true,
+                "error_message": null,
+                "date": "2020-05-22T20:00:00+00:00",
+                "last_updated": "2020-05-23T00:00:00+00:00"
+              },
+              "valid": false
+            }
+          ],
           "fire_starts": {
             "label": "0-1",
             "value": 1,
@@ -118,64 +186,14 @@
               "5": 4
             }
           },
-          "mean_intensity_group": null,
-          "prep_level": null
-        },
-        {
-          "date": "2020-05-25",
-          "dailies": [],
-          "fire_starts": {
-            "label": "0-1",
-            "value": 1,
-            "lookup_table": {
-              "1": 1,
-              "2": 1,
-              "3": 2,
-              "4": 3,
-              "5": 4
-            }
-          },
-          "mean_intensity_group": null,
-          "prep_level": null
+          "mean_intensity_group": 1.0,
+          "prep_level": 1.0
         }
       ]
     }
   ],
   "planning_area_fire_starts": {
     "1": [
-      {
-        "label": "0-1",
-        "value": 1,
-        "lookup_table": {
-          "1": 1,
-          "2": 1,
-          "3": 2,
-          "4": 3,
-          "5": 4
-        }
-      },
-      {
-        "label": "0-1",
-        "value": 1,
-        "lookup_table": {
-          "1": 1,
-          "2": 1,
-          "3": 2,
-          "4": 3,
-          "5": 4
-        }
-      },
-      {
-        "label": "0-1",
-        "value": 1,
-        "lookup_table": {
-          "1": 1,
-          "2": 1,
-          "3": 2,
-          "4": 3,
-          "5": 4
-        }
-      },
       {
         "label": "0-1",
         "value": 1,

--- a/api/app/tests/hfi/test_hfi_endpoint_response_loaded.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_response_loaded.json
@@ -137,12 +137,40 @@
           },
           "mean_intensity_group": null,
           "prep_level": null
+        },
+        {
+          "date": "2020-05-26",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
         }
       ]
     }
   ],
   "planning_area_fire_starts": {
     "1": [
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
       {
         "label": "0-1",
         "value": 1,

--- a/api/app/tests/hfi/test_hfi_endpoint_response_not_loaded.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_response_not_loaded.json
@@ -137,12 +137,40 @@
           },
           "mean_intensity_group": null,
           "prep_level": null
+        },
+        {
+          "date": "2020-05-26",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
         }
       ]
     }
   ],
   "planning_area_fire_starts": {
     "1": [
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
       {
         "label": "0-1",
         "value": 1,

--- a/api/app/tests/hfi/test_hfi_endpoint_response_save_invalid.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_response_save_invalid.json
@@ -137,12 +137,40 @@
           },
           "mean_intensity_group": null,
           "prep_level": null
+        },
+        {
+          "date": "2020-05-26",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
         }
       ]
     }
   ],
   "planning_area_fire_starts": {
     "1": [
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
       {
         "label": "0-1",
         "value": 1,

--- a/api/app/tests/hfi/test_hfi_endpoint_response_save_true.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_response_save_true.json
@@ -137,12 +137,40 @@
           },
           "mean_intensity_group": null,
           "prep_level": null
+        },
+        {
+          "date": "2020-05-26",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
         }
       ]
     }
   ],
   "planning_area_fire_starts": {
     "1": [
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
       {
         "label": "0-1",
         "value": 1,

--- a/api/app/tests/hfi/test_hfi_endpoint_response_save_true_239.json
+++ b/api/app/tests/hfi/test_hfi_endpoint_response_save_true_239.json
@@ -137,12 +137,40 @@
           },
           "mean_intensity_group": null,
           "prep_level": null
+        },
+        {
+          "date": "2020-05-26",
+          "dailies": [],
+          "fire_starts": {
+            "label": "0-1",
+            "value": 1,
+            "lookup_table": {
+              "1": 1,
+              "2": 1,
+              "3": 2,
+              "4": 3,
+              "5": 4
+            }
+          },
+          "mean_intensity_group": null,
+          "prep_level": null
         }
       ]
     }
   ],
   "planning_area_fire_starts": {
     "1": [
+      {
+        "label": "0-1",
+        "value": 1,
+        "lookup_table": {
+          "1": 1,
+          "2": 1,
+          "3": 2,
+          "4": 3,
+          "5": 4
+        }
+      },
       {
         "label": "0-1",
         "value": 1,


### PR DESCRIPTION
- Added an end-point unit test handling scenario where all days have data for all stations.
- Fixed prep period bug (was not being inclusive)

# Test Links:
[Percentile Calculator](https://wps-pr-1758.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1758.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1758.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1758.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1758.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1758.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1758.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1758.apps.silver.devops.gov.bc.ca/fwi-calculator)
