### PR TITLE
Milliseconds matter

### DIFF
--- a/web/src/features/moreCast2/pages/MoreCast2Page.tsx
+++ b/web/src/features/moreCast2/pages/MoreCast2Page.tsx
@@ -83,7 +83,7 @@ const MoreCast2Page = () => {
     (localStorage.getItem(DEFAULT_MODEL_TYPE_KEY) as ModelType) || DEFAULT_MODEL_TYPE
   )
   const [fromDate, setFromDate] = useState<DateTime>(DateTime.now())
-  const [toDate, setToDate] = useState<DateTime>(DateTime.now().plus({ days: 2 }))
+  const [toDate, setToDate] = useState<DateTime>(fromDate.plus({ days: 2 }))
   const [forecastRows, setForecastRows] = useState<MoreCast2ForecastRow[]>([])
   const [stationPredictionsAsMoreCast2ForecastRows, setStationPredictionsAsMoreCast2ForecastRows] = useState<
     MoreCast2ForecastRow[]


### PR DESCRIPTION
When setting the initial state of the `toDate` date picker,  it was possible that the date would end up 2 days plus 1 or 2 milliseconds into the future. Later on an interval is calculated based on the number of days between `fromDate` and `toDate`. The number of milliseconds in a day are used to parse out the interval and any remainder beyond full-day increments gets grouped into an extra day. So the extra 1-2 milliseconds gets treated as an extra day.


# Test Links:
[Landing Page](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2708.apps.silver.devops.gov.bc.ca/hfi-calculator)
