### PR TITLE
Get docker working for M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ docker-build:
 	# Build dev docker images.
 	# Having issues? try: docker volume prune
 	# Still having issues? try: docker system prune
-	docker-compose build
+	docker compose build
 
 docker-run:
 	# Run docker in dev mode.
-	docker-compose up
+	docker compose up
 
 docker-db:
 	# Run the database
@@ -22,10 +22,10 @@ docker-web-server:
 	docker run -p 3000:3000 wps/web
 
 docker-shell-api:
-	# Shell into the dev container.
-	docker-compose run --rm api bash
+	# Shell into the running dev container.
+	docker compose exec api bash
 
 docker-shell-web:
-	# Shell into the dev container.
+	# Shell into the running dev container.
 	# docker run -it --env-file app/.env --entrypoint bash wps-api_api:latest
-	docker-compose run --rm web bash
+	docker compose exec web bash

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docker-run:
 
 docker-db:
 	# Run the database
-	docker-compose up db
+	docker compose up db
 
 docker-web-server-build:
 	# Build the web in server mode (same dockerfile as used in production)

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,12 +1,22 @@
 # NOTE:
 # This Dockerfile is for local development only!
 
-FROM python:3.8.12-buster
+# debian would match more closely what we have in production, and would probably be ideal,
+# but it's also a pain working with because debian is so old.
+FROM ubuntu:22.04
 
-# wildfire one may have an old certificate, so we have to make debian more forgiving.
-# RUN sed -i 's/TLSv1.2/TLSv1.0/g' /etc/ssl/openssl.cnf
+ARG USERNAME=worker
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
 
-# Install dependancies need by python developer packages
+# Tell r-base not to wait for interactive input.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependancies needed by python developer packages
+# One should really run all these installs and the update in one go - for a consistent install
+# but ease of development trumps consistency in this instance: it's easer to have more
+# faster running steps that can fail, that one big monster install that takes forever 
+# and fails.
 # NOTE: Once we no longer need pyodbc, please remove the apt-get update and install commands below.
 RUN apt-get -y update
 RUN apt-get -y install unixodbc-dev
@@ -19,39 +29,44 @@ RUN apt-get update --fix-missing && apt-get -y install r-base
 # Install cffdrs
 RUN R -e "install.packages('cffdrs')"
 
+# Install some other dependancies
+RUN apt-get -y install git build-essential python3 python3-dev python3-pip curl vim
+
 # Install JDK
 RUN apt-get -y install openjdk-11-jdk
 
-# Install pdf-kit for PDF generation on HFI (with qt support!)
-# As of writing, 0.12.6 (the most recent) is the version currently being installed by 3.8.12-buster,
-# but without qt. We do a manual instllation of 0.12.6 in order to get qt support.
-RUN apt-get update --fix-missing && apt-get -y install xfonts-75dpi xfonts-base
-RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb -P /tmp && \
-    dpkg -i /tmp/wkhtmltox_0.12.6-1.buster_amd64.deb
+# We could install poetry manually, but it's easier to use apt.
+RUN apt-get -y install python3-poetry
+# Poetry expects "python", but by default, on ubuntu, you need to specify "python3", so
+# we work around that, by using the python3-poetry command.
+RUN apt-get -y install python-is-python3
 
-# Update pip
-RUN python -m pip install --upgrade pip
+# from: https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
 
-# Install gdal
-# We don't have much control over what version of gdal we're getting, it's pretty much whatever is
-# available to us. As such, gdal is not installed by poetry, since the version will differ between
-# platforms.
-RUN python -m pip install gdal==$(gdal-config --version)
-
-# Install poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
-    cd /usr/local/bin && \
-    ln -s /opt/poetry/bin/poetry && \
-    poetry config virtualenvs.create false
-
-# Copy poetry files.
-COPY pyproject.toml poetry.lock /tmp/
-
-# Install dependancies.
-RUN cd /tmp && \
-    poetry install --no-root
+RUN mkdir /app
+RUN chown worker /app
+USER worker
+ENV PATH="/home/worker/.local/bin:${PATH}"
 
 WORKDIR /app
+
+# Update pip
+RUN python3 -m pip install --upgrade pip
+
+# Copy poetry files.
+COPY pyproject.toml poetry.lock ./
+
+COPY --chown=worker:worker poetry.lock pyproject.toml ./
+RUN python3 -m pip install cachecontrol
+
+RUN poetry install
+
+# We can't have this inside pyproject.toml because the gdal version differs from platform to platform.
+# To figure out what version of pygdal you need, run gdal-config
+RUN poetry run python -m pip install pygdal==3.4.1.10
+
 COPY ./app /app/app
 RUN mkdir /app/libs
 COPY ./libs /app/libs
@@ -59,4 +74,5 @@ COPY ./libs /app/libs
 EXPOSE 8080
 
 ENV CLASSPATH=/app/libs/REDapp_Lib.jar:/app/libs/WTime.jar:/app/libs/hss-java.jar:${CLASSPATH}
-CMD uvicorn app.main:app --reload --host 0.0.0.0 --port 8080
+CMD PYTHONPATH=. poetry run alembic upgrade head && poetry run uvicorn app.main:app --host 0.0.0.0 --reload --port 8080
+

--- a/api/Makefile
+++ b/api/Makefile
@@ -149,7 +149,7 @@ docker-build:
 	# Build dev docker images.
 	# Having issues? try: docker volume prune
 	# Still having issues? try: docker system prune
-	docker-compose build
+	docker compose build
 
 docker-lint:
 	# Run linting in docker (dev instance).
