### PR TITLE
C7B data bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2022-05-04 HFI Calc - C7B bug (C7B was being calculated as C7)
+
+### Bug
+
+- Fixed [#1981](https://github.com/bcgov/wps/issues/1981): C7B fuel type lookup looking was wrong, causing C7 calculations.
+
 ## 2022-04-28 Fire Behaviour Calc - 422 bug caused by missing station
 
 ### Bug

--- a/api/alembic/versions/16386a52d7bf_update_c7b.py
+++ b/api/alembic/versions/16386a52d7bf_update_c7b.py
@@ -1,0 +1,25 @@
+"""Update C7B
+
+Revision ID: 16386a52d7bf
+Revises: 82cc8ffa75ce
+Create Date: 2022-05-04 13:46:16.589667
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '16386a52d7bf'
+down_revision = '82cc8ffa75ce'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Change fuel type code to C7B where abbrev is C7B
+    op.execute('UPDATE fuel_types SET fuel_type_code = \'C7B\' WHERE abbrev LIKE \'C7B\'')
+
+
+def downgrade():
+    op.execute('UPDATE fuel_types SET fuel_type_code = \'C7\' WHERE abbrev LIKE \'C7B\'')

--- a/api/alembic/versions/16386a52d7bf_update_c7b.py
+++ b/api/alembic/versions/16386a52d7bf_update_c7b.py
@@ -22,4 +22,5 @@ def upgrade():
 
 
 def downgrade():
+    # Change fuel type code back to C7 where abbrev is C7B
     op.execute('UPDATE fuel_types SET fuel_type_code = \'C7\' WHERE abbrev LIKE \'C7B\'')


### PR DESCRIPTION
Fuel type in database was incorrect - C7B was being translated to C7.
# Test Links:
[Percentile Calculator](https://wps-pr-1984.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-1984.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-1984.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-1984.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-1984.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Fire Behaviour Advisory](https://wps-pr-1984.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-1984.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-1984.apps.silver.devops.gov.bc.ca/fwi-calculator)
