### PR TITLE
Use eslint for typescript/javascript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,25 +23,15 @@
     "eslint.format.enable": true,
     "eslint.validate": [
         "javascript",
-        "typescript"
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
     ],
     "eslint.run": "onSave",
     "[python]": {
         "editor.rulers": [
             120
         ]
-    },
-    "[javascript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.tabSize": 2
-    },
-    "[typescript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.tabSize": 2
-    },
-    "[typescriptreact]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.tabSize": 2
     },
     "[yaml]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
Fixes prettier running as default formatter when you run `yarn start`
# Test Links:
[Percentile Calculator](https://wps-pr-2026.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2026.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2026.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2026.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2026.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Fire Behaviour Advisory](https://wps-pr-2026.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-2026.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2026.apps.silver.devops.gov.bc.ca/fwi-calculator)
