### PR TITLE
Turn off postgresql logging in patroni config

### DIFF
--- a/openshift/templates/patroni.yaml
+++ b/openshift/templates/patroni.yaml
@@ -56,6 +56,21 @@ objects:
     status:
       loadBalancer: {}
   - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${APP_NAME}-${SUFFIX}-patroni-config
+      labels:
+        app: ${APP_NAME}-${SUFFIX}
+    data:
+      nats.conf: |-
+        postgresql:
+          parameters:
+            max_connections: 100
+            max_locks_per_transaction: 64
+            max_prepared_transactions: 0
+            log_level: OFF
+          use_pg_rewind: true
+  - apiVersion: v1
     kind: Service
     metadata:
       creationTimestamp: null
@@ -209,6 +224,8 @@ objects:
               volumeMounts:
                 - mountPath: /home/postgres/pgdata
                   name: postgresql
+                - name: patroni-config
+                  mountPath: /etc/patroni/
           dnsPolicy: ClusterFirst
           restartPolicy: Always
           schedulerName: default-scheduler
@@ -219,6 +236,9 @@ objects:
             - name: postgresql
               persistentVolumeClaim:
                 claimName: ${NAME}
+            - name: patroni-config
+              configMap:
+                name: ${APP_NAME}-${SUFFIX}-patroni-config
       updateStrategy:
         type: RollingUpdate
       volumeClaimTemplates:

--- a/openshift/templates/patroni.yaml
+++ b/openshift/templates/patroni.yaml
@@ -58,7 +58,7 @@ objects:
   - apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: ${APP_NAME}-${SUFFIX}-patroni-config
+      name: patroni-config
       labels:
         app: ${APP_NAME}-${SUFFIX}
     data:
@@ -238,7 +238,7 @@ objects:
                 claimName: ${NAME}
             - name: patroni-config
               configMap:
-                name: ${APP_NAME}-${SUFFIX}-patroni-config
+                name: patroni-config
       updateStrategy:
         type: RollingUpdate
       volumeClaimTemplates:


### PR DESCRIPTION

# Test Links:
[Landing Page](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2752.apps.silver.devops.gov.bc.ca/hfi-calculator)
