### PR TITLE
Add wf1Token to forecast submit endpoint

### DIFF
--- a/api/app/schemas/morecast_v2.py
+++ b/api/app/schemas/morecast_v2.py
@@ -77,7 +77,7 @@ class MoreCastForecastInput(BaseModel):
 
 class MoreCastForecastRequest(BaseModel):
     """ Incoming daily forecasts to be saved """
-    wf1Token: str
+    token: str  # WF1 token
     forecasts: List[MoreCastForecastInput]
 
 

--- a/api/app/schemas/morecast_v2.py
+++ b/api/app/schemas/morecast_v2.py
@@ -77,6 +77,7 @@ class MoreCastForecastInput(BaseModel):
 
 class MoreCastForecastRequest(BaseModel):
     """ Incoming daily forecasts to be saved """
+    wf1Token: str
     forecasts: List[MoreCastForecastInput]
 
 

--- a/api/app/tests/morecast_v2/test_morecast_v2_endpoint.py
+++ b/api/app/tests/morecast_v2/test_morecast_v2_endpoint.py
@@ -21,7 +21,7 @@ morecast_v2_post_determinates_url = '/api/morecast-v2/determinates/2023-03-15/20
 
 decode_fn = "jwt.decode"
 
-forecast = MoreCastForecastRequest(wf1Token="testToken", forecasts=[MoreCastForecastInput(
+forecast = MoreCastForecastRequest(token="testToken", forecasts=[MoreCastForecastInput(
     station_code=1, for_date=1, temp=10.0, rh=40, precip=70.2, wind_speed=20.3, wind_direction=40)])
 
 stations = StationsRequest(stations=[1, 2])

--- a/api/app/tests/morecast_v2/test_morecast_v2_endpoint.py
+++ b/api/app/tests/morecast_v2/test_morecast_v2_endpoint.py
@@ -21,7 +21,7 @@ morecast_v2_post_determinates_url = '/api/morecast-v2/determinates/2023-03-15/20
 
 decode_fn = "jwt.decode"
 
-forecast = MoreCastForecastRequest(forecasts=[MoreCastForecastInput(
+forecast = MoreCastForecastRequest(wf1Token="testToken", forecasts=[MoreCastForecastInput(
     station_code=1, for_date=1, temp=10.0, rh=40, precip=70.2, wind_speed=20.3, wind_direction=40)])
 
 stations = StationsRequest(stations=[1, 2])

--- a/web/src/api/moreCast2API.test.ts
+++ b/web/src/api/moreCast2API.test.ts
@@ -49,7 +49,7 @@ describe('moreCast2API', () => {
   })
   it('should call submit endpoint for forecast submission', async () => {
     axios.post = jest.fn().mockResolvedValue({ status: 201 })
-    const res = await submitMoreCastForecastRecords([
+    const res = await submitMoreCastForecastRecords('testToken', [
       buildMorecast2Forecast('1', 1, 'one', DateTime.fromObject({ year: 2021, month: 1, day: 1 })),
       buildMorecast2Forecast('2', 2, 'two', DateTime.fromObject({ year: 2021, month: 1, day: 1 }))
     ])

--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -188,7 +188,7 @@ export async function submitMoreCastForecastRecords(
   const forecastRecords = marshalMoreCast2ForecastRecords(forecasts)
   const url = `/morecast-v2/forecast`
   try {
-    const { status } = await axios.post<MoreCast2ForecastRecord[]>(url, {
+    const { status } = await axios.post<MoreCastForecastRequest>(url, {
       wf1Token,
       forecasts: forecastRecords
     })

--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -156,6 +156,11 @@ export interface MoreCast2ForecastRecord {
   station_name?: string
 }
 
+export interface MoreCastForecastRequest {
+  wf1Token: string
+  forecasts: MoreCast2ForecastRecord[]
+}
+
 export const marshalMoreCast2ForecastRecords = (forecasts: MoreCast2ForecastRow[]): MoreCast2ForecastRecord[] => {
   const forecastRecords: MoreCast2ForecastRecord[] = forecasts.map(forecast => {
     return {
@@ -176,11 +181,15 @@ export const marshalMoreCast2ForecastRecords = (forecasts: MoreCast2ForecastRow[
  * @param forecasts The raw forecast model data.
  * @returns True if the response is a 201, otherwise false.
  */
-export async function submitMoreCastForecastRecords(forecasts: MoreCast2ForecastRow[]): Promise<boolean> {
+export async function submitMoreCastForecastRecords(
+  wf1Token: string,
+  forecasts: MoreCast2ForecastRow[]
+): Promise<boolean> {
   const forecastRecords = marshalMoreCast2ForecastRecords(forecasts)
   const url = `/morecast-v2/forecast`
   try {
     const { status } = await axios.post<MoreCast2ForecastRecord[]>(url, {
+      wf1Token,
       forecasts: forecastRecords
     })
     return status === 201

--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -178,18 +178,19 @@ export const marshalMoreCast2ForecastRecords = (forecasts: MoreCast2ForecastRow[
 
 /**
  * POSTs a batch of forecasts.
+ * @param token The WF1 token.
  * @param forecasts The raw forecast model data.
  * @returns True if the response is a 201, otherwise false.
  */
 export async function submitMoreCastForecastRecords(
-  wf1Token: string,
+  token: string,
   forecasts: MoreCast2ForecastRow[]
 ): Promise<boolean> {
   const forecastRecords = marshalMoreCast2ForecastRecords(forecasts)
   const url = `/morecast-v2/forecast`
   try {
     const { status } = await axios.post<MoreCastForecastRequest>(url, {
-      wf1Token,
+      token,
       forecasts: forecastRecords
     })
     return status === 201

--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -14,7 +14,7 @@ import { selectSelectedStations } from 'features/moreCast2/slices/selectedStatio
 import { groupBy, isEqual, isUndefined } from 'lodash'
 import SaveForecastButton from 'features/moreCast2/components/SaveForecastButton'
 import { ROLES } from 'features/auth/roles'
-import { selectAuthentication } from 'app/rootReducer'
+import { selectAuthentication, selectWf1Authentication } from 'app/rootReducer'
 import { DateRange } from 'components/dateRangePicker/types'
 import MoreCast2Snackbar from 'features/moreCast2/components/MoreCast2Snackbar'
 import { isForecastRowPredicate, getRowsToSave, isForecastValid } from 'features/moreCast2/saveForecasts'
@@ -56,6 +56,7 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
   const selectedStations = useSelector(selectSelectedStations)
   const loading = useSelector(selectWeatherIndeterminatesLoading)
   const { roles, isAuthenticated } = useSelector(selectAuthentication)
+  const { wf1Token } = useSelector(selectWf1Authentication)
 
   // A copy of the sortedMoreCast2Rows as local state
   const [allRows, setAllRows] = useState<MoreCast2Row[]>(morecast2Rows)
@@ -275,9 +276,9 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
   }
 
   const handleSaveClick = async () => {
-    if (isForecastValid(visibleRows)) {
+    if (isForecastValid(visibleRows) && !isUndefined(wf1Token)) {
       const rowsToSave: MoreCast2ForecastRow[] = getRowsToSave(visibleRows)
-      const result = await submitMoreCastForecastRecords(rowsToSave)
+      const result = await submitMoreCastForecastRecords(wf1Token, rowsToSave)
       if (result) {
         setSnackbarMessage(FORECAST_SAVED_MESSAGE)
         setSnackbarSeverity('success')


### PR DESCRIPTION
Allows us to make requests from backend to wf1
# Test Links:
[Landing Page](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2899.apps.silver.devops.gov.bc.ca/hfi-calculator)
