### PR TITLE
Lookup advisory zones if we have a recent run date

### DIFF
--- a/web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
+++ b/web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
@@ -121,10 +121,13 @@ export const FireBehaviourAdvisoryPage: React.FunctionComponent = () => {
         )
       )
     }
-    if (!isNull(mostRecentRunDate)) {
+  }, [mostRecentRunDate, selectedFireZone]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!isNull(mostRecentRunDate) && !isUndefined(mostRecentRunDate)) {
       dispatch(fetchFireZoneAreas(runType, mostRecentRunDate.toString(), dateOfInterest.toISODate()))
     }
-  }, [mostRecentRunDate, selectedFireZone]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [mostRecentRunDate]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className={classes.root}>

--- a/web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
+++ b/web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
@@ -120,6 +120,8 @@ export const FireBehaviourAdvisoryPage: React.FunctionComponent = () => {
           selectedFireZone.mof_fire_zone_id
         )
       )
+    }
+    if (!isNull(mostRecentRunDate)) {
       dispatch(fetchFireZoneAreas(runType, mostRecentRunDate.toString(), dateOfInterest.toISODate()))
     }
   }, [mostRecentRunDate, selectedFireZone]) // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
- We were only looking up fire zone advisory data if we selected a zone, we should be doing so if most recent run date changes
# Test Links:
[Percentile Calculator](https://wps-pr-2610.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-2610.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2610.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2610.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2610.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2610.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2610.apps.silver.devops.gov.bc.ca/hfi-calculator)
