### PR TITLE
Add checks for missing stations

### DIFF
--- a/api/app/hfi/pdf_data_formatter.py
+++ b/api/app/hfi/pdf_data_formatter.py
@@ -140,16 +140,21 @@ def get_merged_station_data(
     Returns all the weather station and daily data we have for a station
     """
     all_station_pdf_data: List[StationPDFData] = []
+    # We do a bunch of null checks here because station_dict is built from
+    # stations we retrieve from WF1, while the dailies come from the HFI request
+    # which can have an different set of stations
     for daily in dailies:
-        station_data = station_dict[daily.code]
+        station_data = station_dict.get(daily.code, None)
         daily_dict = daily.dict()
-        daily_dict.update(station_data)
+        if station_data is not None:
+            daily_dict.update(station_data)
         station_info: StationInfo = next(
             station_info for
             station_info in planning_area_station_info if station_info.station_code == daily.code)
         daily_dict['fuel_type'] = fuel_types[station_info.fuel_type_id]
-        station_pdf_data = StationPDFData(**daily_dict)
-        all_station_pdf_data.append(station_pdf_data)
+        if station_data is not None:
+            station_pdf_data = StationPDFData(**daily_dict)
+            all_station_pdf_data.append(station_pdf_data)
     return all_station_pdf_data
 
 

--- a/api/app/hfi/pdf_data_formatter.py
+++ b/api/app/hfi/pdf_data_formatter.py
@@ -140,21 +140,21 @@ def get_merged_station_data(
     Returns all the weather station and daily data we have for a station
     """
     all_station_pdf_data: List[StationPDFData] = []
-    # We do a bunch of null checks here because station_dict is built from
+    # We do a null check here because station_dict is built from
     # stations we retrieve from WF1, while the dailies come from the HFI request
     # which can have an different set of stations
     for daily in dailies:
         station_data = station_dict.get(daily.code, None)
+        if station_data is None:
+            continue
         daily_dict = daily.dict()
-        if station_data is not None:
-            daily_dict.update(station_data)
+        daily_dict.update(station_data)
         station_info: StationInfo = next(
             station_info for
             station_info in planning_area_station_info if station_info.station_code == daily.code)
         daily_dict['fuel_type'] = fuel_types[station_info.fuel_type_id]
-        if station_data is not None:
-            station_pdf_data = StationPDFData(**daily_dict)
-            all_station_pdf_data.append(station_pdf_data)
+        station_pdf_data = StationPDFData(**daily_dict)
+        all_station_pdf_data.append(station_pdf_data)
     return all_station_pdf_data
 
 

--- a/api/app/routers/hfi_calc.py
+++ b/api/app/routers/hfi_calc.py
@@ -346,8 +346,8 @@ async def get_hfi_result_with_date(fire_centre_id: int,
             else:
                 date_range = None
             request, _, fire_centre_fire_start_ranges = get_prepared_request(session,
-                                                                                          fire_centre_id,
-                                                                                          date_range)
+                                                                             fire_centre_id,
+                                                                             date_range)
 
             # Get the response.
             request_response = await calculate_and_create_response(
@@ -480,12 +480,14 @@ async def get_pdf(
     logger.info('/hfi-calc/fire_centre/%s/%s/%s/pdf', fire_centre_id, start_date, end_date)
 
     with get_read_session_scope() as session:
-        (request,
-         _,
-         fire_centre_fire_start_ranges) = get_prepared_request(session,
-                                                               fire_centre_id,
-                                                               DateRange(start_date=start_date,
-                                                                         end_date=end_date))
+        if start_date and end_date:
+            date_range = DateRange(start_date=start_date, end_date=end_date)
+        else:
+            date_range = None
+
+        request, _, fire_centre_fire_start_ranges = get_prepared_request(session,
+                                                                         fire_centre_id,
+                                                                         date_range)
 
         # Get the response.
         request_response = await calculate_and_create_response(


### PR DESCRIPTION
The pdf endpoint assumes the list of stations from WF1 is the same list of stations for a HFI request. This is not true since we made the change to render the HFI table based on the request. 

The calculations are based on the HFI request as well so now every function/artifact is based on it.

Tested with data from prod.
# Test Links:
[Landing Page](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2838.apps.silver.devops.gov.bc.ca/hfi-calculator)
