### PR TITLE
Isolate PDF request

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "python.pythonPath": "${workspaceFolder}/api/.venv/bin/python",
     "python.defaultInterpreterPath": "${workspaceFolder}/api/.venv/bin/python",
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
@@ -46,6 +45,9 @@
         "editor.insertSpaces": true,
         "editor.tabSize": 2,
         "editor.formatOnSave": true
+    },
+    "[json]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
     },
     "python.testing.pytestArgs": [
         "api"

--- a/api/app/routers/hfi_calc.py
+++ b/api/app/routers/hfi_calc.py
@@ -317,7 +317,7 @@ async def load_hfi_result(fire_centre_id: int,
 async def load_hfi_result_with_date(fire_centre_id: int,
                                     start_date: Optional[date],
                                     response: Response,
-                                    token=Depends(authentication_required)):
+                                    _=Depends(authentication_required)):
     """ Given a fire centre id (and optionally a start date), load the most recent HFIResultRequest.
     If there isn't a stored request, one will be created.
     """

--- a/api/app/routers/hfi_calc.py
+++ b/api/app/routers/hfi_calc.py
@@ -156,7 +156,7 @@ async def select_planning_area_station(
     planning_area_id: int, station_code: int,
     enable: bool,
     response: Response,
-    token=Depends(authentication_required)  # pylint: disable=unused-argument
+    token=Depends(authentication_required)
 ):
     """ Enable / disable a station withing a planning area """
     logger.info('/fire_centre/%s/%s/planning_area/%s/station/%s/selected/%s',
@@ -195,7 +195,7 @@ async def set_planning_area_station_fuel_type(
     planning_area_id: int,
     station_code: int,
     fuel_type_id: int,
-    response: Response,  # pylint: disable=unused-argument
+    response: Response,
     token=Depends(authentication_required)  # pylint: disable=unused-argument
 ):
     """ Set the fuel type for a station in a planning area. """
@@ -255,7 +255,7 @@ async def set_prep_period(fire_centre_id: int,
                           start_date: date,
                           end_date: date,
                           response: Response,
-                          token=Depends(authentication_required)  # pylint: disable=unused-argument
+                          token=Depends(authentication_required)
                           ):
     """ Set the prep period """
     logger.info('/fire_centre/%s/%s/%s', fire_centre_id, start_date, end_date)
@@ -326,18 +326,13 @@ async def load_hfi_result_with_date(fire_centre_id: int,
         response.headers["Cache-Control"] = no_cache
 
         with get_read_session_scope() as session:
-            request, request_loaded, fire_centre_fire_start_ranges = get_prepared_request(session,
-                                                                                          fire_centre_id,
-                                                                                          start_date)
+            request, _, fire_centre_fire_start_ranges = get_prepared_request(session,
+                                                                             fire_centre_id,
+                                                                             start_date)
 
             # Get the response.
             request_response = await calculate_and_create_response(
                 session, request, fire_centre_fire_start_ranges)
-
-        # TODO: change this! once we've changed how pdf works, we no longer need to save here!
-        if not request_loaded:
-            # If a start date was specified, we go ahead and save this request.
-            save_request_in_database(request, token.get('preferred_username', None))
 
         return request_response
 
@@ -347,7 +342,7 @@ async def load_hfi_result_with_date(fire_centre_id: int,
 
 
 @router.get('/fire-centres', response_model=HFIWeatherStationsResponse)
-async def get_fire_centres(response: Response):  # pylint: disable=too-many-locals
+async def get_fire_centres(response: Response):
     """ Returns list of fire centres and planning area for each fire centre,
     and weather stations within each planning area. Also returns the assigned fuel type
     for each weather station. """
@@ -368,54 +363,37 @@ async def get_fire_centres(response: Response):  # pylint: disable=too-many-loca
 @router.get('/fire_centre/{fire_centre_id}/{start_date}/pdf')
 async def download_pdf(
     fire_centre_id: int, start_date: date,
-    response: Response,
-    token=Depends(authentication_required)  # pylint: disable=unused-argument
+    _: Response,
+    token=Depends(authentication_required)
 ):
     """ Returns a PDF of the HFI results for the supplied fire centre and start date. """
-    # TODO: stub - implement!
     logger.info('/hfi-calc/fire_centre/%s/%s/pdf', fire_centre_id, start_date)
-    response.headers["Cache-Control"] = no_cache
-    raise NotImplementedError('Not implemented')
 
+    with get_read_session_scope() as session:
+        (request,
+         _,
+         fire_centre_fire_start_ranges) = get_prepared_request(session,
+                                                               fire_centre_id,
+                                                               start_date)
 
-@router.post('/download-pdf')
-async def download_result_pdf(request: HFIResultRequest,
-                              token=Depends(authentication_required)):
-    """ Assembles and returns PDF byte representation of HFI result. """
-    # TODO: Replace this method with @router.get('/fire_centre/{fire_centre_id}/{start_date}/pdf')
-    # THIS FUNCTION IS DEPRECATED.
-    try:
-        logger.info('/hfi-calc/download-pdf')
-        with get_read_session_scope() as session:
-            fire_start_ranges = list(load_fire_start_ranges(session, request.selected_fire_center_id))
-            (results,
-             valid_date_range) = await calculate_latest_hfi_results(session, request, fire_start_ranges)
+        # Get the response.
+        request_response = await calculate_and_create_response(
+            session, request, fire_centre_fire_start_ranges)
 
-        response = HFIResultResponse(
-            date_range=valid_date_range,
-            selected_station_code_ids=request.selected_station_code_ids,
-            planning_area_station_info=request.planning_area_station_info,
-            selected_fire_center_id=request.selected_fire_center_id,
-            planning_area_hfi_results=results,
-            fire_start_ranges=fire_start_ranges)
+    fire_centres_list = await hydrate_fire_centres()
 
-        fire_centres_list = await hydrate_fire_centres()
+    # Loads template as string from a function
+    # See: https://jinja.palletsprojects.com/en/3.0.x/api/?highlight=functionloader#jinja2.FunctionLoader
+    jinja_env = Environment(loader=FunctionLoader(get_template), autoescape=True)
 
-        # Loads template as string from a function
-        # See: https://jinja.palletsprojects.com/en/3.0.x/api/?highlight=functionloader#jinja2.FunctionLoader
-        jinja_env = Environment(loader=FunctionLoader(get_template), autoescape=True)
+    username = token.get('preferred_username', None)
 
-        username = token.get('preferred_username', None)
+    pdf_bytes, pdf_filename = generate_pdf(request_response,
+                                           fire_centres_list,
+                                           username,
+                                           get_pst_now(),
+                                           jinja_env)
 
-        pdf_bytes, pdf_filename = generate_pdf(response,
-                                               fire_centres_list,
-                                               username,
-                                               get_pst_now(),
-                                               jinja_env)
-
-        return Response(pdf_bytes, headers={'Content-Disposition': f'attachment; filename={pdf_filename}',
-                                            'Access-Control-Expose-Headers': 'Content-Disposition',
-                                            'Cache-Control': no_cache})
-    except Exception as exc:
-        logger.critical(exc, exc_info=True)
-        raise
+    return Response(pdf_bytes, headers={'Content-Disposition': f'attachment; filename={pdf_filename}',
+                                        'Access-Control-Expose-Headers': 'Content-Disposition',
+                                        'Cache-Control': no_cache})

--- a/api/app/tests/hfi/test_hfi_endpoint_request.feature
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.feature
@@ -12,11 +12,9 @@ Feature: /hfi/
 
         Examples:
             | url                                                                                              | verb | status_code | response_json                                            | request_saved | stored_request_json                   |
-            # TODO: change code so request_saved == False for get requests (we need it right now for pdf download to work, but that's getting fixed soon)
-            | /api/hfi-calc/fire_centre/1                                                                      | get  | 200         | hfi/test_hfi_endpoint_load_response.json                 | True          | None                                  |
+            | /api/hfi-calc/fire_centre/1                                                                      | get  | 200         | hfi/test_hfi_endpoint_load_response.json                 | False         | None                                  |
             | /api/hfi-calc/fire_centre/1                                                                      | get  | 200         | hfi/test_hfi_endpoint_load_response.json                 | False         | test_hfi_endpoint_stored_request.json |
-            # TODO: change code so request_saved == False for get requests (we need it right now for pdf download to work, but that's getting fixed soon)
-            | /api/hfi-calc/fire_centre/1/2020-05-21                                                           | get  | 200         | hfi/test_hfi_endpoint_load_response.json                 | True          | None                                  |
+            | /api/hfi-calc/fire_centre/1/2020-05-21                                                           | get  | 200         | hfi/test_hfi_endpoint_load_response.json                 | False         | None                                  |
             | /api/hfi-calc/fire_centre/1/2020-05-21                                                           | get  | 200         | hfi/test_hfi_endpoint_load_response.json                 | False         | test_hfi_endpoint_stored_request.json |
             # Test set fire start range
             | /api/hfi-calc/fire_centre/1/2020-05-21/planning_area/1/fire_starts/2020-05-21/fire_start_range/2 | post | 200         | hfi/test_hfi_endpoint_response_set_fire_start_range.json | True          | None                                  |
@@ -29,6 +27,7 @@ Feature: /hfi/
             # Test start + end date
             | /api/hfi-calc/fire_centre/1/2020-05-21/2020-05-26                                                | post | 200         | hfi/test_hfi_endpoint_set_date_range_response.json       | True          | None                                  |
             | /api/hfi-calc/fire_centre/1/2020-05-21/2020-05-26                                                | post | 200         | hfi/test_hfi_endpoint_set_date_range_response.json       | True          | test_hfi_endpoint_stored_request.json |
+    # pdf
 
 
     Scenario: HFI - pdf download

--- a/api/app/tests/hfi/test_hfi_endpoint_request.feature
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.feature
@@ -1,7 +1,6 @@
 Feature: /hfi/
 
     Scenario: HFI - request
-        # In this scenario, we expect a request to be loaded from the database - but there isn't one.
         Given I have a stored request <stored_request_json>
         And I spy on store_hfi_request
         And I received a hfi-calc <url> with <verb>
@@ -27,16 +26,22 @@ Feature: /hfi/
             # Test start + end date
             | /api/hfi-calc/fire_centre/1/2020-05-21/2020-05-26                                                | post | 200         | hfi/test_hfi_endpoint_set_date_range_response.json       | True          | None                                  |
             | /api/hfi-calc/fire_centre/1/2020-05-21/2020-05-26                                                | post | 200         | hfi/test_hfi_endpoint_set_date_range_response.json       | True          | test_hfi_endpoint_stored_request.json |
-    # pdf
+            # pdf
+            | api/hfi-calc/fire_centre/1/2020-05-21/pdf                                                        | get  | 200         | None                                                     | False         | None                                  |
+            | api/hfi-calc/fire_centre/1/2020-05-21/pdf                                                        | get  | 200         | None                                                     | False         | test_hfi_endpoint_stored_request.json |
+
 
 
     Scenario: HFI - pdf download
-        Given I received a hfi-calc request url:<url> verb:<verb> request:<request_json>
+        # Very similar to the scenario above, except we don't bother with checking the response content.
+        Given I have a stored request <stored_request_json>
+        And I spy on store_hfi_request
+        And I received a hfi-calc <url> with <verb>
         Then the response status code is <status_code>
         And the response isn't cached
+        And request == saved = <request_saved>
 
         Examples:
-            # TODO: These test currently exposes a "bug" in the code where removing a station from one area, means it's removed from all.
-            | url                        | verb | request_json                   | status_code |
-            # Test perfect scenario, we have 2 stations, they're both selected, and they have data for all days.
-            | /api/hfi-calc/download-pdf | post | test_hfi_endpoint_request.json | 200         |
+            | url                                       | verb | status_code | request_saved | stored_request_json                   |
+            | api/hfi-calc/fire_centre/1/2020-05-21/pdf | get  | 200         | False         | None                                  |
+            | api/hfi-calc/fire_centre/1/2020-05-21/pdf | get  | 200         | False         | test_hfi_endpoint_stored_request.json |

--- a/api/app/tests/hfi/test_hfi_endpoint_request.py
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.py
@@ -46,7 +46,14 @@ def _setup_mock(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.usefixtures('mock_jwt_decode')
 @scenario('test_hfi_endpoint_request.feature', 'HFI - request')
-def test_fire_behaviour_calculator_scenario_no_request_stored():
+def test_fire_behaviour_calculator_scenario():
+    """ BDD Scenario. """
+    pass
+
+
+@pytest.mark.usefixtures('mock_jwt_decode')
+@scenario('test_hfi_endpoint_request.feature', 'HFI - pdf download')
+def test_fire_behaviour_calculator_pdf_scenario():
     """ BDD Scenario. """
     pass
 

--- a/api/app/tests/hfi/test_hfi_endpoint_request.py
+++ b/api/app/tests/hfi/test_hfi_endpoint_request.py
@@ -87,28 +87,6 @@ def given_hfi_calc_url(monkeypatch: pytest.MonkeyPatch, url: str, verb: str):
     }
 
 
-@given(parsers.parse("I received a hfi-calc request url:{url} verb:{verb} request:{request_json}"),
-       target_fixture='response',
-       converters={'request_json': load_json_file_with_name(__file__), 'url': str})
-def given_hfi_calc_url_with_request(
-        monkeypatch: pytest.MonkeyPatch, url: str, request_json: Tuple[dict, str], verb: str):
-    """ Handle request
-    """
-    _setup_mock(monkeypatch)
-
-    client = TestClient(app.main.app)
-    headers = {'Content-Type': 'application/json',
-               'Authorization': 'Bearer token'}
-    if verb == 'get':
-        response = client.get(url, headers=headers)
-    else:
-        response = client.post(url, headers=headers, json=request_json[0])
-    return {
-        'response': response,
-        'filename': request_json[1]
-    }
-
-
 @then(parsers.parse("request == saved = {request_saved}"), converters={'request_saved': strtobool})
 def then_request_saved(spy_store_hfi_request: MagicMock, request_saved: bool):
     assert spy_store_hfi_request.called == request_saved
@@ -118,10 +96,3 @@ def then_request_saved(spy_store_hfi_request: MagicMock, request_saved: bool):
 def then_response_not_cached(response):
     """ Check that the response isn't being cached """
     assert response['response'].headers['cache-control'] == 'max-age=0'
-
-
-@pytest.mark.usefixtures('mock_jwt_decode')
-@scenario('test_hfi_endpoint_request.feature', 'HFI - pdf download')
-def test_fire_behaviour_calculator_scenario_pdf_download():
-    """ BDD Scenario. """
-    pass

--- a/web/cypress/integration/hfi-calculator-page.spec.ts
+++ b/web/cypress/integration/hfi-calculator-page.spec.ts
@@ -55,7 +55,8 @@ function interceptSetFireStarts() {
 }
 
 function interceptDownload() {
-  cy.intercept('POST', 'api/hfi-calc/download-pdf', {
+  cy.intercept('GET', 'api/hfi-calc/fire_centre/1/2021-08-02/pdf', {
+    // In reality the server returns a pdf file, not a json file - but for this test it really doesn't matter.
     fixture: 'hfi-calc/dailies-saved.json'
   }).as('downloadPDF')
 }

--- a/web/cypress/integration/hfi-calculator-page.spec.ts
+++ b/web/cypress/integration/hfi-calculator-page.spec.ts
@@ -55,10 +55,7 @@ function interceptSetFireStarts() {
 }
 
 function interceptDownload() {
-  cy.intercept('GET', 'api/hfi-calc/fire_centre/1/2021-08-02/pdf', {
-    // In reality the server returns a pdf file, not a json file - but for this test it really doesn't matter.
-    fixture: 'hfi-calc/dailies-saved.json'
-  }).as('downloadPDF')
+  cy.intercept('GET', 'api/hfi-calc/fire_centre/1/2021-08-02/pdf').as('downloadPDF')
 }
 
 describe('HFI Calculator Page', () => {

--- a/web/src/api/hfiCalculatorAPI.ts
+++ b/web/src/api/hfiCalculatorAPI.ts
@@ -1,6 +1,5 @@
 import axios from 'api/axios'
 import {
-  HFIResultRequest,
   HFIResultResponse,
   PlanningAreaResult,
   RawHFIResultResponse
@@ -146,12 +145,9 @@ function buildResult(data: RawHFIResultResponse) {
   return planningAreaResultsWithDates
 }
 
-export async function getPDF(request: HFIResultRequest): Promise<void> {
-  const response = await axios.post(
-    baseUrl + 'download-pdf',
-    {
-      ...request
-    },
+export async function getPDF(fire_center_id: number, start_date: string): Promise<void> {
+  const response = await axios.get(
+    baseUrl + 'fire_centre/' + fire_center_id + '/' + start_date + '/pdf',
     {
       responseType: 'blob'
     }

--- a/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
+++ b/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
@@ -4,7 +4,6 @@ import { Container, ErrorBoundary, GeneralHeader } from 'components'
 import { fetchHFIStations } from 'features/hfiCalculator/slices/stationsSlice'
 import {
   FireStartRange,
-  PlanningAreaResult,
   setSelectedFireCentre,
   fetchLoadDefaultHFIResult,
   fetchSetNewFireStarts,
@@ -36,20 +35,6 @@ import HFIErrorAlert from 'features/hfiCalculator/components/HFIErrorAlert'
 import DownloadPDFButton from 'features/hfiCalculator/components/DownloadPDFButton'
 import EmptyFireCentreRow from 'features/hfiCalculator/components/EmptyFireCentre'
 import { DateRange } from 'components/dateRangePicker/types'
-
-function constructPlanningAreaFireStarts(
-  planning_area_hfi_results: PlanningAreaResult[]
-) {
-  // TODO: delete this function when it's redundant!
-  const fireStarts = {} as { [key: number]: FireStartRange[] }
-  planning_area_hfi_results.forEach(planningAreaResult => {
-    fireStarts[planningAreaResult.planning_area_id] = []
-    planningAreaResult.daily_results.forEach(dailyResult => {
-      fireStarts[planningAreaResult.planning_area_id].push(dailyResult.fire_starts)
-    })
-  })
-  return fireStarts
-}
 
 const useStyles = makeStyles(() => ({
   ...formControlStyles,
@@ -204,16 +189,11 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
 
   const handleDownloadClicked = () => {
     if (!isUndefined(result)) {
-      dispatch(
-        fetchPDFDownload({
-          selected_station_code_ids: result.selected_station_code_ids,
-          selected_fire_center_id: result.selected_fire_center_id,
-          planning_area_fire_starts: constructPlanningAreaFireStarts(
-            result.planning_area_hfi_results
-          ),
-          date_range: result.date_range
-        })
-      )
+      if (!isUndefined(result) && !isUndefined(result.date_range.start_date)) {
+        dispatch(
+          fetchPDFDownload(result.selected_fire_center_id, result.date_range.start_date)
+        )
+      }
     }
   }
 

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -83,14 +83,6 @@ export interface RawHFIResultResponse {
   fire_start_ranges: FireStartRange[]
 }
 
-export interface HFIResultRequest {
-  date_range?: PrepDateRange
-  selected_station_code_ids: number[]
-  selected_fire_center_id: number
-  planning_area_fire_starts: { [key: number]: FireStartRange[] }
-  persist_request?: boolean
-}
-
 export interface HFILoadResultRequest {
   start_date?: string
   end_date?: string
@@ -244,11 +236,11 @@ export const fetchSetNewFireStarts =
   }
 
 export const fetchPDFDownload =
-  (request: HFIResultRequest): AppThunk =>
+  (fire_center_id: number, start_date: string): AppThunk =>
   async dispatch => {
     try {
       dispatch(pdfDownloadStart())
-      await getPDF(request)
+      await getPDF(fire_center_id, start_date)
       dispatch(pdfDownloadEnd())
     } catch (err) {
       dispatch(getHFIResultFailed((err as Error).toString()))


### PR DESCRIPTION
- [x] PDF specific endpoint that loads from saved requests only
- [x] Back end tests for new PDF endpoint
- [x] Front end test updated to reflect new endpoint
- [x] Some re-factoring around now redundant code / comments etc.
- [x] Set json formatter to "vscode.json-language-features" for project in setttings.json
- [x] Removed redundant pythonopath from settings.json

# Test Links:
[Percentile Calculator](https://wps-pr-1868.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1868.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1868.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1868.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1868.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1868.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1868.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1868.apps.silver.devops.gov.bc.ca/fwi-calculator)
