### PR TITLE
Provide a Null option in column menu

### DIFF
--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -14,7 +14,7 @@ export enum ModelChoice {
   MANUAL = 'MANUAL',
   PERSISTENCE = 'PERSISTENCE',
   ACTUAL = 'ACTUAL',
-  NULL = ''
+  NULL = 'NULL'
 }
 
 export const DEFAULT_MODEL_TYPE: ModelType = ModelChoice.HRDPS
@@ -29,7 +29,7 @@ export type ModelType =
   | 'MANUAL'
   | 'FORECAST'
   | 'ACTUAL'
-  | ''
+  | 'NULL'
 
 export const ModelChoices: ModelType[] = [
   ModelChoice.GDPS,
@@ -38,6 +38,7 @@ export const ModelChoices: ModelType[] = [
   ModelChoice.PERSISTENCE,
   ModelChoice.MANUAL,
   ModelChoice.NAM,
+  ModelChoice.NULL,
   ModelChoice.RDPS
 ]
 

--- a/web/src/features/moreCast2/components/ApplyToColumnMenu.tsx
+++ b/web/src/features/moreCast2/components/ApplyToColumnMenu.tsx
@@ -3,7 +3,7 @@ import SaveIcon from '@mui/icons-material/Save'
 import { Button, FormControl, Grid, Menu, MenuItem } from '@mui/material'
 import { GridColDef } from '@mui/x-data-grid'
 import WeatherModelDropdown from 'features/moreCast2/components/WeatherModelDropdown'
-import { ModelChoices, DEFAULT_MODEL_TYPE, ModelType, ModelChoice } from 'api/moreCast2API'
+import { DEFAULT_MODEL_TYPE, ModelOptions, ModelType } from 'api/moreCast2API'
 import { isNull } from 'lodash'
 
 export interface ApplyFunctionMenuItemProps {
@@ -62,7 +62,7 @@ const ApplyToColumnMenu = ({ colDef, contextMenu, handleClose, updateColumnWithM
             <Grid item>
               <WeatherModelDropdown
                 label="Select model to apply to column"
-                weatherModelOptions={ModelChoices.filter(model => model !== ModelChoice.MANUAL)}
+                weatherModelOptions={ModelOptions}
                 selectedModelType={selectedColumnModel}
                 setSelectedModelType={setSelectedColumnModel}
               />

--- a/web/src/features/moreCast2/components/GridComponentRenderer.tsx
+++ b/web/src/features/moreCast2/components/GridComponentRenderer.tsx
@@ -25,16 +25,10 @@ export class GridComponentRenderer {
     const index = field.indexOf('Forecast')
     const prefix = field.slice(0, index)
     const actualField = `${prefix}Actual`
+    const label = params.row[field].choice === ModelChoice.NULL ? '' : params.row[field].choice
 
     const disabled = !isNaN(params.row[actualField])
-    return (
-      <TextField
-        disabled={disabled}
-        size="small"
-        label={params.row[field].choice}
-        value={params.formattedValue}
-      ></TextField>
-    )
+    return <TextField disabled={disabled} size="small" label={label} value={params.formattedValue}></TextField>
   }
 
   public predictionItemValueSetter = (

--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -250,7 +250,7 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo, modelType, setModelT
         const predictionItem = row[forecastField] as PredictionItem
         const sourceKey = `${prefix}${modelType}` as keyof MoreCast2Row
         predictionItem.choice = modelType
-        predictionItem.value = row[sourceKey] as number
+        predictionItem.value = (row[sourceKey] as number) || NaN
       }
     }
     setVisibleRows(newRows)

--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -29,7 +29,7 @@ import { isForecastRowPredicate, getRowsToSave, isForecastValid } from 'features
 
 const FORECAST_ERROR_MESSAGE = 'The forecast was not saved; an unexpected error occurred.'
 const FORECAST_SAVED_MESSAGE = 'Forecast was successfully saved.'
-const FORECAST_WARN_MESSAGE = 'A forecast cannot contain N/A values.'
+const FORECAST_WARN_MESSAGE = 'Forecast not submitted. A forecast can only contain N/A values for the Wind Direction.'
 
 interface TabbedDataGridProps {
   morecast2Rows: MoreCast2Row[]

--- a/web/src/features/moreCast2/saveForecast.test.ts
+++ b/web/src/features/moreCast2/saveForecast.test.ts
@@ -78,7 +78,7 @@ const buildForecastMissingWindDirection = (
   precipForecast: { choice: 'GDPS', value: 0 },
   rhForecast: { choice: 'GDPS', value: 0 },
   tempForecast: { choice: 'GDPS', value: 0 },
-  windDirectionForecast: { choice: '', value: NaN },
+  windDirectionForecast: { choice: 'NULL', value: NaN },
   windSpeedForecast: { choice: 'GDPS', value: 0 }
 })
 
@@ -101,11 +101,11 @@ const buildNAForecast = (id: string, forDate: DateTime, stationCode: number, sta
   stationCode,
   stationName,
   ...baseRow,
-  precipForecast: { choice: '', value: NaN },
-  rhForecast: { choice: '', value: NaN },
-  tempForecast: { choice: '', value: NaN },
-  windDirectionForecast: { choice: '', value: NaN },
-  windSpeedForecast: { choice: '', value: NaN }
+  precipForecast: { choice: 'NULL', value: NaN },
+  rhForecast: { choice: 'NULL', value: NaN },
+  tempForecast: { choice: 'NULL', value: NaN },
+  windDirectionForecast: { choice: 'NULL', value: NaN },
+  windSpeedForecast: { choice: 'NULL', value: NaN }
 })
 
 const buildForecastWithActuals = (

--- a/web/src/features/moreCast2/saveForecasts.ts
+++ b/web/src/features/moreCast2/saveForecasts.ts
@@ -1,3 +1,4 @@
+import { ModelChoice } from 'api/moreCast2API'
 import { MoreCast2ForecastRow, MoreCast2Row } from 'features/moreCast2/interfaces'
 import { isUndefined } from 'lodash'
 
@@ -12,13 +13,13 @@ export const isForecastRowPredicate = (row: MoreCast2Row) =>
 // A valid forecast row has values for precipForecast, rhForecast, tempForecast and windSpeedForecast
 export const validForecastPredicate = (row: MoreCast2Row) =>
   !isUndefined(row.precipForecast) &&
-  row.precipForecast.choice !== '' &&
+  row.precipForecast.choice !== ModelChoice.NULL &&
   !isUndefined(row.rhForecast) &&
-  row.rhForecast.choice !== '' &&
+  row.rhForecast.choice !== ModelChoice.NULL &&
   !isUndefined(row.tempForecast) &&
-  row.tempForecast.choice !== '' &&
+  row.tempForecast.choice !== ModelChoice.NULL &&
   !isUndefined(row.windSpeedForecast) &&
-  row.windSpeedForecast.choice !== ''
+  row.windSpeedForecast.choice !== ModelChoice.NULL
 
 export const getForecastRows = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   return rows ? rows.filter(isForecastRowPredicate) : []
@@ -38,10 +39,10 @@ export const getRowsToSave = (rows: MoreCast2Row[]): MoreCast2ForecastRow[] => {
     stationCode: r.stationCode,
     stationName: r.stationName,
     forDate: r.forDate,
-    precip: r.precipForecast || { choice: '', value: NaN },
-    rh: r.rhForecast || { choice: '', value: NaN },
-    temp: r.tempForecast || { choice: '', value: NaN },
-    windDirection: r.windDirectionForecast || { choice: '', value: NaN },
-    windSpeed: r.windSpeedForecast || { choice: '', value: NaN }
+    precip: r.precipForecast || { choice: ModelChoice.NULL, value: NaN },
+    rh: r.rhForecast || { choice: ModelChoice.NULL, value: NaN },
+    temp: r.tempForecast || { choice: ModelChoice.NULL, value: NaN },
+    windDirection: r.windDirectionForecast || { choice: ModelChoice.NULL, value: NaN },
+    windSpeed: r.windSpeedForecast || { choice: ModelChoice.NULL, value: NaN }
   }))
 }


### PR DESCRIPTION
Adds a 'Null' option to the column menu that sets all editable forecasted values in the column to Null - N/A - NaN.

The option is available for all forecast columns, not just Wind Direction.

# Test Links:
[Landing Page](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2809.apps.silver.devops.gov.bc.ca/hfi-calculator)
