### PR TITLE
Added unit test + link for bad station

### DIFF
--- a/.github/workflows/pr_description.js
+++ b/.github/workflows/pr_description.js
@@ -17,7 +17,7 @@ module.exports = async ({ github, context }) => {
     body += `[MoreCast](${prBaseUrl}/morecast)\n`;
     body += `[C-Haines](${prBaseUrl}/c-haines)\n`;
     body += `[FireBat](${prBaseUrl}/fire-behaviour-calculator)\n`;
-    body += `[FireBat bookmark](${prBaseUrl}/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN)\n`;
+    body += `[FireBat bookmark](${prBaseUrl}/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)\n`;
     body += `[Fire Behaviour Advisory](${prBaseUrl}/fire-behaviour-advisory)\n`;
     body += `[HFI Calculator](${prBaseUrl}/hfi-calculator)\n`;
     body += `[FWI Calculator](${prBaseUrl}/fwi-calculator)\n`;

--- a/web/cypress/integration/fire-behaviour-advisory-calculator-page.spec.ts
+++ b/web/cypress/integration/fire-behaviour-advisory-calculator-page.spec.ts
@@ -131,6 +131,15 @@ describe('FireBAT Calculator Page', () => {
     })
   })
   describe('Row management', () => {
+    it.only('Removes invalid stations', () => {
+      cy.intercept('GET', 'api/stations/*', { fixture: 'weather-stations.json' }).as('getStations')
+      cy.intercept('POST', 'api/fba-calc/stations', req => {
+        // One of our stations (9999) is invalid, so we expect it to be excluded from the request.
+        expect(req.body.stations.length).to.eq(1)
+      }).as('calculateResults')
+      cy.visit(FIRE_BEHAVIOR_CALC_ROUTE + '?s=322&f=c1&c=1&w=2,s=9999&f=c1&c=1&w=2')
+      cy.wait('@calculateResults')
+    })
     it('Disables remove row(s) button when table is empty', () => {
       cy.intercept('GET', 'api/stations/*', { fixture: 'weather-stations.json' }).as('getStations')
       cy.visit(FIRE_BEHAVIOR_CALC_ROUTE)

--- a/web/cypress/integration/fire-behaviour-advisory-calculator-page.spec.ts
+++ b/web/cypress/integration/fire-behaviour-advisory-calculator-page.spec.ts
@@ -131,7 +131,7 @@ describe('FireBAT Calculator Page', () => {
     })
   })
   describe('Row management', () => {
-    it.only('Removes invalid stations', () => {
+    it('Removes invalid stations', () => {
       cy.intercept('GET', 'api/stations/*', { fixture: 'weather-stations.json' }).as('getStations')
       cy.intercept('POST', 'api/fba-calc/stations', req => {
         // One of our stations (9999) is invalid, so we expect it to be excluded from the request.


### PR DESCRIPTION
I've revised my opinion on the previous fix being a "band-aid". I think this is actually the best place. Removing the row entirely after loading stations is a bit weird, because the row just disappears. Getting the row to stay, and to load the others would actually be a lot of work. Much simpler to just exclude it from the fetch.

- added unit test
- added invalid station code into test link
# Test Links:
[Percentile Calculator](https://wps-pr-1977.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1977.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1977.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1977.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1977.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Fire Behaviour Advisory](https://wps-pr-1977.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1977.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1977.apps.silver.devops.gov.bc.ca/fwi-calculator)
