### PR TITLE
Add debug flag for certbox cronjob

### DIFF
--- a/openshift/scripts/oc_deploy_to_production.sh
+++ b/openshift/scripts/oc_deploy_to_production.sh
@@ -48,4 +48,4 @@ PROJ_TARGET=${PROJ_TARGET} CPU_REQUEST=1000m CPU_LIMIT=2000m bash $(dirname ${0}
 PROJ_TARGET=${PROJ_TARGET} CPU_REQUEST=50m CPU_LIMIT=500m BACKUP_VOLUME_SIZE=3Gi bash $(dirname ${0})/oc_provision_backup_mariadb.sh prod ${RUN_TYPE}
 PROJ_TARGET=${PROJ_TARGET} CPU_REQUEST=50m CPU_LIMIT=500m bash $(dirname ${0})/oc_provision_backup_mariadb_cronjob.sh prod ${RUN_TYPE}
 echo Configure
-PROJ_TARGET=${PROJ_TARGET} CERTBOT_STAGING=false DRYRUN=false bash $(dirname ${0})/oc_provision_certbot_cronjob.sh prod ${RUN_TYPE}
+PROJ_TARGET=${PROJ_TARGET} CERTBOT_STAGING=false DRYRUN=false DEBUG=true bash $(dirname ${0})/oc_provision_certbot_cronjob.sh prod ${RUN_TYPE}


### PR DESCRIPTION
Add debug flag when running certbox jobs so we can easily debug them in the future
# Test Links:
[Percentile Calculator](https://wps-pr-1873.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1873.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1873.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1873.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1873.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1873.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1873.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1873.apps.silver.devops.gov.bc.ca/fwi-calculator)
