### PR TITLE
Add loading overlay for HFI tiles, remove click popup, only load tiles at zonal zoom level, remove click popup

### DIFF
--- a/web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/src/features/fba/components/map/FBAMap.tsx
@@ -92,7 +92,6 @@ const FBAMap = (props: FBAMapProps) => {
   })
   const classes = useStyles()
   const { stations } = useSelector(selectFireWeatherStations)
-  const [showRawHFI, setShowRawHFI] = useState(false)
   const [showHighHFI, setShowHighHFI] = useState(true)
   const [map, setMap] = useState<ol.Map | null>(null)
   const mapRef = useRef<HTMLDivElement | null>(null)
@@ -234,17 +233,6 @@ const FBAMap = (props: FBAMapProps) => {
       map.addLayer(latestHFILayer)
     }
   }, [props.forDate, showHighHFI, props.setIssueDate, props.runType]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (!map) return
-    const layerName = 'hfiRaw'
-    removeLayerByName(map, layerName)
-    if (showRawHFI) {
-      const isoDate = props.forDate.toISODate().replaceAll('-', '')
-      const layer = hfiTileFactory(`gpdqha/sfms/cog/cog_hfi${isoDate}.tif`, layerName)
-      map.addLayer(layer)
-    }
-  }, [props.forDate, showRawHFI]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     // The React ref is used to attach to the div rendered in our

--- a/web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/src/features/fba/components/map/FBAMap.tsx
@@ -1,30 +1,19 @@
 import * as ol from 'ol'
-import * as proj from 'ol/proj'
 import { defaults as defaultControls, FullScreen } from 'ol/control'
-import { Coordinate } from 'ol/coordinate'
 import { fromLonLat } from 'ol/proj'
 import OLVectorLayer from 'ol/layer/Vector'
 import VectorTileLayer from 'ol/layer/VectorTile'
 import XYZ from 'ol/source/XYZ'
-import OLOverlay from 'ol/Overlay'
 import VectorTileSource from 'ol/source/VectorTile'
 import MVT from 'ol/format/MVT'
 import VectorSource from 'ol/source/Vector'
 import GeoJSON from 'ol/format/GeoJSON'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import React, { useEffect, useRef, useState } from 'react'
 import makeStyles from '@mui/styles/makeStyles'
 import { ErrorBoundary } from 'components'
-import { selectFireWeatherStations, selectFireZoneAreas, selectValueAtCoordinate } from 'app/rootReducer'
-import {
-  sfmsElevationSource,
-  twelveArcElevationSource,
-  ftlSource,
-  sfmsFtlSource,
-  sfmsSlopeSource,
-  sfmsAspectSource,
-  source as baseMapSource
-} from 'features/fireWeather/components/maps/constants'
+import { selectFireWeatherStations, selectFireZoneAreas } from 'app/rootReducer'
+import { source as baseMapSource } from 'features/fireWeather/components/maps/constants'
 import Tile from 'ol/layer/Tile'
 import { FireCenter } from 'api/fbaAPI'
 import { extentsMap } from 'features/fba/fireCentreExtents'
@@ -39,14 +28,11 @@ import {
 } from 'features/fba/components/map/featureStylers'
 import { CENTER_OF_BC } from 'utils/constants'
 import { DateTime } from 'luxon'
-import { AppDispatch } from 'app/store'
-import { fetchValuesAtCoordinate } from 'features/fba/slices/valueAtCoordinateSlice'
 import { LayerControl } from 'features/fba/components/map/layerControl'
-import FBATooltip from 'features/fba/components/map/FBATooltip'
 import { RASTER_SERVER_BASE_URL } from 'utils/env'
-import { EventsKey } from 'ol/events'
 import { RunType } from 'features/fba/pages/FireBehaviourAdvisoryPage'
 import { buildHFICql } from 'features/fba/cqlBuilder'
+import LoadingBackdrop from 'features/hfiCalculator/components/LoadingBackdrop'
 
 export const MapContext = React.createContext<ol.Map | null>(null)
 
@@ -105,23 +91,12 @@ const FBAMap = (props: FBAMapProps) => {
     }
   })
   const classes = useStyles()
