### PR TITLE
Fix HFI controls subheader

### DIFF
--- a/web/src/features/hfiCalculator/components/FireCentreDropdown.tsx
+++ b/web/src/features/hfiCalculator/components/FireCentreDropdown.tsx
@@ -13,8 +13,6 @@ const useStyles = makeStyles({
     color: 'white'
   },
   wrapper: {
-    display: 'flex',
-    alignItems: 'center',
     minWidth: 300
   },
   fireCentreTextField: {

--- a/web/src/features/hfiCalculator/components/HFIPageSubHeader.tsx
+++ b/web/src/features/hfiCalculator/components/HFIPageSubHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 
-import { Button, FormControl, Grid } from '@material-ui/core'
+import { Button, FormControl } from '@material-ui/core'
 import FireCentreDropdown from 'features/hfiCalculator/components/FireCentreDropdown'
 import { isUndefined } from 'lodash'
 import { FireCentre } from 'api/hfiCalcAPI'
@@ -16,20 +16,15 @@ import PrepDateRangeSelector from 'features/hfiCalculator/components/PrepDateRan
 const useStyles = makeStyles(theme => ({
   ...formControlStyles,
   root: {
-    minHeight: 50,
-    maxHeight: 62,
-    marginBottom: '1rem',
-    paddingBottom: '0.25rem',
-    paddingTop: '0.25rem',
-    paddingLeft: '1rem',
-    paddingRight: '1rem',
-    fontSize: '1.3rem',
     background: theme.palette.primary.light,
     color: theme.palette.primary.contrastText,
-    alignContent: 'center'
-  },
-  gridContainer: {
-    height: '85%'
+    minHeight: 60,
+    display: 'flex',
+    flexWrap: 'nowrap',
+    alignItems: 'center',
+    paddingLeft: 25,
+    paddingRight: 25,
+    gap: 10
   },
   helpIcon: {
     fill: 'white'
@@ -42,7 +37,6 @@ const useStyles = makeStyles(theme => ({
   },
   aboutButtonGridItem: {
     marginLeft: 'auto',
-    minWidth: 210,
     maxHeight: 56
   },
   minWidth210: {
@@ -70,51 +64,35 @@ export const HFIPageSubHeader: React.FunctionComponent<Props> = (props: Props) =
 
   return (
     <div className={classes.root}>
-      <Grid
-        container
-        spacing={1}
-        alignItems="center"
-        direction="row"
-        className={classes.gridContainer}
-      >
-        <Grid item md={3}>
-          <FormControl className={classes.minWidth210}>
-            <FireCentreDropdown
-              fireCentres={props.fireCentres}
-              selectedValue={
-                isUndefined(props.selectedFireCentre)
-                  ? null
-                  : { name: props.selectedFireCentre?.name }
-              }
-              onChange={props.selectNewFireCentre}
-            />
-          </FormControl>
-        </Grid>
-        <Grid item md={3} lg={2}>
-          <PrepDateRangeSelector
-            dateRange={props.result ? props.result.date_range : undefined}
-            setDateRange={props.setDateRange}
-          />
-        </Grid>
-        <Grid item md={3}>
-          <LastUpdatedHeader
-            dailies={props.result?.planning_area_hfi_results.flatMap(areaResult =>
-              areaResult.daily_results.flatMap(dailyResult =>
-                dailyResult.dailies.map(validatedDaily => validatedDaily.daily)
-              )
-            )}
-          />
-        </Grid>
-        <Grid item md={1} className={classes.aboutButtonGridItem}>
-          <FormControl className={classes.minWidth210}>
-            <Button onClick={openAboutModal} size="small">
-              <HelpOutlineOutlined className={classes.helpIcon}></HelpOutlineOutlined>
-              <p className={classes.aboutButtonText}>About this data</p>
-            </Button>
-          </FormControl>
-          <AboutDataModal modalOpen={modalOpen} setModalOpen={setModalOpen} />
-        </Grid>
-      </Grid>
+      <FireCentreDropdown
+        fireCentres={props.fireCentres}
+        selectedValue={
+          isUndefined(props.selectedFireCentre)
+            ? null
+            : { name: props.selectedFireCentre?.name }
+        }
+        onChange={props.selectNewFireCentre}
+      />
+      <PrepDateRangeSelector
+        dateRange={props.result ? props.result.date_range : undefined}
+        setDateRange={props.setDateRange}
+      />
+      <LastUpdatedHeader
+        dailies={props.result?.planning_area_hfi_results.flatMap(areaResult =>
+          areaResult.daily_results.flatMap(dailyResult =>
+            dailyResult.dailies.map(validatedDaily => validatedDaily.daily)
+          )
+        )}
+      />
+      <div className={classes.aboutButtonGridItem}>
+        <FormControl className={classes.minWidth210}>
+          <Button onClick={openAboutModal} size="small">
+            <HelpOutlineOutlined className={classes.helpIcon}></HelpOutlineOutlined>
+            <p className={classes.aboutButtonText}>About this data</p>
+          </Button>
+        </FormControl>
+        <AboutDataModal modalOpen={modalOpen} setModalOpen={setModalOpen} />
+      </div>
     </div>
   )
 }

--- a/web/src/features/hfiCalculator/components/PrepDateRangeSelector.tsx
+++ b/web/src/features/hfiCalculator/components/PrepDateRangeSelector.tsx
@@ -43,6 +43,17 @@ export const dateRangePickerTheme = createTheme({
       root: {
         fill: 'white'
       }
+    },
+    MuiIconButton: {
+      root: {
+        paddingLeft: 0,
+        paddingRight: 12
+      }
+    },
+    MuiTextField: {
+      root: {
+        minWidth: 270
+      }
     }
   }
 })


### PR DESCRIPTION
-  Eschew grid in favor of flexbox, remove redundant styles, fix styles
# Test Links:
[Percentile Calculator](https://wps-pr-1857.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1857.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1857.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1857.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1857.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1857.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1857.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1857.apps.silver.devops.gov.bc.ca/fwi-calculator)
