### PR TITLE
test that wind speed override results in fwi update on response

### DIFF
--- a/api/app/tests/fba_calc/c1_request_ws_override.json
+++ b/api/app/tests/fba_calc/c1_request_ws_override.json
@@ -1,0 +1,13 @@
+{
+    "date": "2021-07-05",
+    "stations": [
+        {
+            "id": 0,
+            "station_code": 230,
+            "fuel_type": "C1",
+            "crown_base_height": 2,
+            "percentage_conifer": 100,
+            "wind_speed": 20
+        }
+    ]
+}

--- a/api/app/tests/fba_calc/c1_response_ws_override.json
+++ b/api/app/tests/fba_calc/c1_response_ws_override.json
@@ -1,0 +1,38 @@
+{
+    "date": "2021-07-05",
+    "stations": [
+        {
+            "id": 0,
+            "station_code": 230,
+            "station_name": "HORSEFLY",
+            "zone_code": "C3",
+            "elevation": 701,
+            "fuel_type": "C1",
+            "status": "ADJUSTED",
+            "temp": 25.2,
+            "rh": 31.0,
+            "wind_direction": 282,
+            "wind_speed": 20.0,
+            "precipitation": 0.0,
+            "grass_cure": null,
+            "fine_fuel_moisture_code": 91.00282372367012,
+            "drought_code": 340.544,
+            "initial_spread_index": 13.554947624318125,
+            "build_up_index": 117.899,
+            "duff_moisture_code": 103.923,
+            "fire_weather_index": 41.295521580139784,
+            "head_fire_intensity": 5031.742103269186,
+            "rate_of_spread": 8.301304058597559,
+            "fire_type": "IC",
+            "percentage_crown_fraction_burned": 0.7993874667752983,
+            "flame_length": 4.095421062304089,
+            "sixty_minute_fire_size": 5.553027144762176,
+            "thirty_minute_fire_size": 1.0009932672530117,
+            "critical_hours_hfi_4000": {
+                "start": 16.0,
+                "end": 18.0
+            },
+            "critical_hours_hfi_10000": null
+        }
+    ]
+}

--- a/api/app/tests/fba_calc/test_fba.feature
+++ b/api/app/tests/fba_calc/test_fba.feature
@@ -11,6 +11,7 @@ Feature: /fbc/
         Examples:
             | request_json                  | status_code | response_json                           |
             | c1_request.json               | 200         | fba_calc/c1_response.json               |
+            | c1_request_ws_override.json   | 200         | fba_calc/c1_response_ws_override.json   |
             | c1_request_no_daily_data.json | 200         | fba_calc/c1_response_no_daily_data.json |
             | c1_request_forecast.json      | 200         | fba_calc/c1_response_forecast.json      |
             | c1_request_multiple.json      | 200         | fba_calc/c1_response_multiple.json      |


### PR DESCRIPTION
Add a test where the wind speed is overridden. This checks not only that FWI is re-calculated, but that all other values are also adjusted.
# Test Links:
[Percentile Calculator](https://wps-pr-2047.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2047.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2047.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2047.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2047.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Fire Behaviour Advisory](https://wps-pr-2047.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-2047.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2047.apps.silver.devops.gov.bc.ca/fwi-calculator)
