### PR TITLE
Renovate: Run every day @ 2am but only create PRs on the weekend

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,7 @@ name: Renovate
 on:
   schedule:
     # Scheduled workflows run on the latest commit on the default or base branch.
-    - cron: "0 2 * * 0"
+    - cron: "0 2 * * *"
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/renovate.json
+++ b/renovate.json
@@ -56,5 +56,9 @@
     "enabled": true
   },
   "autodiscover": true,
-  "autodiscoverFilter": "bcgov/wps"
+  "autodiscoverFilter": "bcgov/wps",
+  "rebaseWhen": "behind-base-branch",
+  "schedule": [
+    "every weekend"
+  ]
 }


### PR DESCRIPTION
- There are lots of "noisy" packages updating patch versions all the time (github actions, etc.) and renovate will create PRs at any time
- This changes the renovate package scanning schedule to every day @2am, but restricting PR creation to the weekend so we don't get new PRs all the time
- Renovate will now also rebase existing PRs anytime it's behind the `main` branch
# Test Links:
[Percentile Calculator](https://wps-pr-2475.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2475.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2475.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2475.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2475.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2475.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2475.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2475.apps.silver.devops.gov.bc.ca/fwi-calculator)
