### PR TITLE
Round numbers when editing

### DIFF
--- a/web/src/features/moreCast2/components/MoreCast2DataGrid.tsx
+++ b/web/src/features/moreCast2/components/MoreCast2DataGrid.tsx
@@ -7,7 +7,6 @@ import {
   GridValueGetterParams,
   GridValueSetterParams
 } from '@mui/x-data-grid'
-import { isNumber, isUndefined } from 'lodash'
 import { DateTime } from 'luxon'
 import { ModelChoice } from 'api/moreCast2API'
 import { MoreCast2ForecastRow } from 'features/moreCast2/interfaces'

--- a/web/src/features/moreCast2/components/MoreCast2DataGrid.tsx
+++ b/web/src/features/moreCast2/components/MoreCast2DataGrid.tsx
@@ -33,11 +33,11 @@ const MoreCast2DataGrid = (props: MoreCast2DataGridProps) => {
   const { rows } = props
   const loading = useSelector(selectMorecast2TableLoading)
 
+  // Rounds the value to the number of decimal places specified by precision
   const numFormatter = (value: number, precision: number) => {
     if (isUndefined(value) || isNaN(value)) {
       return NaN
     }
-
     const multiplier = Math.pow(10, precision || 0)
     return Math.round(value * multiplier) / multiplier
   }
@@ -62,7 +62,7 @@ const MoreCast2DataGrid = (props: MoreCast2DataGridProps) => {
     if (isNaN(oldValue) && isNaN(newValue)) {
       return { ...params.row }
     }
-
+    // Check if the user has edited the value. If so, update the value and choice to reflect the Manual edit.
     if (newValue !== numFormatter(params.row[field].value, precision)) {
       params.row[field].choice = ModelChoice.MANUAL
       params.row[field].value = newValue

--- a/web/src/features/moreCast2/components/MoreCast2DataGrid.tsx
+++ b/web/src/features/moreCast2/components/MoreCast2DataGrid.tsx
@@ -33,18 +33,10 @@ const MoreCast2DataGrid = (props: MoreCast2DataGridProps) => {
   const { rows } = props
   const loading = useSelector(selectMorecast2TableLoading)
 
-  // Rounds the value to the number of decimal places specified by precision
-  const numFormatter = (value: number, precision: number) => {
-    if (isUndefined(value) || isNaN(value)) {
-      return NaN
-    }
-    const multiplier = Math.pow(10, precision || 0)
-    return Math.round(value * multiplier) / multiplier
-  }
-
   const predictionItemValueFormatter = (params: GridValueFormatterParams, precision: number) => {
-    const value = params?.value
-    return isNumber(value) && !isNaN(value) ? value.toFixed(precision) : NOT_AVAILABLE
+    const value = Number.parseFloat(params?.value)
+
+    return isNaN(value) ? NOT_AVAILABLE : value.toFixed(precision)
   }
 
   const predictionItemValueGetter = (params: GridValueGetterParams, precision: number) => {
@@ -52,7 +44,7 @@ const MoreCast2DataGrid = (props: MoreCast2DataGridProps) => {
     if (isNaN(value)) {
       return 'NaN'
     }
-    return numFormatter(params?.value?.value, precision)
+    return value.toFixed(precision)
   }
 
   const predictionItemValueSetter = (params: GridValueSetterParams, field: string, precision: number) => {
@@ -63,7 +55,7 @@ const MoreCast2DataGrid = (props: MoreCast2DataGridProps) => {
       return { ...params.row }
     }
     // Check if the user has edited the value. If so, update the value and choice to reflect the Manual edit.
-    if (newValue !== numFormatter(params.row[field].value, precision)) {
+    if (newValue.toFixed(precision) !== params.row[field].value.toFixed(precision)) {
       params.row[field].choice = ModelChoice.MANUAL
       params.row[field].value = newValue
     }

--- a/web/src/features/moreCast2/pages/MoreCast2Page.tsx
+++ b/web/src/features/moreCast2/pages/MoreCast2Page.tsx
@@ -92,7 +92,7 @@ const MoreCast2Page = () => {
 
   const fetchStationPredictions = () => {
     const stationCodes = fireCenter?.stations.map(station => station.code) || []
-    if (toDate <= fromDate) {
+    if (toDate.startOf('day') < fromDate.startOf('day')) {
       setForecastRows([])
       return
     }


### PR DESCRIPTION
This PR fixes a couple of UI quirks:
1. Rounds numbers to a specific decimal place when editing (model data has many decimal places, but we want 0 or one depending on the column
2. It was possible to encounter a situation where a user selects the same start/end date, menaing we should show data for that date, yet the data grid was blank (fix was the comparison in MoreCast2Page.tsx).

Finally, React was throwing an error when attempting to edit a cell with a N/A value. The reason was that the underlying NaN was being passed to an `<input type=number>` element which can't handle 'NaN'. Instead, we now pass in a stringified 'NaN' which gives us a console warning, but not an error.
# Test Links:
[Landing Page](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2699.apps.silver.devops.gov.bc.ca/hfi-calculator)
