### PR TITLE
Bump width for prep range picker

### DIFF
--- a/web/src/features/hfiCalculator/components/PrepDateRangeSelector.tsx
+++ b/web/src/features/hfiCalculator/components/PrepDateRangeSelector.tsx
@@ -52,7 +52,7 @@ export const dateRangePickerTheme = createTheme({
     },
     MuiTextField: {
       root: {
-        minWidth: 270
+        minWidth: 300
       }
     }
   }


### PR DESCRIPTION
'September' date range text does not fit the text field for prep date range picker. Bump width (matches width of fire centre dropdown too)

Before:
<img width="652" alt="Screen Shot 2022-04-05 at 4 10 33 PM" src="https://user-images.githubusercontent.com/1447136/161865644-efa69929-c1b7-4ec6-8e9a-b1bfc37bdaba.png">

After:
<img width="682" alt="Screen Shot 2022-04-05 at 4 11 06 PM" src="https://user-images.githubusercontent.com/1447136/161865683-4a53b7fe-9ff0-4a71-9b6d-1e774611cf76.png">