-  const dispatch: AppDispatch = useDispatch()
   const { stations } = useSelector(selectFireWeatherStations)
-  const { values, loading } = useSelector(selectValueAtCoordinate)
   const [showRawHFI, setShowRawHFI] = useState(false)
-  const [showFTL, setShowFTL] = useState(false)
-  const [showFTL_M, setShowFTL_M] = useState(false)
-  const [showSfmsFtl, setShowSfmsFtl] = useState(false)
   const [showHighHFI, setShowHighHFI] = useState(true)
-  const [showSfmsElevation, setShowSfmsElevation] = useState(false)
-  const [show12arcElevation, setShow12arcElevation] = useState(false)
-  const [showSfmsSlope, setShowSfmsSlope] = useState(false)
-  const [showSfmsAspect, setShowSfmsAspect] = useState(false)
   const [map, setMap] = useState<ol.Map | null>(null)
-  const [singleClickKey, setSingleClickKey] = useState<EventsKey | null>(null)
-  const [overlayPosition, setOverlayPosition] = useState<Coordinate | undefined>(undefined)
   const mapRef = useRef<HTMLDivElement | null>(null)
-  const overlayRef = useRef<HTMLDivElement | null>(null)
+  const [hfiTilesLoading, setHFITilesLoading] = useState(false)
   const [fireZoneVector, setFireZoneVector] = useState(
     new VectorTileLayer({
       source: new VectorTileSource({
@@ -164,17 +139,6 @@ const FBAMap = (props: FBAMapProps) => {
       })
     )
   }, [fireZoneAreas, props.advisoryThreshold])
-
-  const hfiVector = new VectorTileLayer({
-    source: new VectorTileSource({
-      attributions: ['BC Wildfire Service'],
-      format: new MVT(),
-      url: `${TILE_SERVER_URL}/public.hfi/{z}/{x}/{y}.pbf?${buildHFICql(props.forDate, props.runType)}`
-    }),
-    style: hfiStyler,
-    zIndex: 100,
-    properties: { name: 'hfiVector' }
-  })
 
   // Seperate layer for polygons and for labels, to avoid duplicate labels.
   const fireZoneLabel = new VectorTileLayer({
@@ -254,10 +218,17 @@ const FBAMap = (props: FBAMapProps) => {
           })
         }
       })
+      source.on('tileloadstart', function () {
+        setHFITilesLoading(true)
+      })
+      source.on(['tileloadend', 'tileloaderror'], function () {
+        setHFITilesLoading(false)
+      })
       const latestHFILayer = new VectorTileLayer({
         source,
         style: hfiStyler,
         zIndex: 100,
+        minZoom: 6,
         properties: { name: layerName }
       })
       map.addLayer(latestHFILayer)
@@ -274,49 +245,6 @@ const FBAMap = (props: FBAMapProps) => {
       map.addLayer(layer)
     }
   }, [props.forDate, showRawHFI]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const addRemoveLayer = (map: ol.Map | null, show: boolean, layerName: string, source: XYZ) => {
-    if (!map) return
-    if (show) {
-      map.addLayer(new Tile({ source: source, properties: { name: layerName } }))
-    } else {
-      removeLayerByName(map, layerName)
-    }
-  }
-
-  useEffect(() => {
-    addRemoveLayer(map, showFTL, 'ftl', ftlSource)
-  }, [showFTL]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    addRemoveLayer(map, showSfmsElevation, 'sfmsElevation', sfmsElevationSource)
-  }, [showSfmsElevation]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    addRemoveLayer(map, show12arcElevation, '12arcElevation', twelveArcElevationSource)
-  }, [show12arcElevation]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    addRemoveLayer(map, showSfmsFtl, 'sfmsFtl', sfmsFtlSource)
-  }, [showSfmsFtl]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    addRemoveLayer(map, showSfmsAspect, 'sfmsAspect', sfmsAspectSource)
-  }, [showSfmsAspect]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    addRemoveLayer(map, showSfmsSlope, 'sfmsSlope', sfmsSlopeSource)
-  }, [showSfmsSlope]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (!map) return
-    const layerName = 'ftlM'
-    if (showFTL_M) {
-      map.addLayer(new Tile({ source: ftlSourceFactory('m1/m2'), properties: { name: layerName } }))
-    } else {
-      removeLayerByName(map, layerName)
-    }
-  }, [showFTL_M]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     // The React ref is used to attach to the div rendered in our
@@ -338,7 +266,6 @@ const FBAMap = (props: FBAMapProps) => {
           source: baseMapSource
         }),
         fireZoneVector,
