### PR TITLE
Add cli/default users for nats

### DIFF
--- a/api/app/auto_spatial_advisory/nats_consumer.py
+++ b/api/app/auto_spatial_advisory/nats_consumer.py
@@ -54,7 +54,11 @@ async def run():
         closed_cb=closed_cb,
     )
     jetstream = nats_connection.jetstream()
-
+    # we create a stream, this is important, we need to messages to stick around for a while!
+    # idempotent operation, IFF stream with same configuration is added each time
+    await jetstream.add_stream(name=stream_name,
+                               config=StreamConfig(retention=RetentionPolicy.WORK_QUEUE),
+                               subjects=subjects)
     sfms_sub = await jetstream.pull_subscribe(stream=stream_name,
                                               subject=sfms_file_subject,
                                               durable=hfi_classify_durable_group)

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -73,13 +73,13 @@ objects:
             cli: { 
                 jetstream: enable
                 users: [
-                    {user: cli, password: cli}
+                    {user: cli, password: cli, permissions: {publish: ">", subscribe: ">"}}
                   ]
             },
             consumer: { 
                 jetstream: enable
                 users: [
-                    {user: consumer, password: consumer}
+                    {user: consumer, password: consumer, permissions: {publish: ">", subscribe: ">"}}
                   ]
             } 
         }

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -75,8 +75,15 @@ objects:
                 users: [
                     {user: cli, password: cli}
                   ]
-            }
+            },
+            consumer: { 
+                jetstream: enable
+                users: [
+                    {user: consumer, password: consumer}
+                  ]
+            } 
         }
+        no_auth_user: consumer
         leafnodes {
           port: 7422
         }

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -69,6 +69,7 @@ objects:
             cluster_advertise: $CLUSTER_ADVERTISE
             connect_retries: 50
         }
+        $SYS { users = [ { user: "cli", pass: "cli" } ] }
         leafnodes {
           port: 7422
         }

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -70,14 +70,13 @@ objects:
             connect_retries: 50
         }
         accounts: {
-            SYS: { 
+            cli: { 
                 jetstream: enable
                 users: [
                     {user: cli, password: cli}
                   ]
             }
         }
-        system_account: SYS
         leafnodes {
           port: 7422
         }

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -71,6 +71,7 @@ objects:
         }
         accounts: {
             SYS: { 
+                jetstream: enable
                 users: [
                     {user: cli, password: cli}
                   ]

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -69,7 +69,14 @@ objects:
             cluster_advertise: $CLUSTER_ADVERTISE
             connect_retries: 50
         }
-        $SYS { users = [ { user: "cli", pass: "cli" } ] }
+        accounts: {
+            SYS: { 
+                users: [
+                    {user: cli, password: cli}
+                  ]
+            }
+        }
+        system_account: SYS
         leafnodes {
           port: 7422
         }


### PR DESCRIPTION
Nats introduced accounts to auth pods. I added one for connecting via CLI and a default one for publisher/consumer.

See:
- https://docs.nats.io/running-a-nats-service/configuration/securing_nats/authorization
- https://github.com/nats-io/nats-server/issues/1713

# Test Links:
[Percentile Calculator](https://wps-pr-2431.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2431.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2431.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2431.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2431.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2431.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2431.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2431.apps.silver.devops.gov.bc.ca/fwi-calculator)
