### PR TITLE
Don't deploy for renovate bot user

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -101,7 +101,7 @@ jobs:
 
   deploy-dev:
     name: Deploy to Dev
-    if: github.actor != 'renovate'
+    if: github.triggering_actor != 'renovate'
     needs:
       [build-api-image, build-web-image, prepare-dev-database, deploy-dev-queue]
     runs-on: ubuntu-22.04
@@ -152,7 +152,7 @@ jobs:
 
   deploy-tileserv:
     name: Deploy tileserv to Dev
-    if: github.actor != 'renovate'
+    if: github.triggering_actor != 'renovate'
     runs-on: ubuntu-22.04
     # We need
     # - the image to be built before we can deploy.
@@ -174,7 +174,7 @@ jobs:
 
   deploy-dev-queue:
     name: Deploy Message Queue to Dev
-    if: github.actor != 'renovate'
+    if: github.triggering_actor != 'renovate'
     runs-on: ubuntu-22.04
     # We need
     # - the image to be built before we can deploy.
@@ -212,7 +212,7 @@ jobs:
 
   deploy-c-haines:
     name: Deploy c-haines cronjob
-    if: github.actor != 'renovate'
+    if: github.triggering_actor != 'renovate'
     runs-on: ubuntu-22.04
     # We need
     # - the image to be built before we can deploy.
@@ -254,7 +254,7 @@ jobs:
 
   deploy-test:
     name: Deploy to Test
-    if: github.actor != 'renovate'
+    if: github.triggering_actor != 'renovate'
     needs: [build-api-image, build-web-image, prepare-test-database]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -101,6 +101,7 @@ jobs:
 
   deploy-dev:
     name: Deploy to Dev
+    if: github.actor != 'renovate'
     needs:
       [build-api-image, build-web-image, prepare-dev-database, deploy-dev-queue]
     runs-on: ubuntu-22.04
@@ -151,6 +152,7 @@ jobs:
 
   deploy-tileserv:
     name: Deploy tileserv to Dev
+    if: github.actor != 'renovate'
     runs-on: ubuntu-22.04
     # We need
     # - the image to be built before we can deploy.
@@ -172,6 +174,7 @@ jobs:
 
   deploy-dev-queue:
     name: Deploy Message Queue to Dev
+    if: github.actor != 'renovate'
     runs-on: ubuntu-22.04
     # We need
     # - the image to be built before we can deploy.
@@ -209,6 +212,7 @@ jobs:
 
   deploy-c-haines:
     name: Deploy c-haines cronjob
+    if: github.actor != 'renovate'
     runs-on: ubuntu-22.04
     # We need
     # - the image to be built before we can deploy.
@@ -250,6 +254,7 @@ jobs:
 
   deploy-test:
     name: Deploy to Test
+    if: github.actor != 'renovate'
     needs: [build-api-image, build-web-image, prepare-test-database]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Only run deployment jobs if the actor is not `renovate`

Github context `triggering_actor` is the user who triggered the workflow run: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability

GHA conditionals: https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution

We can still re-trigger these jobs manually.
# Test Links:
[Percentile Calculator](https://wps-pr-2506.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2506.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2506.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2506.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2506.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2506.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2506.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2506.apps.silver.devops.gov.bc.ca/fwi-calculator)
