### PR TITLE
Add check for empty existing stations in station admin

### DIFF
--- a/api/app/hfi/hfi_admin.py
+++ b/api/app/hfi/hfi_admin.py
@@ -157,6 +157,8 @@ def get_next_order(updated_stations: List[PlanningWeatherStation], other_station
         if station.order_of_appearance_in_planning_area_list is not None]
 
     if len(updated_orders) == 0:
+        if len(existing_orders) == 0:
+            return 1
         return max(existing_orders) + 1
     return max(updated_orders) + 1
 

--- a/api/app/tests/hfi/test_hfi_admin.py
+++ b/api/app/tests/hfi/test_hfi_admin.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from app.db.models.hfi_calc import PlanningWeatherStation
-from app.hfi.hfi_admin import add_stations, get_next_order_by_planning_area, get_unique_planning_area_ids, remove_stations, update_station_ordering
+from app.hfi.hfi_admin import add_stations, get_next_order, get_next_order_by_planning_area, get_unique_planning_area_ids, remove_stations, update_station_ordering
 from app.schemas.hfi_calc import HFIAdminAddedStation
 
 timestamp = datetime.fromisoformat("2019-06-10T18:42:49")
@@ -269,3 +269,22 @@ def test_remove_stations():
     assert stations_with_order_updates[0].planning_area_id == all_planning_area_stations[2].planning_area_id
     assert stations_with_order_updates[0].station_code == all_planning_area_stations[2].station_code
     assert stations_with_order_updates[0].order_of_appearance_in_planning_area_list == 1  # last one left
+
+
+def test_get_next_order_no_updated_or_existing():
+    """ If there are no updated or existing stations, the next order should be 1 """
+    assert get_next_order([], []) == 1
+
+
+def test_get_next_order_no_updated():
+    """ If there are no updated or existing stations, the next order should be 1 """
+    assert get_next_order([], [PlanningWeatherStation(planning_area_id=1,
+                                                      station_code=3,
+                                                      order_of_appearance_in_planning_area_list=1)]) == 2
+
+
+def test_get_next_order_no_existing():
+    """ If there are no updated or existing stations, the next order should be 1 """
+    assert get_next_order([], [PlanningWeatherStation(planning_area_id=1,
+                                                      station_code=3,
+                                                      order_of_appearance_in_planning_area_list=1)]) == 2


### PR DESCRIPTION
Checks for empty existing stations list when user deletes all existing stations 
# Test Links:
[Landing Page](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2828.apps.silver.devops.gov.bc.ca/hfi-calculator)
