### PR TITLE
Nginx logs to stdout

### DIFF
--- a/openshift/templates/tileserv/README.md
+++ b/openshift/templates/tileserv/README.md
@@ -34,6 +34,11 @@ https://github.com/CrunchyData/pg_tileserv
 - Run with `docker run -dit -e DATABASE_URL=postgresql://tileserv:tileserv@host.docker.internal/tileserv pg_tileserv`
   Note: May not run with mac m1 machines since `pg_tileserv` is only built for platform `linux/amd64`
 
+### Nginx build
+
+- Shouldn't need to be built often besides updates
+- Make any changes then run `oc -n e1e498-tools start-build nginx-tileserv --from-dir .` while in this folder
+
 ## Deployment
 
 See `deploy-tileserv` job defined in `.github/workflows/deployment.yml`

--- a/openshift/templates/tileserv/nginx.conf
+++ b/openshift/templates/tileserv/nginx.conf
@@ -20,7 +20,7 @@ http {
                     '"$http_referer" "$http_user_agent" '
                     'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log /dev/stdout main;
 
     sendfile        on;
     tcp_nopush      on;


### PR DESCRIPTION
- So we can see them, then they should be indexed in Kibana
- E.g: https://console.apps.silver.devops.gov.bc.ca/k8s/ns/e1e498-dev/pods/wps-tileserv-pr-2469-1-bvddd/logs
# Test Links:
[Percentile Calculator](https://wps-pr-2469.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2469.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2469.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2469.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2469.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2469.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2469.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2469.apps.silver.devops.gov.bc.ca/fwi-calculator)
