### PR TITLE
Move builds to openshift, update workflows to use poetry 1.3.1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.2.1"
+          key: "poetry-installer-1.3.1"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -40,7 +40,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.2.1
+          python install-poetry.py --version 1.3.1
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
       - name: Cache poetry
@@ -49,15 +49,15 @@ jobs:
           cache-name: cache-poetry
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.2.1-cache-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-poetry-1.3.1-cache-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-poetry-1.2.1-cache-
+            ${{ runner.os }}-poetry-1.3.1-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v3
         with:
           path: ~/work/wps/wps/api/.venv
-          key: ${{ runner.os }}-venv-poetry-1.2.1-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-venv-poetry-1.3.1-${{ hashFiles('**/poetry.lock') }}
       - name: Install python dependencies using poetry (api)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
@@ -103,7 +103,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.2.1"
+          key: "poetry-installer-1.3.1"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -113,7 +113,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.2.1
+          python install-poetry.py --version 1.3.1
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
       # poetry cache folder: /home/runner/.cache/pypoetry
@@ -123,15 +123,15 @@ jobs:
           cache-name: cache-poetry
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.2.1-cache-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-poetry-1.3.1-cache-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-poetry-1.2.1-cache-
+            ${{ runner.os }}-poetry-1.3.1-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v3
         with:
           path: ~/work/wps/wps/api/.venv
-          key: ${{ runner.os }}-venv-poetry-1.2.1-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-venv-poetry-1.3.1-${{ hashFiles('**/poetry.lock') }}
       - name: Install python dependencies using poetry (api)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api

--- a/.github/workflows/post_merge_integration.yml
+++ b/.github/workflows/post_merge_integration.yml
@@ -31,7 +31,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.2.1"
+          key: "poetry-installer-1.3.1"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.2.1
+          python install-poetry.py --version 1.3.1
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
       - name: Cache poetry
@@ -50,15 +50,15 @@ jobs:
           cache-name: cache-poetry
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.2.1-cache-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-poetry-1.3.1-cache-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-poetry-1.2.1-cache-
+            ${{ runner.os }}-poetry-1.3.1-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v3
         with:
           path: ~/work/wps/wps/api/.venv
-          key: ${{ runner.os }}-venv-poetry-1.2.1-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-venv-poetry-1.3.1-${{ hashFiles('**/poetry.lock') }}
       - name: Install python dependencies using poetry (api)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
@@ -104,7 +104,7 @@ jobs:
           cache-name: cache-poetry-installer
         with:
           path: "~/poetry_installer"
-          key: "poetry-installer-1.2.1"
+          key: "poetry-installer-1.3.1"
       - name: Download poetry installer
         if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
         run: |
@@ -114,7 +114,7 @@ jobs:
       - name: Install poetry (api)
         run: |
           cd ~/poetry_installer
-          python install-poetry.py --version 1.2.1
+          python install-poetry.py --version 1.3.1
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
       # poetry cache folder: /home/runner/.cache/pypoetry
@@ -124,15 +124,15 @@ jobs:
           cache-name: cache-poetry
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.2.1-cache-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-poetry-1.3.1-cache-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-poetry-1.2.1-cache-
+            ${{ runner.os }}-poetry-1.3.1-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v3
         with:
           path: ~/work/wps/wps/api/.venv
-          key: ${{ runner.os }}-venv-poetry-1.2.1-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-venv-poetry-1.3.1-${{ hashFiles('**/poetry.lock') }}
       - name: Install python dependencies using poetry (api)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api

--- a/openshift/wps-api-base/README.md
+++ b/openshift/wps-api-base/README.md
@@ -17,17 +17,15 @@ oc -n e1e498-tools process -f build.yaml | oc -n e1e498-tools apply -f -
 oc -n e1e498-tools -p GIT_BRANCH=my-branch process -f build.yaml | oc -n e1e498-tools apply -f -
 ```
 
-## The image can also be built locally, and then pushed to Openshift
+## The image can also be built by kicking off a build in Openshift
 
 ```bash
