### PR TITLE
IDIR role check for saving a forecast

### DIFF
--- a/web/src/features/auth/roles.ts
+++ b/web/src/features/auth/roles.ts
@@ -5,5 +5,8 @@ export const ROLES = {
     STATION_ADMIN: 'hfi_station_admin',
     SET_FUEL_TYPE: 'hfi_set_fuel_type',
     SET_READY_STATE: 'hfi_set_ready_state'
+  },
+  MORECAST_2: {
+    WRITE_FORECAST: 'morecast2_write_forecast'
   }
 }

--- a/web/src/features/moreCast2/components/SaveForecastButton.tsx
+++ b/web/src/features/moreCast2/components/SaveForecastButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import SaveIcon from '@mui/icons-material/Save'
+import { Button } from '@mui/material'
+
+export interface SubmitForecastButtonProps {
+  enabled: boolean
+}
+
+const SaveForecastButton = ({ enabled }: SubmitForecastButtonProps) => {
+  return (
+    <Button variant="contained" data-testid={'submit-forecast-button'} disabled={!enabled} startIcon={<SaveIcon />}>
+      Save Forecast
+    </Button>
+  )
+}
+
+export default React.memo(SaveForecastButton)

--- a/web/src/features/moreCast2/components/saveForecastButton.test.tsx
+++ b/web/src/features/moreCast2/components/saveForecastButton.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react'
+import store from 'app/store'
+import SaveForecastButton from 'features/moreCast2/components/SaveForecastButton'
+import React from 'react'
+import { Provider } from 'react-redux'
+
+describe('SaveForecastButton', () => {
+  it('should render the button as enabled', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <SaveForecastButton enabled={true} />
+      </Provider>
+    )
+
+    const manageStationsButton = getByTestId('submit-forecast-button')
+    expect(manageStationsButton).toBeInTheDocument()
+    expect(manageStationsButton).toBeEnabled()
+  })
+  it('should render the button as disabled', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <SaveForecastButton enabled={false} />
+      </Provider>
+    )
+
+    const manageStationsButton = getByTestId('submit-forecast-button')
+    expect(manageStationsButton).toBeInTheDocument()
+    expect(manageStationsButton).toBeDisabled()
+  })
+})

--- a/web/src/features/moreCast2/pages/MoreCast2Page.tsx
+++ b/web/src/features/moreCast2/pages/MoreCast2Page.tsx
@@ -6,7 +6,7 @@ import { isNull, isUndefined } from 'lodash'
 import { DateTime } from 'luxon'
 import { FireCenter, FireCenterStation } from 'api/fbaAPI'
 import { ModelChoice, ModelChoices, ModelType } from 'api/moreCast2API'
-import { selectFireCenters, selectModelStationPredictions } from 'app/rootReducer'
+import { selectAuthentication, selectFireCenters, selectModelStationPredictions } from 'app/rootReducer'
 import { AppDispatch } from 'app/store'
 import { fetchFireCenters } from 'commonSlices/fireCentersSlice'
 import { GeneralHeader } from 'components'
@@ -18,6 +18,8 @@ import StationPanel from 'features/moreCast2/components/StationPanel'
 import { MoreCast2ForecastRow } from 'features/moreCast2/interfaces'
 import { getModelStationPredictions } from 'features/moreCast2/slices/modelSlice'
 import { createDateInterval, fillInTheBlanks, parseModelsForStationsHelper } from 'features/moreCast2/util'
+import SaveForecastButton from 'features/moreCast2/components/SaveForecastButton'
+import { ROLES } from 'features/auth/roles'
 
 const useStyles = makeStyles(theme => ({
   content: {
@@ -47,6 +49,9 @@ const useStyles = makeStyles(theme => ({
     width: '375px',
     borderRight: '1px solid black',
     overflowY: 'auto'
+  },
+  actionButtonContainer: {
+    marginTop: 15
   }
 }))
 
@@ -59,6 +64,7 @@ const MoreCast2Page = () => {
   const dispatch: AppDispatch = useDispatch()
   const { fireCenters } = useSelector(selectFireCenters)
   const { stationPredictions } = useSelector(selectModelStationPredictions)
+  const { roles, isAuthenticated } = useSelector(selectAuthentication)
   const [fireCenter, setFireCenter] = useState<FireCenter | undefined>(undefined)
   const [selectedStations, setSelectedStations] = useState<FireCenterStation[]>([])
   const [modelType, setModelType] = useState<ModelType>(
@@ -153,7 +159,7 @@ const MoreCast2Page = () => {
           />
         </div>
         <div className={classes.observations}>
-          <Typography variant="h5">Observations</Typography>
+          <Typography variant="h5">Forecasts</Typography>
           <Grid container spacing={1}>
             <Grid item xs={3}>
               <FormControl className={classes.formControl}>
@@ -172,6 +178,11 @@ const MoreCast2Page = () => {
             <Grid item xs={3}>
               <FormControl className={classes.formControl}>
                 <WPSDatePicker date={toDate} label="To" updateDate={setToDate} />
+              </FormControl>
+            </Grid>
+            <Grid item xs={2}>
+              <FormControl className={classes.actionButtonContainer}>
+                <SaveForecastButton enabled={roles.includes(ROLES.MORECAST_2.WRITE_FORECAST) && isAuthenticated} />
               </FormControl>
             </Grid>
           </Grid>


### PR DESCRIPTION
- Adds a save button on morecast2, not hooked up to anything yet
- Enabled when logged in user has forecaster write permission
- Disabled otherwise
# Test Links:
[Landing Page](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2695.apps.silver.devops.gov.bc.ca/hfi-calculator)
