### PR TITLE
Ruff linter: Ignore == to is rule

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -96,3 +96,4 @@ per-file-ignores = { "alembic/versions/00df3c7b5cba_rethink_classification.py" =
     "E712",
 ] }
 line-length = 185
+ignore = ["E712"]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -90,10 +90,6 @@ per-file-ignores = { "alembic/versions/00df3c7b5cba_rethink_classification.py" =
     "F401",
     "E402",
     "F811",
-], "app/db/crud/hfi_calc.py" = [
-    "E712",
-], "app/db/crud/observations.py" = [
-    "E712",
 ] }
 line-length = 185
 ignore = ["E712"]


### PR DESCRIPTION
This rule will flag filter functions in `numpy` and `sqlalchemy` filters which will break the code.

See: https://github.com/charliermarsh/ruff/issues/2443
# Test Links:
[Landing Page](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2650.apps.silver.devops.gov.bc.ca/hfi-calculator)