-        hfiVector,
         fireCentreVector,
         // thessianVector,
         fireZoneLabel,
@@ -347,15 +274,7 @@ const FBAMap = (props: FBAMapProps) => {
       overlays: [],
       controls: defaultControls().extend([
         new FullScreen(),
-        LayerControl.buildLayerCheckbox('FTL 2018', setShowFTL, showFTL),
-        LayerControl.buildLayerCheckbox('FTL 2018 M1/M2', setShowFTL_M, showFTL_M),
-        LayerControl.buildLayerCheckbox('FTL SFMS', setShowSfmsFtl, showSfmsFtl),
-        LayerControl.buildLayerCheckbox('High HFI', setShowHighHFI, showHighHFI),
-        LayerControl.buildLayerCheckbox('Raw HFI', setShowRawHFI, showRawHFI),
-        LayerControl.buildLayerCheckbox('SFMS Elevation', setShowSfmsElevation, showSfmsElevation),
-        LayerControl.buildLayerCheckbox('12 arc Elevation', setShow12arcElevation, show12arcElevation),
-        LayerControl.buildLayerCheckbox('SFMS Slope', setShowSfmsSlope, showSfmsSlope),
-        LayerControl.buildLayerCheckbox('SFMS Aspect', setShowSfmsAspect, showSfmsAspect)
+        LayerControl.buildLayerCheckbox('High HFI', setShowHighHFI, showHighHFI)
       ])
     })
     mapObject.setTarget(mapRef.current)
@@ -367,43 +286,8 @@ const FBAMap = (props: FBAMapProps) => {
       }
     }
 
-    if (overlayRef.current) {
-      const overlay = new OLOverlay({
-        element: overlayRef.current,
-        autoPan: { animation: { duration: 250 } },
-        id: 'popup'
-      })
-
-      mapObject.addOverlay(overlay)
-    }
-
     setMap(mapObject)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (!map) return
-    if (singleClickKey) {
-      map.un('singleclick', singleClickKey.listener)
-    }
-    const newKey = map.on('singleclick', e => {
-      const overlay = map.getOverlayById('popup')
-      if (overlay) {
-        const coordinate = proj.transform(e.coordinate, 'EPSG:3857', 'EPSG:4326')
-        // fetch hfi at coordinate
-        dispatch(fetchValuesAtCoordinate(coordinate[1], coordinate[0], props.forDate))
-        setOverlayPosition(e.coordinate)
-      }
-    })
-    setSingleClickKey(newKey)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.forDate, map, dispatch])
-
-  useEffect(() => {
-    if (!map) return
-    const overlay = map.getOverlayById('popup')
-    if (overlay) overlay.setPosition(overlayPosition)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [overlayPosition])
 
   useEffect(() => {
     const stationsSource = new VectorSource({
@@ -429,8 +313,8 @@ const FBAMap = (props: FBAMapProps) => {
       <MapContext.Provider value={map}>
         <div className={classes.main}>
           <div ref={mapRef} data-testid="fba-map" className={props.className}></div>
-          <FBATooltip ref={overlayRef} valuesAtCoordinate={values} loading={loading} onClose={setOverlayPosition} />
         </div>
+        <LoadingBackdrop isLoadingWithoutError={hfiTilesLoading} />
       </MapContext.Provider>
     </ErrorBoundary>
   )


### PR DESCRIPTION
- Remove unused layer switches
- HFI tiles load at zoom level 6 (max level for zone labels) and higher
- Loading indicator when HFI tiles are in flight
- Removed click popup since we'll have zonal summaries soon

# Test Links:
[Percentile Calculator](https://wps-pr-2557.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2557.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2557.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2557.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2557.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2557.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2557.apps.silver.devops.gov.bc.ca/hfi-calculator)
