### PR TITLE
Add threading id to rocket chat log

### DIFF
--- a/api/app/rocketchat_notifications.py
+++ b/api/app/rocketchat_notifications.py
@@ -5,6 +5,7 @@ Notification content can be customized based on requestor.
 from datetime import datetime, timezone
 import traceback
 import logging
+import threading
 import requests
 from app import config
 
@@ -22,7 +23,7 @@ def send_rocketchat_notification(text: str, exc_info: Exception) -> dict:
     the response.
     """
     full_message = f"{datetime.now(tz=timezone.utc).isoformat()}\n{text}\n\
-        {config.get('HOSTNAME')}: {exc_info}\n\
+        {config.get('HOSTNAME')} ({threading.get_native_id()}): {exc_info}\n\
         {traceback.format_exception(etype=type(exc_info),value=exc_info,tb=exc_info.__traceback__)}"
     result = None
     try:


### PR DESCRIPTION
Added a thread id to the rocket chat log, in hopes that it will make it possible to confirm that response timeouts on `/ready` are causing timeouts on other endpoints. 
# Test Links:
[Percentile Calculator](https://wps-pr-1934.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1934.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1934.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1934.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1934.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1934.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1934.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1934.apps.silver.devops.gov.bc.ca/fwi-calculator)
