### PR TITLE
Re-enable and fix test with user event

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -92,8 +92,10 @@
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.12",
     "@cypress/instrument-cra": "^1.4.0",
+    "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
+    "@testing-library/user-event": "^14.1.1",
     "@types/jest": "^27.0.2",
     "@types/recharts": "^1.8.23",
     "cypress": "^9.5.4",

--- a/web/src/features/hfiCalculator/components/fireStartsDropdown.test.tsx
+++ b/web/src/features/hfiCalculator/components/fireStartsDropdown.test.tsx
@@ -1,4 +1,5 @@
-import { render, fireEvent, within, waitFor } from '@testing-library/react'
+import { render, within, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import FireStartsDropdown from 'features/hfiCalculator/components/FireStartsDropdown'
 import React from 'react'
 describe('FireStartsDropdown', () => {
@@ -25,7 +26,7 @@ describe('FireStartsDropdown', () => {
     await waitFor(() => expect(input.value).toBe(lowestFireStarts.label))
     await waitFor(() => expect(setFireStartsMock).toBeCalledTimes(0))
   })
-  xit('should change value on change and call parent callback', async () => {
+  it('should change value on change and call parent callback', async () => {
     const setFireStartsMock = jest.fn()
     const { getByTestId } = render(
       <FireStartsDropdown
@@ -40,12 +41,11 @@ describe('FireStartsDropdown', () => {
     const input = within(autocomplete).getByRole('combobox') as HTMLInputElement
 
     autocomplete.focus()
-    // assign value to input field
-    fireEvent.change(input, { target: { value: '2' } })
-    fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
-    fireEvent.keyDown(autocomplete, { key: 'Enter' })
+    userEvent.type(autocomplete, '2')
 
     await waitFor(() => expect(input.value).toBe('2'))
+
+    userEvent.type(autocomplete, '{enter}')
     await waitFor(() => expect(setFireStartsMock).toBeCalledTimes(1))
     await waitFor(() =>
       expect(setFireStartsMock).toBeCalledWith(testAreaId, dayOffset, highestFireStarts)

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3538,6 +3538,20 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
+"@testing-library/dom@^8.13.0":
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
+  integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@testing-library/jest-dom@^5.14.1":
   version "5.14.1"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz#8501e16f1e55a55d675fe73eecee32cdaddb9766"
@@ -3560,6 +3574,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
+
+"@testing-library/user-event@^14.1.1":
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.1.1.tgz#e1ff6118896e4b22af31e5ea2f9da956adde23d8"
+  integrity sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
I left a test x'd in the material UI upgrade and Sy just found it.
Re-eanbled and fixed it by using the recommend `user-event` library for `rtl`
# Test Links:
[Percentile Calculator](https://wps-pr-1948.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1948.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1948.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1948.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1948.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=1108&f=c5&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN#state=2ec784ca-c46a-49d0-b2b3-1cf32a9015a2&session_state=7d9447c8-db66-4661-b4cb-03d2ac0d1d8f&code=32292df4-2bdf-4f90-a4a8-c8dbcda682a9.7d9447c8-db66-4661-b4cb-03d2ac0d1d8f.2b63f390-f3dc-43ae-89f2-016453863476)
[Fire Behaviour Advisory](https://wps-pr-1948.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1948.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1948.apps.silver.devops.gov.bc.ca/fwi-calculator)
