### PR TITLE
Added Alembic migration for deleting Bear Lake from PGFC

### DIFF
--- a/api/alembic/versions/ac65354014bd_remove_bear_lake_station.py
+++ b/api/alembic/versions/ac65354014bd_remove_bear_lake_station.py
@@ -34,7 +34,7 @@ def downgrade():
     # fire centre is Prince George FC, planning area is Prince George Zone
     res = conn.execute('SELECT id FROM planning_areas WHERE name LIKE {}'.format('\'Prince George Zone%%\''))
     results = res.fetchall()
-    planning_area_id = str(results[0]).replace('(', '').replace(',', '').replace(')', '')
+    planning_area_id = results[0][0]
 
     # order_of_appearance_in_planning_area_list is 4
     op.execute(

--- a/api/alembic/versions/ac65354014bd_remove_bear_lake_station.py
+++ b/api/alembic/versions/ac65354014bd_remove_bear_lake_station.py
@@ -1,0 +1,41 @@
+"""Remove Bear Lake station from planning_area_stations
+for Prince George Fire Centre. 
+Bear Lake station (code 149) no longer exists in WFWX and is causing problems in prod.
+
+Revision ID: ac65354014bd
+Revises: 16386a52d7bf
+Create Date: 2022-05-12 12:31:45.944743
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm.session import Session
+
+
+# revision identifiers, used by Alembic.
+revision = 'ac65354014bd'
+down_revision = '16386a52d7bf'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('DELETE FROM planning_weather_stations WHERE station_code = 149')
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    # default fuel type for Bear Lake is C3
+    res = conn.execute('SELECT id FROM fuel_types WHERE abbrev LIKE \'C3\'')
+    results = res.fetchall()
+    fuel_type_id = str(results[0]).replace('(', '').replace(',', '').replace(')', '')
+
+    # fire centre is Prince George FC, planning area is Prince George Zone
+    res = conn.execute('SELECT id FROM planning_areas WHERE name LIKE {}'.format('\'Prince George Zone%%\''))
+    results = res.fetchall()
+    planning_area_id = str(results[0]).replace('(', '').replace(',', '').replace(')', '')
+
+    # order_of_appearance_in_planning_area_list is 4
+    op.execute(
+        'INSERT INTO planning_weather_stations (station_code, fuel_type_id, planning_area_id, order_of_appearance_in_planning_area_list) VALUES (149, {}, {}, 4)'.format(fuel_type_id, planning_area_id))


### PR DESCRIPTION
Easy fix for one of the critical bugs in HFI Calc affecting PGFC: remove Bear Lake weather station from planning_weather_stations table.

Doing this means that M/FIG & Prep Level are now calculated as expected for Prince George Zone.

Note that this hasn't fixed the jank in PGFC's PDF. Don't know the cause of that.
# Test Links:
[Percentile Calculator](https://wps-pr-2025.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2025.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2025.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2025.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2025.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Fire Behaviour Advisory](https://wps-pr-2025.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-2025.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2025.apps.silver.devops.gov.bc.ca/fwi-calculator)
