### PR TITLE
pushed cpu up to 100m

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -36,7 +36,7 @@ jobs:
           echo Provision database
           CPU_REQUEST=75m CPU_LIMIT=2000m MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi PVC_SIZE=45Gi PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_db.sh prod apply
           echo Deploy API
-          CPU_REQUEST=50m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=3Gi REPLICAS=3 PROJ_TARGET=e1e498-prod VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca bash ./openshift/scripts/oc_deploy.sh prod apply
+          CPU_REQUEST=100m CPU_LIMIT=500m MEMORY_REQUEST=2Gi MEMORY_LIMIT=3Gi REPLICAS=3 PROJ_TARGET=e1e498-prod VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca bash ./openshift/scripts/oc_deploy.sh prod apply
           echo Env Canada Subscriber
           PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_gdps_cronjob.sh prod apply
           PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh prod apply

--- a/openshift/templates/deploy.dc.yaml
+++ b/openshift/templates/deploy.dc.yaml
@@ -325,7 +325,7 @@ objects:
                 # initialDelaySeconds and initialDelaySeconds + periodSeconds
                 initialDelaySeconds: 30
                 periodSeconds: 120
-                timeoutSeconds: 5
+                timeoutSeconds: 20
   - apiVersion: v1
     kind: Service
     metadata:


### PR DESCRIPTION
- cpu is overridden at deploy
- also upped timeout on health

# Test Links:
[Percentile Calculator](https://wps-pr-1774.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1774.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1774.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1774.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1774.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1774.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1774.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1774.apps.silver.devops.gov.bc.ca/fwi-calculator)
