### PR TITLE
Task/update pipeline

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.1.11"
+          key: "poetry-installer-1.2.0"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.1.11
+          python install-poetry.py --version 1.2.0
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config experimental.new-installer false
@@ -55,6 +55,10 @@ jobs:
           key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
             ${{ runner.os }}-poetry-cache-
+      - name: Install numpy
+        working-directory: ./api
+        run: |
+          poetry run pip install numpy
       - name: Install python dependencies using poetry (api)
         working-directory: ./api
         run: |
@@ -74,7 +78,6 @@ jobs:
         # gdal, but it now has a bug that causes it to fail to install on ubuntu20.04)
         working-directory: ./api
         run: |
-          poetry run pip install numpy
           poetry run pip install pygdal==3.0.4.10
       - name: Lint (api)
         # We used to be able to do linting before installing gdal, but it's not possible anymore.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -211,7 +211,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.2.0"
+          key: "poetry-installer-1.1.11"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -221,7 +221,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.2.0
+          python install-poetry.py --version 1.1.11
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config experimental.new-installer false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6.15]
+        python-version: [3.8]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -211,7 +211,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.1.11"
+          key: "poetry-installer-1.2.0"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -221,7 +221,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.1.11
+          python install-poetry.py --version 1.2.0
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config experimental.new-installer false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.2.0
+          python install-poetry.py --version 1.1.11
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config experimental.new-installer false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,10 +55,6 @@ jobs:
           key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
             ${{ runner.os }}-poetry-cache-
-      - name: Install numpy
-        working-directory: ./api
-        run: |
-          poetry run pip install numpy
       - name: Install python dependencies using poetry (api)
         working-directory: ./api
         run: |
@@ -78,6 +74,7 @@ jobs:
         # gdal, but it now has a bug that causes it to fail to install on ubuntu20.04)
         working-directory: ./api
         run: |
+          poetry run pip install numpy
           poetry run pip install pygdal==3.0.4.10
       - name: Lint (api)
         # We used to be able to do linting before installing gdal, but it's not possible anymore.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.1.11
+          python install-poetry.py --version 1.2.0
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config experimental.new-installer false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.6.15]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -208,7 +208,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.2.0"
+          key: "poetry-installer-1.1.11"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -218,7 +218,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.2.0
+          python install-poetry.py --version 1.1.11
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config experimental.new-installer false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -109,7 +109,6 @@ jobs:
         working-directory: ./api
         run: |
           export LD_LIBRARY_PATH=$(poetry run python -m rpy2.situation LD_LIBRARY_PATH):${LD_LIBRARY_PATH}
-          export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6:/$LD_PRELOAD
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATHpoetry
           export ORIGINS=testorigin
           poetry run coverage run --source=app -m pytest -x -o log_cli=true --disable-warnings -vvv
@@ -212,7 +211,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.1.11"
+          key: "poetry-installer-1.2.0"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -222,7 +221,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.1.11
+          python install-poetry.py --version 1.2.0
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
       # poetry cache folder: /home/runner/.cache/pypoetry

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           echo
           mkdir ~/poetry_installer
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py > ~/poetry_installer/install-poetry.py
+          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
@@ -217,13 +217,14 @@ jobs:
         run: |
           echo
           mkdir ~/poetry_installer
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py > ~/poetry_installer/install-poetry.py
+          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
           python install-poetry.py --version 1.2.0
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
+          poetry config experimental.new-installer false
       # poetry cache folder: /home/runner/.cache/pypoetry
       - name: Cache poetry
         uses: actions/cache@v3

--- a/.github/workflows/post_merge_integration.yml
+++ b/.github/workflows/post_merge_integration.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo
           mkdir ~/poetry_installer
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py > ~/poetry_installer/install-poetry.py
+          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer

--- a/.github/workflows/post_merge_integration.yml
+++ b/.github/workflows/post_merge_integration.yml
@@ -32,7 +32,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.1.11"
+          key: "poetry-installer-1.2.0"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -42,7 +42,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.1.11
+          python install-poetry.py --version 1.2.0
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config experimental.new-installer false

--- a/openshift/s3-backup/docker/pyproject.toml
+++ b/openshift/s3-backup/docker/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Sybrand Strauss <sybrand.strauss@gov.bc.ca>"]
 license = "Apache License, Version 2.0, January 2004"
 
 [tool.poetry.dependencies]
-python = ">=3.6.8,<=3.6.15"
+python = ">=3.8"
 aiobotocore = "^2.0.0"
 python-decouple = "^3.5"
 

--- a/openshift/s3-backup/docker/pyproject.toml
+++ b/openshift/s3-backup/docker/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Sybrand Strauss <sybrand.strauss@gov.bc.ca>"]
 license = "Apache License, Version 2.0, January 2004"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.6.8,<=3.6.15"
 aiobotocore = "^2.0.0"
 python-decouple = "^3.5"
 


### PR DESCRIPTION
- Bump poetry from 1.1.11 to 1.2.0
    - Matches the currently running `wps-api-base:latest`, to be committed in follow up PR
- Use official poetry download link: https://python-poetry.org/docs/#installing-with-the-official-installer
- Removes unnecessary `export LD_PRELOAD`
- Keep backup job at py 3.6 and poetry 1.1.11 since it's base image uses that python version, and poetry 1.2.0 fails to install with py>3.6

# Test Links:
[Percentile Calculator](https://wps-pr-2270.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2270.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2270.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2270.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2270.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Fire Behaviour Advisory](https://wps-pr-2270.apps.silver.devops.gov.bc.ca/fire-behaviour-advisory)
[HFI Calculator](https://wps-pr-2270.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2270.apps.silver.devops.gov.bc.ca/fwi-calculator)