-# build your docker image
-docker build . --tag=wps-api-base:my-tag
-# tag it for upload
-docker tag wps-api-base:my-tag image-registry.apps.silver.devops.gov.bc.ca/e1e498-tools/wps-api-base:my-tag
-# log in to openshift docker
-docker login -u developer -p $(oc whoami -t) image-registry.apps.silver.devops.gov.bc.ca
-# push it
-docker push image-registry.apps.silver.devops.gov.bc.ca/e1e498-tools/wps-api-base:my-tag
-# once you're good to go
-oc -n e1e498-tools tag wps-api-base:my-tag wps-api-base:ubuntu.22.04-latest
+# dry run to check first
+VERSION=<dd-mm-yyyy> oc_build.sh
+
+# then run
+VERSION=<dd-mm-yyyy> oc_build.sh apply
+
+# now tag the built image as prod
+oc -n e1e498-tools tag wps-api-base:<dd-mm-yyyy> wps-api-base:ubuntu.22.04-latest
 ```

--- a/openshift/wps-api-base/docker/Dockerfile
+++ b/openshift/wps-api-base/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.
 # - wkhtmltopdf (for making pdf's)
 
 # Enable for mac M1
-# RUN dpkg -i /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+# RUN dpkg -i /tmp/wkhtmltox_0.12.6.1-2.jammy_arm64.deb
 RUN dpkg -i /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
 
 # Install cffdrs

--- a/openshift/wps-api-base/docker/Dockerfile
+++ b/openshift/wps-api-base/docker/Dockerfile
@@ -1,15 +1,4 @@
 ARG DOCKER_IMAGE=artifacts.developer.gov.bc.ca/docker-remote/ubuntu:22.04
-# STAGE 0 : "poetry"
-FROM registry.access.redhat.com/rhel7/rhel-tools AS download
-# We grab the image for step 0 from registry.access.redhat.com because both openshift and your
-# local machine can access it - so it's easy to test in both environments.
-# We can use any image we want here - we just need something to grab the latest poetry installer
-# for us. We don't want to have any dependencies on the final image, that we don't need there
-# and curl is one of those.
-
-RUN curl -sSL https://install.python-poetry.org > /tmp/install.python-poetry.org
-RUN curl -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb > /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-
 # For the final stage, we use ubuntu:22.04
 # Rationale for using ubuntu:22.04:
 # - It's the latest ubuntu LTS release.
@@ -34,12 +23,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 # - gdal (for geospatial)
 # - R (for cffdrs)
 # - xfonts-75dpi, xfonts-base (for wkhtmltopdf)
-RUN apt-get update --fix-missing && apt-get -y install python3 python3-pip python3-dev python-is-python3 libgdal-dev r-base xfonts-base xfonts-75dpi
+RUN apt-get update --fix-missing && apt-get -y install python3 python3-pip python3-dev python-is-python3 libgdal-dev r-base xfonts-base xfonts-75dpi curl
+
+RUN curl -sSL https://install.python-poetry.org > /tmp/install.python-poetry.org
+RUN curl -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb > /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+# Enable for mac M1
+# RUN curl -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_arm64.deb > /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+
 
 # - wkhtmltopdf (for making pdf's)
-COPY --from=download /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-RUN dpkg -i /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
 
+# Enable for mac M1
+# RUN dpkg -i /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+RUN dpkg -i /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
 
 # Install cffdrs
 RUN R -e "install.packages('cffdrs')"
@@ -62,6 +58,5 @@ WORKDIR /home/$USERNAME
 # Update pip
 RUN python3 -m pip install --upgrade pip
 
-# Install poetry (using installation file from previous stage)
-COPY --from=download /tmp/install.python-poetry.org /tmp/install.python-poetry.org
+# Install poetry
 RUN cat /tmp/install.python-poetry.org | python3 -

--- a/openshift/wps-api-base/openshift/build.yaml
+++ b/openshift/wps-api-base/openshift/build.yaml
@@ -15,7 +15,7 @@ parameters:
   - name: SUFFIX
   - name: VERSION
     description: Output version
-    value: "ubuntu.22.04-latest"
+    required: true
   - name: GIT_URL
     value: https://github.com/bcgov/wps.git
   - name: GIT_BRANCH
@@ -56,10 +56,68 @@ objects:
           kind: ImageStreamTag
           name: ${NAME}${SUFFIX}:${VERSION}
       source:
-        type: Git
-        git:
-          uri: ${GIT_URL}
-          ref: origin/${GIT_BRANCH}
-        contextDir: openshift/wps-api-base/docker
+        dockerfile: |
+          ARG DOCKER_IMAGE=artifacts.developer.gov.bc.ca/docker-remote/ubuntu:22.04
+          # For the final stage, we use ubuntu:22.04
+          # Rationale for using ubuntu:22.04:
+          # - It's the latest ubuntu LTS release.
+          # - It generally has a more recent version of gdal than debian.
+          # - It generally has a fairly recent version of python.
+          # - It has a more recent version of wkhtmltopdf and supporting libraries than debian.
+          #
+          # When building local, you can pull direct from docker, instead of artifacts.developer.gov.bc.ca:
+          # docker build --build-arg DOCKER_IMAGE=ubuntu:22.04 . --tag=wps-api-base:ubuntu.22.04-latest
+          FROM ${DOCKER_IMAGE}
+
+          # We don't want to run our app as root, so we define a worker user.
+          ARG USERNAME=worker
+          ARG USER_UID=1000
+          ARG USER_GID=$USER_UID
+
+          # Tell r-base not to wait for interactive input.
+          ENV DEBIAN_FRONTEND=noninteractive
+
+          # Install pre-requisites
+          # - python (we want python!)
+          # - gdal (for geospatial)
+          # - R (for cffdrs)
+          # - xfonts-75dpi, xfonts-base (for wkhtmltopdf)
+          RUN apt-get update --fix-missing && apt-get -y install python3 python3-pip python3-dev python-is-python3 libgdal-dev r-base xfonts-base xfonts-75dpi curl
+
+          RUN curl -sSL https://install.python-poetry.org > /tmp/install.python-poetry.org
+          RUN curl -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb > /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+          # Enable for mac M1
+          # RUN curl -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_arm64.deb > /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+
+
+          # - wkhtmltopdf (for making pdf's)
+
+          # Enable for mac M1
+          # RUN dpkg -i /tmp/wkhtmltox_0.12.6.1-2.jammy_arm64.deb
+          RUN dpkg -i /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+
+          # Install cffdrs
+          RUN R -e "install.packages('cffdrs')"
+
+          # Create our worker user
+          RUN groupadd --gid $USER_GID $USERNAME \
+              && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+          # When our app is running, we want to allow poetry full access to the workers home directory.
+          # +x : to execute the poetry binary
+          # +r : to read poetry cache
+          RUN chmod a+rx /home/$USERNAME
+
+          USER $USERNAME
+          ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
+
+          # Set the working directory to the user's home directory
+          WORKDIR /home/$USERNAME
+
+          # Update pip
+          RUN python3 -m pip install --upgrade pip
+
+          # Install poetry
+          RUN cat /tmp/install.python-poetry.org | python3 -
       strategy:
         type: Docker

--- a/openshift/wps-api-base/openshift/oc_build.sh
+++ b/openshift/wps-api-base/openshift/oc_build.sh
@@ -1,0 +1,62 @@
+#!/bin/sh -l
+#
+
+# %
+# % OpenShift Build Helper
+# %
+# %   Intended for use with a pull request-based pipeline.
+# %   Suffixes incl.: pr-###, test and prod.
+# %
+# % Usage:
+# %
+# %   ${THIS_FILE} [SUFFIX] [apply]
+# %
+# % Examples:
+# %
+# %   Provide a PR number. Defaults to a dry-run.
+# %   VERSION=jan-10-2023 ${THIS_FILE}
+# %
+# %   Apply when satisfied.
+# %   VERSION=jan-10-2023 ${THIS_FILE} apply
+# %
+
+# Process a template (mostly variable substition)
+#​​
+PROJ_TOOLS="e1e498-tools"
+
+OC_PROCESS="oc -n ${PROJ_TOOLS} process -f build.yaml \
+ -p VERSION=${VERSION}"
+
+# Apply a template (apply or use --dry-run)
+
+OC_APPLY="oc -n ${PROJ_TOOLS} apply -f -"
+[ "${APPLY}" ] || OC_APPLY="${OC_APPLY} --dry-run=client"
+
+# Cancel non complete builds and start a new build (apply or don't run)
+#
+OC_START_BUILD="oc -n ${PROJ_TOOLS} start-build --follow=true --wait=true"
+[ "${APPLY}" ] || OC_START_BUILD=""
+
+# Execute commands
+#
+eval "${OC_PROCESS}"
+eval "${OC_PROCESS} | ${OC_APPLY}"
+eval "${OC_START_BUILD}"
+
+if [ "${APPLY}" ]; then
+	# Get the most recent build version
+	BUILD_LAST=$(oc -n ${PROJ_TOOLS} get bc/${OBJ_NAME} -o 'jsonpath={.status.lastVersion}')
+	# Command to get the build result
+	BUILD_RESULT=$(oc -n ${PROJ_TOOLS} get build/${OBJ_NAME}-${BUILD_LAST} -o 'jsonpath={.status.phase}')
+
+	# Make sure that result is a successful completion
+	if [ "${BUILD_RESULT}" != "Complete" ]; then
+		echo "Build result: ${BUILD_RESULT}"
+		echo -e "\n*** Build not complete! ***\n"
+		exit 1
+	fi
+fi
+
+# Provide oc command instruction
+#
+display_helper "${OC_PROCESS} | ${OC_APPLY}" "${OC_START_BUILD}"


### PR DESCRIPTION
- Builds moved to run in openshift since we have dependencies (wkhtml2pdf) that won't build on m1
- Updated readme to build new `wps-api-base` image on openshift and promote as prod
- Bump poetry version in workflows to 1.3.1 so new dependencies will be updated in the lockfile
- Removed multistage docker build since it won't run on m1 anyways

# Test Links:
[Percentile Calculator](https://wps-pr-2508.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2508.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2508.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2508.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2508.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2508.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2508.apps.silver.devops.gov.bc.ca/hfi-calculator)
[FWI Calculator](https://wps-pr-2508.apps.silver.devops.gov.bc.ca/fwi-calculator)
