### PR TITLE
more extensive error logging in api/app/wildfire_one/wildfire_fetchers.py

### DIFF
--- a/api/app/wildfire_one/wfwx_api.py
+++ b/api/app/wildfire_one/wfwx_api.py
@@ -318,7 +318,7 @@ async def get_dailies(
     # for local dev, we can use redis to reduce load in prod, and generally just makes development faster.
     # for production, it's more tricky - we don't want to put too much load on the wf1 api, but we don't
     # want stale values either. We default to 5 minutes, or 300 seconds.
-    cache_expiry_seconds = config.get('REDIS_DAILIES_BY_STATION_CODE_CACHE_EXPIRY', 300)
+    cache_expiry_seconds: Final = int(config.get('REDIS_DAILIES_BY_STATION_CODE_CACHE_EXPIRY', 300))
     use_cache = cache_expiry_seconds is not None and config.get('REDIS_USE') == 'True'
 
     dailies_iterator = fetch_paged_response_generator(session, header, BuildQueryDailiesByStationCode(

--- a/api/app/wildfire_one/wildfire_fetchers.py
+++ b/api/app/wildfire_one/wildfire_fetchers.py
@@ -199,8 +199,7 @@ async def fetch_hourlies(
 
     url, params = prepare_fetch_hourlies_query(raw_station, start_timestamp, end_timestamp)
 
-    cache_expiry_seconds = cache_expiry_seconds = config.get(
-        'REDIS_HOURLIES_BY_STATION_CODE_CACHE_EXPIRY', 300)
+    cache_expiry_seconds: Final = int(config.get('REDIS_HOURLIES_BY_STATION_CODE_CACHE_EXPIRY', 300))
 
     # Get hourlies
     if use_cache and cache_expiry_seconds is not None and config.get('REDIS_USE') == 'True':

--- a/api/app/wildfire_one/wildfire_fetchers.py
+++ b/api/app/wildfire_one/wildfire_fetchers.py
@@ -44,6 +44,7 @@ async def _fetch_cached_response(session: ClientSession, headers: dict, url: str
                 text = await response.text()
                 logger.error('response.text() = %s', text)
                 send_rocketchat_notification(f'JSONDecodeError, response.text() = {text}', error)
+                raise
         try:
             if response.status == 200:
                 cache.set(key, json.dumps(response_json).encode(), ex=cache_expiry_seconds)


### PR DESCRIPTION
There's an unhandled error that's showing up in rocket chat, relating to invalid json coming from wf1. I'd like to have more detail about it.
# Test Links:
[Percentile Calculator](https://wps-pr-1939.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1939.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1939.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1939.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1939.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1939.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1939.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1939.apps.silver.devops.gov.bc.ca/fwi-calculator)
