### PR TITLE
Task/ux quick wins/2781

### DIFF
--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -6,12 +6,8 @@ const useStyles = makeStyles({
     color: 'white',
     fontStyle: 'bold',
     fontSize: '1.1em',
-    textDecoration: 'none',
-    cursor: 'pointer',
-
-    '&:hover': {
-      textDecoration: 'underline'
-    }
+    textDecoration: 'underline',
+    cursor: 'pointer'
   }
 })
 
@@ -30,7 +26,7 @@ const Contact = (props: Props) => {
       className={classes.contact}
       href={`mailto:bcws.predictiveservices@gov.bc.ca?subject=Predictive Services Unit - ${productName}`}
     >
-      Contact Predictive Services Unit
+      Email: bcws.predictiveservices@gov.bc.ca
     </a>
   )
 }

--- a/web/src/components/Contact.tsx
+++ b/web/src/components/Contact.tsx
@@ -8,6 +8,11 @@ const useStyles = makeStyles({
     fontSize: '1.1em',
     textDecoration: 'underline',
     cursor: 'pointer'
+  },
+  plainText: {
+    color: 'white',
+    fontStyle: 'bold',
+    fontSize: '1.1em'
   }
 })
 
@@ -21,13 +26,16 @@ const Contact = (props: Props) => {
   const classes = useStyles()
 
   return (
-    <a
-      id="contact-link"
-      className={classes.contact}
-      href={`mailto:bcws.predictiveservices@gov.bc.ca?subject=Predictive Services Unit - ${productName}`}
-    >
-      Email: bcws.predictiveservices@gov.bc.ca
-    </a>
+    <div>
+      <a className={classes.plainText}>Email: </a>
+      <a
+        id="contact-link"
+        className={classes.contact}
+        href={`mailto:bcws.predictiveservices@gov.bc.ca?subject=Predictive Services Unit - ${productName}`}
+      >
+        bcws.predictiveservices@gov.bc.ca
+      </a>
+    </div>
   )
 }
 

--- a/web/src/features/landingPage/components/SidebarToolList.tsx
+++ b/web/src/features/landingPage/components/SidebarToolList.tsx
@@ -43,7 +43,7 @@ const SidebarToolList: React.FunctionComponent = () => {
         return (
           <div key={item.name}>
             <ListItem className={classes.listItem} disablePadding>
-              <ListItemButton component={'a'} href={item.route} target="_blank">
+              <ListItemButton component={'a'} href={item.route}>
                 <ListItemIcon className={classes.icon}>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.name} secondary={isSmall && item.description} />
                 {item.isBeta && (

--- a/web/src/features/landingPage/components/SidebarToolList.tsx
+++ b/web/src/features/landingPage/components/SidebarToolList.tsx
@@ -22,6 +22,9 @@ const useStyles = makeStyles(theme => ({
   icon: {
     minWidth: '3rem'
   },
+  text: {
+    textDecoration: 'underline'
+  },
   list: {
     [theme.breakpoints.down('sm')]: {
       padding: theme.spacing(2)
@@ -45,7 +48,7 @@ const SidebarToolList: React.FunctionComponent = () => {
             <ListItem className={classes.listItem} disablePadding>
               <ListItemButton component={'a'} href={item.route}>
                 <ListItemIcon className={classes.icon}>{item.icon}</ListItemIcon>
-                <ListItemText primary={item.name} secondary={isSmall && item.description} />
+                <ListItemText className={classes.text} primary={item.name} secondary={isSmall && item.description} />
                 {item.isBeta && (
                   <div className={classes.beta}>
                     <BetaTag />

--- a/web/src/features/landingPage/components/ToolCard.tsx
+++ b/web/src/features/landingPage/components/ToolCard.tsx
@@ -75,13 +75,13 @@ const ToolCard: React.FunctionComponent<ToolCardProps> = (props: ToolCardProps) 
     const path = props.route
     if (path.startsWith('http')) {
       return (
-        <a className={classes.link} href={path} rel="noreferrer" target="_blank">
+        <a className={classes.link} href={path} rel="noreferrer">
           {props.name}
         </a>
       )
     } else {
       return (
-        <Link className={classes.link} to={{ pathname: props.route }} target="_blank">
+        <Link className={classes.link} to={{ pathname: props.route }}>
           {props.name}
         </Link>
       )
@@ -102,7 +102,6 @@ const ToolCard: React.FunctionComponent<ToolCardProps> = (props: ToolCardProps) 
           size="large"
           variant="contained"
           sx={{ fontSize: '1.125rem', fontWeight: 700 }}
-          target="_blank"
         >
           Get Started
         </Button>


### PR DESCRIPTION
# Changes Made:
- from Landing Page, clicking on a link to one of our apps will open the app in the same tab as the landing page
- changed the text in the header to "Email: bcws....@gov.bc.ca" instead of "Contact PSU" (this change affects the headers in all of our apps)
- added persistent underlines to the Contact (mailto) link, and to the app links in the hamburger menu of our landing page

# Test Links:
[Landing Page](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2792.apps.silver.devops.gov.bc.ca/hfi-calculator)
