### PR TITLE
Actuals can be labelled as manuals

### DIFF
--- a/api/app/tests/wildfire_one/test_schema_parsers.py
+++ b/api/app/tests/wildfire_one/test_schema_parsers.py
@@ -187,6 +187,15 @@ async def test_indeterminate_mapper_actual(anyio_backend):
 
 
 @pytest.mark.anyio
+async def test_indeterminate_mapper_manual(anyio_backend):
+    observed, forecast = await weather_indeterminate_list_mapper(async_observed_dailies("MANUAL"))
+    assert len(forecast) == 0
+    assert len(observed) == 1
+    assert observed[0].determinate == WeatherDeterminate.ACTUAL
+    assert observed[0].station_code == 1
+
+
+@pytest.mark.anyio
 async def test_indeterminate_mapper_forecast(anyio_backend):
     observed, forecast = await weather_indeterminate_list_mapper(async_observed_dailies("FORECAST"))
     assert len(observed) == 0

--- a/api/app/wildfire_one/schema_parsers.py
+++ b/api/app/wildfire_one/schema_parsers.py
@@ -81,7 +81,7 @@ async def weather_indeterminate_list_mapper(raw_dailies: Generator[dict, None, N
     observed_dailies = []
     forecasts = []
     async for raw_daily in raw_dailies:
-        if is_station_valid(raw_daily.get('stationData')) and raw_daily.get('recordType').get('id') in [WF1RecordTypeEnum.ACTUAL, WF1RecordTypeEnum.MANUAL]:
+        if is_station_valid(raw_daily.get('stationData')) and raw_daily.get('recordType').get('id') in [WF1RecordTypeEnum.ACTUAL.value, WF1RecordTypeEnum.MANUAL.value]:
             observed_dailies.append(WeatherIndeterminate(
                 station_code=raw_daily.get('stationData').get('stationCode'),
                 station_name=raw_daily.get('stationData').get('displayLabel'),
@@ -93,7 +93,7 @@ async def weather_indeterminate_list_mapper(raw_dailies: Generator[dict, None, N
                 wind_direction=raw_daily.get('windDirection'),
                 wind_speed=raw_daily.get('windSpeed')
             ))
-        elif is_station_valid(raw_daily.get('stationData')) and raw_daily.get('recordType').get('id') == WF1RecordTypeEnum.FORECAST:
+        elif is_station_valid(raw_daily.get('stationData')) and raw_daily.get('recordType').get('id') == WF1RecordTypeEnum.FORECAST.value:
             forecasts.append(WeatherIndeterminate(
                 station_code=raw_daily.get('stationData').get('stationCode'),
                 station_name=raw_daily.get('stationData').get('displayLabel'),

--- a/api/app/wildfire_one/schema_parsers.py
+++ b/api/app/wildfire_one/schema_parsers.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 class WF1RecordTypeEnum(enum.Enum):
     ACTUAL = 'ACTUAL'
     FORECAST = 'FORECAST'
+    MANUAL = 'MANUAL'
 
 
 class WFWXWeatherStation():
@@ -80,7 +81,7 @@ async def weather_indeterminate_list_mapper(raw_dailies: Generator[dict, None, N
     observed_dailies = []
     forecasts = []
     async for raw_daily in raw_dailies:
-        if is_station_valid(raw_daily.get('stationData')) and raw_daily.get('recordType').get('id') == "ACTUAL":
+        if is_station_valid(raw_daily.get('stationData')) and raw_daily.get('recordType').get('id') in [WF1RecordTypeEnum.ACTUAL, WF1RecordTypeEnum.MANUAL]:
             observed_dailies.append(WeatherIndeterminate(
                 station_code=raw_daily.get('stationData').get('stationCode'),
                 station_name=raw_daily.get('stationData').get('displayLabel'),
@@ -92,7 +93,7 @@ async def weather_indeterminate_list_mapper(raw_dailies: Generator[dict, None, N
                 wind_direction=raw_daily.get('windDirection'),
                 wind_speed=raw_daily.get('windSpeed')
             ))
-        elif is_station_valid(raw_daily.get('stationData')) and raw_daily.get('recordType').get('id') == "FORECAST":
+        elif is_station_valid(raw_daily.get('stationData')) and raw_daily.get('recordType').get('id') == WF1RecordTypeEnum.FORECAST:
             forecasts.append(WeatherIndeterminate(
                 station_code=raw_daily.get('stationData').get('stationCode'),
                 station_name=raw_daily.get('stationData').get('displayLabel'),


### PR DESCRIPTION
If a forecaster manually enters data in the past for a weather station it is recorded in WF1 as a 'MANUAL' value instead of an 'ACTUAL'. This PR adjust our code to treat ACTUAL and MANUAL as equivalent in our API.

To test:
1. Load up the MoreCast2 PR deployment
2. Uncheck 'Show only my groups'
3. Search for Boss1
4. When the data loads, toggle off 14G and toggle on Smallwood

Expected result: You should see Actual values for June 15 for Smallwood. Note that the date order is incorrect! I'll file a new ticket for that issue. The 'actual' values should match the values in WF1 test which appear as Manual entries as seen below:

![image](https://github.com/bcgov/wps/assets/7094320/4c859f32-c2f0-48db-9392-c1326bb340ad)


Sanity check: Look at Smallwood in your local dev environment on the main branch and you won't see the manual values from WF1 test for June 15.

# Test Links:
[Landing Page](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2942.apps.silver.devops.gov.bc.ca/hfi-calculator)
