### PR TITLE
HFI Calc: Include only selected stations that also exist in wf1

### DIFF
--- a/api/app/hfi/hfi_calc.py
+++ b/api/app/hfi/hfi_calc.py
@@ -373,6 +373,7 @@ def calculate_hfi_results(fuel_type_lookup: Dict[int, FuelTypeModel],
     planning_area_to_dailies: List[PlanningAreaResult] = []
 
     station_lookup: Dict[str, WFWXWeatherStation] = {station.wfwx_id: station for station in wfwx_stations}
+    wfwx_station_codes: List[int] = set([station.code for station in wfwx_stations])
 
     for area_id in planning_area_station_info.keys():
 
@@ -391,10 +392,10 @@ def calculate_hfi_results(fuel_type_lookup: Dict[int, FuelTypeModel],
             num_prep_days,
             lowest_fire_starts)
 
+        selected_stations = [station.station_code for station in planning_area_station_info[area_id]
+                             if station.selected is True and station.station_code in wfwx_station_codes]
         all_dailies_valid: bool = True
-        num_unique_station_codes = len([
-            station.station_code for station in filter(
-                lambda station: (station.selected), planning_area_station_info[area_id])])
+        num_unique_station_codes = len(set(selected_stations))
 
         (daily_results,
          all_dailies_valid) = calculate_daily_results(num_prep_days,

--- a/api/app/hfi/hfi_calc.py
+++ b/api/app/hfi/hfi_calc.py
@@ -1,7 +1,7 @@
 """ HFI calculation logic """
 import math
 import logging
-from typing import Optional, List, Dict, Tuple
+from typing import Optional, List, Dict, Set, Tuple
 from datetime import date, datetime, timedelta, timezone
 from statistics import mean
 from aiohttp.client import ClientSession
@@ -373,7 +373,7 @@ def calculate_hfi_results(fuel_type_lookup: Dict[int, FuelTypeModel],
     planning_area_to_dailies: List[PlanningAreaResult] = []
 
     station_lookup: Dict[str, WFWXWeatherStation] = {station.wfwx_id: station for station in wfwx_stations}
-    wfwx_station_codes: List[int] = set([station.code for station in wfwx_stations])
+    wfwx_station_codes: Set[int] = set([station.code for station in wfwx_stations])
 
     for area_id in planning_area_station_info.keys():
 


### PR DESCRIPTION
We have Salmon Arm, code 346 in our database for Vernon planning area but that doesn't exist anymore, so we were getting None values for MIG and Prep calculations.

This change simplifies the selected station list and filters out stations that don't exist in wf1.

# Test Links:
[Landing Page](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2853.apps.silver.devops.gov.bc.ca/hfi-calculator)
