### PR TITLE
Set read timeout for async connections to 30 seconds

### DIFF
--- a/api/app/db/database.py
+++ b/api/app/db/database.py
@@ -51,7 +51,7 @@ _read_engine = create_engine(
     pool_pre_ping=True, connect_args=connect_args)
 
 # TODO: figure out connection pooling? pre-ping etc.?
-_async_read_engine = create_async_engine(ASYNC_DB_READ_STRING)
+_async_read_engine = create_async_engine(ASYNC_DB_READ_STRING, connect_args={"timeout": 30})
 _async_write_engine = create_async_engine(ASYNC_DB_WRITE_STRING)
 
 # bind session to database


### PR DESCRIPTION
From: https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.create_async_engine

Tested locally and don't get timeout exceptions anymore
# Test Links:
[Percentile Calculator](https://wps-pr-2556.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2556.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2556.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2556.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2556.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2556.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2556.apps.silver.devops.gov.bc.ca/hfi-calculator)
