### PR TITLE
Success toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-## 2022-04-11 HFI Calc [#1634](https://github.com/bcgov/wps/issues/1634)
+## 2022-04-11 HFI Calc : Prep Period [#1634](https://github.com/bcgov/wps/issues/1634)
 
 ### Features
 
 - **hfi calculator:** Load the most recently saved prep record that overlaps with the current date. (Previous behaviour was to load the most recently modified prep record.)
-
 - **hfi calculator:** Changing the prep period date does not result in a write to the database. Users can change thus change dates without affecting other users. (Previous behaviour was to create/update a prep record when changing the date.)
 - **hfi calculator:** When a fire starts are changed or weather stations are toggled, a prep period record is created in the database.
 - **hfi calculator:** Changing the prep period end date results in losing fire starts & weather station toggles. (Previous behaviour would retain fire starts & weather station toggles if the start date was unchanged.)
 - **hfi calculator:** Changed warning message from "Any changes made to dates, fire starts or selected stations ..." to "Any changes made to fire starts or selected stations..."
+
+## 2022-04-12 HFI Calc : Success Snackbar [#1634](https://github.com/bcgov/wps/issues/1634)
+
+### Features
+
+- **hfi calculator:** Add a success snackbar that shows when user has successfully made a change to prep.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2022-04-12 HFI Calc : Success Snackbar [#1634](https://github.com/bcgov/wps/issues/1634)
+
+### Features
+
+- **hfi calculator:** Add a success snackbar that shows when user has successfully made a change to prep.
+
 ## 2022-04-11 HFI Calc : Prep Period [#1634](https://github.com/bcgov/wps/issues/1634)
 
 ### Features
@@ -7,9 +13,3 @@
 - **hfi calculator:** When a fire starts are changed or weather stations are toggled, a prep period record is created in the database.
 - **hfi calculator:** Changing the prep period end date results in losing fire starts & weather station toggles. (Previous behaviour would retain fire starts & weather station toggles if the start date was unchanged.)
 - **hfi calculator:** Changed warning message from "Any changes made to dates, fire starts or selected stations ..." to "Any changes made to fire starts or selected stations..."
-
-## 2022-04-12 HFI Calc : Success Snackbar [#1634](https://github.com/bcgov/wps/issues/1634)
-
-### Features
-
-- **hfi calculator:** Add a success snackbar that shows when user has successfully made a change to prep.

--- a/web/cypress/integration/hfi-calculator-page.spec.ts
+++ b/web/cypress/integration/hfi-calculator-page.spec.ts
@@ -75,6 +75,7 @@ describe('HFI Calculator Page', () => {
       cy.getByTestId('select-station-239').click({ force: true })
       cy.wait('@selectStationTrue')
       cy.getByTestId('select-station-239').find('input').should('be.checked')
+      cy.getByTestId('hfi-success-alert').should('exist')
     })
     it('prep period should send a new request to the server', () => {
       interceptGetPrepPeriod(1, '2021-08-03', '2021-08-07')
@@ -94,10 +95,11 @@ describe('HFI Calculator Page', () => {
       cy.getByTestId('date-range-picker-wrapper').type('{esc}')
 
       cy.wait('@getPrepPeriod')
+
+      cy.getByTestId('hfi-success-alert').should('not.exist')
     })
     it('new fire starts should send a new request to the server', () => {
-      // Selecting a new fire start, should result in a new request to the server, that comes back with "request_persist_success": true, or
-      // which should cause the save button to become disabled.
+      // Selecting a new fire start, should result in a new request to the server.
       interceptSetFireStarts()
       cy.getByTestId('fire-starts-dropdown')
         .first()
@@ -106,6 +108,7 @@ describe('HFI Calculator Page', () => {
         .type('{downarrow}')
         .type('{enter}')
       cy.wait('@setFireStarts')
+      cy.getByTestId('hfi-success-alert').should('exist')
     })
     it('should switch the tab to prep period from a daily tab when a different fire centre is selected', () => {
       cy.getByTestId('daily-toggle-1').click({ force: true })

--- a/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
     '& .MuiAlert-icon': {
       color: 'white'
     },
-    marginTop: '120px'
+    marginTop: 120
   }
 })
 

--- a/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
@@ -27,18 +27,17 @@ const HFISuccessAlert = ({ message }: HFISuccessAlertProps) => {
   }
 
   return (
-    <div>
-      <Snackbar
-        open={open}
-        autoHideDuration={6000}
-        onClose={handleClose}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      >
-        <Alert className={classes.alert} onClose={handleClose} severity="success">
-          {message}
-        </Alert>
-      </Snackbar>
-    </div>
+    <Snackbar
+      data-testid="hfi-success-alert"
+      open={open}
+      autoHideDuration={6000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    >
+      <Alert className={classes.alert} onClose={handleClose} severity="success">
+        {message}
+      </Alert>
+    </Snackbar>
   )
 }
 

--- a/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
@@ -1,0 +1,30 @@
+import { Alert } from '@material-ui/lab'
+import { Snackbar } from '@material-ui/core'
+import React from 'react'
+
+export interface HFISuccessAlertProps {
+  message: string | null
+}
+
+const HFISuccessAlert = ({ message }: HFISuccessAlertProps) => {
+  const [open, setOpen] = React.useState(true)
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={6000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    >
+      <Alert onClose={handleClose} severity="success">
+        {message}
+      </Alert>
+    </Snackbar>
+  )
+}
+
+export default React.memo(HFISuccessAlert)

--- a/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
@@ -1,3 +1,4 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Alert } from '@material-ui/lab'
 import { Snackbar } from '@material-ui/core'
 import React from 'react'
@@ -6,7 +7,25 @@ export interface HFISuccessAlertProps {
   message: string | null
 }
 
+const useStyles = makeStyles(
+  { root: {} }
+  // (theme: Theme) => {
+
+  // }
+  // createStyles({
+  //   root: {
+  //     marginTop: '200px'
+  //     // width: '100%',
+  //     // '& > * + *': {
+  //     //   marginTop: theme.spacing(2)
+  //     // },
+  //     // marginBottom: theme.spacing(2)
+  //   }
+  // })
+)
+
 const HFISuccessAlert = ({ message }: HFISuccessAlertProps) => {
+  const classes = useStyles()
   const [open, setOpen] = React.useState(true)
 
   const handleClose = () => {
@@ -14,16 +33,18 @@ const HFISuccessAlert = ({ message }: HFISuccessAlertProps) => {
   }
 
   return (
-    <Snackbar
-      open={open}
-      autoHideDuration={6000}
-      onClose={handleClose}
-      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-    >
-      <Alert onClose={handleClose} severity="success">
-        {message}
-      </Alert>
-    </Snackbar>
+    <div className={classes.root}>
+      <Snackbar
+        open={open}
+        // autoHideDuration={6000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <Alert onClose={handleClose} severity="success">
+          {message}
+        </Alert>
+      </Snackbar>
+    </div>
   )
 }
 

--- a/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
@@ -1,28 +1,24 @@
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
 import { Alert } from '@material-ui/lab'
-import { Snackbar } from '@material-ui/core'
+import { Collapse } from '@material-ui/core'
 import React from 'react'
 
 export interface HFISuccessAlertProps {
   message: string | null
 }
 
-const useStyles = makeStyles(
-  { root: {} }
-  // (theme: Theme) => {
-
-  // }
-  // createStyles({
-  //   root: {
-  //     marginTop: '200px'
-  //     // width: '100%',
-  //     // '& > * + *': {
-  //     //   marginTop: theme.spacing(2)
-  //     // },
-  //     // marginBottom: theme.spacing(2)
-  //   }
-  // })
-)
+const useStyles = makeStyles({
+  alert: {
+    width: '220px',
+    margin: 'auto',
+    backgroundColor: '#2E8540',
+    color: 'white',
+    '& .MuiAlert-icon': {
+      color: 'white'
+    }
+  },
+  '@global': {}
+})
 
 const HFISuccessAlert = ({ message }: HFISuccessAlertProps) => {
   const classes = useStyles()
@@ -33,17 +29,21 @@ const HFISuccessAlert = ({ message }: HFISuccessAlertProps) => {
   }
 
   return (
-    <div className={classes.root}>
-      <Snackbar
+    <div>
+      {/* Ideally we should be using Snackbar (@material-ui/core) here, but with the warning message always being present it
+      doesn't really work */}
+      {/* <Snackbar
         open={open}
-        // autoHideDuration={6000}
+        autoHideDuration={6000}
         onClose={handleClose}
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      >
-        <Alert onClose={handleClose} severity="success">
+      > */}
+      <Collapse in={open}>
+        <Alert className={classes.alert} onClose={handleClose} severity="success">
           {message}
         </Alert>
-      </Snackbar>
+      </Collapse>
+      {/* </Snackbar> */}
     </div>
   )
 }

--- a/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
+++ b/web/src/features/hfiCalculator/components/HFISuccessAlert.tsx
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles'
 import { Alert } from '@material-ui/lab'
-import { Collapse } from '@material-ui/core'
+import { Snackbar } from '@material-ui/core'
 import React from 'react'
 
 export interface HFISuccessAlertProps {
@@ -9,15 +9,13 @@ export interface HFISuccessAlertProps {
 
 const useStyles = makeStyles({
   alert: {
-    width: '220px',
-    margin: 'auto',
     backgroundColor: '#2E8540',
     color: 'white',
     '& .MuiAlert-icon': {
       color: 'white'
-    }
-  },
-  '@global': {}
+    },
+    marginTop: '120px'
+  }
 })
 
 const HFISuccessAlert = ({ message }: HFISuccessAlertProps) => {
@@ -30,20 +28,16 @@ const HFISuccessAlert = ({ message }: HFISuccessAlertProps) => {
 
   return (
     <div>
-      {/* Ideally we should be using Snackbar (@material-ui/core) here, but with the warning message always being present it
-      doesn't really work */}
-      {/* <Snackbar
+      <Snackbar
         open={open}
         autoHideDuration={6000}
         onClose={handleClose}
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      > */}
-      <Collapse in={open}>
+      >
         <Alert className={classes.alert} onClose={handleClose} severity="success">
           {message}
         </Alert>
-      </Collapse>
-      {/* </Snackbar> */}
+      </Snackbar>
     </div>
   )
 }

--- a/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
+++ b/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
@@ -248,9 +248,9 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
     return (
       <React.Fragment>
         <Container maxWidth={'xl'}>
-          {buildSuccessNotification()}
           <LiveChangesAlert />
           {errorNotification}
+          {buildSuccessNotification()}
           <FormControl className={classes.formControl}>
             <ViewSwitcherToggles
               dateRange={dateRange}

--- a/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
+++ b/web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
@@ -32,6 +32,7 @@ import { FireCentre } from 'api/hfiCalcAPI'
 import { HFIPageSubHeader } from 'features/hfiCalculator/components/HFIPageSubHeader'
 import { isNull, isUndefined } from 'lodash'
 import HFIErrorAlert from 'features/hfiCalculator/components/HFIErrorAlert'
+import HFISuccessAlert from 'features/hfiCalculator/components/HFISuccessAlert'
 import DownloadPDFButton from 'features/hfiCalculator/components/DownloadPDFButton'
 import EmptyFireCentreRow from 'features/hfiCalculator/components/EmptyFireCentre'
 import { DateRange } from 'components/dateRangePicker/types'
@@ -83,7 +84,8 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
     selectedFireCentre,
     loading,
     dateRange,
-    error: hfiError
+    error: hfiError,
+    changeSaved
   } = useSelector(selectHFICalculatorState)
 
   const setSelectedStation = (
@@ -207,6 +209,13 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
     return <React.Fragment></React.Fragment>
   }
 
+  const buildSuccessNotification = () => {
+    if (changeSaved) {
+      return <HFISuccessAlert message="Changes saved!" />
+    }
+    return <React.Fragment></React.Fragment>
+  }
+
   const isLoadingWithoutError = () => {
     return (
       (loading || stationDataLoading || isUndefined(result)) &&
@@ -239,6 +248,7 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
     return (
       <React.Fragment>
         <Container maxWidth={'xl'}>
+          {buildSuccessNotification()}
           <LiveChangesAlert />
           {errorNotification}
           <FormControl className={classes.formControl}>

--- a/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -65,6 +65,7 @@ export interface HFICalculatorState {
   planningAreaHFIResults: { [key: string]: PlanningAreaResult }
   selectedFireCentre: FireCentre | undefined
   result: HFIResultResponse | undefined
+  changeSaved: boolean
 }
 
 export interface HFIResultResponse {
@@ -107,7 +108,8 @@ const initialState: HFICalculatorState = {
   planningAreaFireStarts: {},
   planningAreaHFIResults: {},
   selectedFireCentre: undefined,
-  result: undefined
+  result: undefined,
+  changeSaved: false
 }
 
 const dailiesSlice = createSlice({
@@ -116,6 +118,7 @@ const dailiesSlice = createSlice({
   reducers: {
     loadHFIResultStart(state: HFICalculatorState) {
       state.loading = true
+      state.changeSaved = false
     },
     pdfDownloadStart(state: HFICalculatorState) {
       state.loading = true
@@ -126,6 +129,7 @@ const dailiesSlice = createSlice({
     getHFIResultFailed(state: HFICalculatorState, action: PayloadAction<string>) {
       state.error = action.payload
       state.loading = false
+      state.changeSaved = false
     },
     setSelectedPrepDate: (state: HFICalculatorState, action: PayloadAction<string>) => {
       state.selectedPrepDate = action.payload
@@ -135,6 +139,9 @@ const dailiesSlice = createSlice({
       action: PayloadAction<FireCentre | undefined>
     ) => {
       state.selectedFireCentre = action.payload
+    },
+    setChangeSaved: (state: HFICalculatorState, action: PayloadAction<boolean>) => {
+      state.changeSaved = action.payload
     },
     setResult: (
       state: HFICalculatorState,
@@ -154,7 +161,8 @@ export const {
   getHFIResultFailed,
   setSelectedPrepDate,
   setSelectedFireCentre,
-  setResult
+  setResult,
+  setChangeSaved
 } = dailiesSlice.actions
 
 export default dailiesSlice.reducer
@@ -191,6 +199,7 @@ export const fetchSetStationSelected =
         selected
       )
       dispatch(setResult(result))
+      dispatch(setChangeSaved(true))
     } catch (err) {
       dispatch(getHFIResultFailed((err as Error).toString()))
       logError(err)
@@ -229,6 +238,7 @@ export const fetchSetNewFireStarts =
         fire_start_range_id
       )
       dispatch(setResult(result))
+      dispatch(setChangeSaved(true))
     } catch (err) {
       dispatch(getHFIResultFailed((err as Error).toString()))
       logError(err)


### PR DESCRIPTION
Snackbar with "Changes saved!" appears when changing fire starts or toggling weather stations.

Note to devs: Not sure about dispatch(setChangeSaved(true)) - we used to have a save state in the response, but we don't have it anymore. I could bring it back, but it seems redundant, if you're doing a POST, then a 200 response would imply success in saving.

# Test Links:
[Percentile Calculator](https://wps-pr-1884.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1884.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1884.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1884.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1884.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1884.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1884.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1884.apps.silver.devops.gov.bc.ca/fwi-calculator)
