### PR TITLE
Ignore axios

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "ignorePaths": [
     "openshift/s3-backup/docker/poetry.lock"
   ],
+  "ignoreDeps": [
+    "axios"
+  ],
   "onboardingConfig": {
     "extends": [
       "config:base"


### PR DESCRIPTION
We have a ticket to upgrade axios to v1 in the backlog, which will allow us to avoid breaking changes of their API.

Right now since axios is under v1, the updates contain a lot of breaking changes, and our grouped updates fail because of it. So until we finish this task: https://github.com/orgs/bcgov/projects/23/views/1 we'll ask Renovate to ignore it.
# Test Links:
[Percentile Calculator](https://wps-pr-2491.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2491.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2491.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2491.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2491.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2491.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2491.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2491.apps.silver.devops.gov.bc.ca/fwi-calculator)