@@ -160,7 +160,7 @@ docker-test:
 	# We use the dev instance, because the "production" version doesn't have
 	# a number of the development dependancies.
 	# Make sure that your docker pycache doesn't conflict with your local pycache.
-	docker-compose run --rm api pytest -x -n 3 app
+	docker compose run --rm api pytest -x -n 3 app
 
 docker-test-coverage:
 	# Run tests with coverage in docker (dev instance).
@@ -169,39 +169,39 @@ docker-test-coverage:
 docker-shell:
 	# Shell into the dev container.
 	# docker run -it --env-file app/.env --entrypoint bash wps-api_api:latest
-	docker-compose run --rm api bash
+	docker compose run --rm api bash
 
 docker-run:
 	# Run docker in dev mode.
-	docker-compose up
+	docker compose up
 
 docker-shell-db:
 	# Shell into the db container
-	docker-compose exec db psql -h db -U wps
+	docker compose exec db psql -h db -U wps
 
 docker-redis:
 	# Start up a local Redis service within docker container
-	docker-compose up redis
+	docker compose up redis
 
 docker-run-env-canada:
 	# Run a python script to download model data from Env Canada on docker
 	# Needs to run "make docker-run" first
-	docker-compose exec api python -m app.weather_models.env_canada GDPS
-	docker-compose exec api python -m app.weather_models.env_canada HRDPS
-	docker-compose exec api python -m app.weather_models.env_canada RDPS
+	docker compose exec api python -m app.weather_models.env_canada GDPS
+	docker compose exec api python -m app.weather_models.env_canada HRDPS
+	docker compose exec api python -m app.weather_models.env_canada RDPS
 
 docker-run-noon-forecasts:
 	# Run a python script to download forecast data from BC Wild Fire on docker
 	# Needs to run "make docker-run" first
-	docker-compose exec api python -m app.jobs.noon_forecasts
+	docker compose exec api python -m app.jobs.noon_forecasts
 
 docker-run-hourly-actuals:
 	# Run a python script to download hourly actuals from BC Wild Fire on docker.
 	# Needs to run "make docker-run" first
-	docker-compose exec api python -m app.jobs.hourly_actuals
+	docker compose exec api python -m app.jobs.hourly_actuals
 
 database-upgrade:
 	PYTHONPATH=. $(POETRY_RUN) alembic upgrade head
 
 docker-database-upgrade:
-	docker-compose exec -e PYTHONPATH=. api alembic upgrade head
+	docker compose exec -e PYTHONPATH=. api alembic upgrade head

--- a/api/README.md
+++ b/api/README.md
@@ -10,18 +10,6 @@ Wildfire Predictive Services Unit support decision making in prevention, prepare
 
 - Docker [Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac/), [Win](https://hub.docker.com/editions/community/docker-ce-desktop-windows/), [Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/), [Fedora](https://docs.docker.com/install/linux/docker-ce/fedora/)
 
-- Docker Compose
-
-```bash
-brew install docker-compose
-```
-
-OR
-
-```bash
-pip install docker-compose
-```
-
 ### Installing
 
 You will need an environment file. See: .env.example.
@@ -31,7 +19,7 @@ You will need an environment file. See: .env.example.
 For local development, you can copy .env.example to .env.docker.
 
 ```bash
-docker-compose build
+docker compose build
 ```
 
 #### Local machine, running MacOS
@@ -193,7 +181,7 @@ make docker-run
 will execute:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 #### Local machine, running mac os

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -5,7 +5,7 @@ description = "Wildfire Predictive Services Unit API"
 authors = ["Sybrand Strauss <sybrand.strauss@gov.bc.ca>"]
 
 [tool.poetry.dependencies]
-python = ">=3.8.10,<3.10"
+python = ">=3.8.10,<3.11"
 fastapi = "^0"
 requests = "^2"
 aiodns = "^3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - python_cache:/app/python_cache
     networks:
       - wps_network
-    command: bash -c "PYTHONPATH=. alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --reload --port 8080"
+    # command: bash -c "PYTHONPATH=. poetry run alembic upgrade head && poetry run uvicorn app.main:app --host 0.0.0.0 --reload --port 8080"
   redis:
     image: redis
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - python_cache:/app/python_cache
     networks:
       - wps_network
-    # command: bash -c "PYTHONPATH=. poetry run alembic upgrade head && poetry run uvicorn app.main:app --host 0.0.0.0 --reload --port 8080"
+    command: bash -c "PYTHONPATH=. poetry run alembic upgrade head && poetry run uvicorn app.main:app --host 0.0.0.0 --reload --port 8080"
   redis:
     image: redis
     ports:

--- a/web/README.md
+++ b/web/README.md
@@ -62,7 +62,7 @@ It correctly bundles React in production mode and optimizes the build for the be
 ##### Running the application in docker:
 
 1. Create `.env` file at root using `.env.example` as a sample
-2. Run `docker-compose build` and then `docker-compose up`
+2. Run `docker compose build` and then `docker compose up`
 3. Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 ## Config


### PR DESCRIPTION
- Change Dockerfile base image - buster didn't have M1 compatible image  (also easer i.m.h.o. to work with Ubuntu for local development)
- Make a number of changes to get python to run as non root
- Updated some "docker compose" commands - "docker-compose" is now redundant, compose is build into latest versions of docker.
- Allowing a more recent version of python, we need to update to the latest version of python across our base anyway!
# Test Links:
[Percentile Calculator](https://wps-pr-2250.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2250.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2250.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2250.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2250.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Fire Behaviour Advisory](https://wps-pr-2250.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-2250.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2250.apps.silver.devops.gov.bc.ca/fwi-calculator)
