### PR TITLE
Sort by stationName and forDate

### DIFF
--- a/web/src/features/moreCast2/slices/dataSlice.ts
+++ b/web/src/features/moreCast2/slices/dataSlice.ts
@@ -408,7 +408,7 @@ export const selectAllMoreCast2Rows = createSelector([selectWeatherIndeterminate
     weatherIndeterminates.forecasts,
     weatherIndeterminates.predictions
   )
-  const sortedRows = sortRowsByStationName(rows)
+  const sortedRows = sortRowsByStationNameAndDate(rows)
   return sortedRows
 })
 
@@ -428,26 +428,25 @@ export const selectForecastMoreCast2Rows = createSelector([selectAllMoreCast2Row
 
 export const selectWeatherIndeterminatesLoading = (state: RootState) => state.weatherIndeterminates.loading
 
-function sortRowsByStationName(rows: MoreCast2Row[]) {
-  const groupedRows = groupRowsByStationName(rows)
-  const keys = Object.keys(groupedRows)
+function sortRowsByStationNameAndDate(rows: MoreCast2Row[]) {
+  // Group the rows by station name to start
+  const groupedRows = groupBy(rows, 'stationName')
+  // Now sort the rows by 'forDate' within each group
+  const groupedSorted: { [key: string]: MoreCast2Row[] } = {}
+  for (const [key, value] of Object.entries(groupedRows)) {
+    groupedSorted[key] = value.sort((a, b) => (a.forDate < b.forDate ? -1 : a.forDate > b.forDate ? 1 : 0))
+  }
+
+  // Finally, sort the keys of the groups alphabetically and then build up a new
+  // array of rows which will be sorted first by station name and then by the forDate
+  const keys = Object.keys(groupedSorted)
   keys.sort()
   let sortedRows: MoreCast2Row[] = []
   for (const key of keys) {
-    const rowsForKey = groupedRows[key]
+    const rowsForKey = groupedSorted[key]
     sortedRows = [...sortedRows, ...rowsForKey]
   }
   return sortedRows
-}
-
-function groupRowsByStationName(rows: MoreCast2Row[]) {
-  return rows.reduce((acc: { [key: string]: MoreCast2Row[] }, item: MoreCast2Row) => {
-    const group = item.stationName
-    acc[group] = acc[group] || []
-    acc[group].push(item)
-
-    return acc
-  }, {})
 }
 
 /**

--- a/web/src/features/moreCast2/slices/dataSlice.ts
+++ b/web/src/features/moreCast2/slices/dataSlice.ts
@@ -428,13 +428,24 @@ export const selectForecastMoreCast2Rows = createSelector([selectAllMoreCast2Row
 
 export const selectWeatherIndeterminatesLoading = (state: RootState) => state.weatherIndeterminates.loading
 
+// Comparator function for use in sorting Luxon DateTime objects with JavaScript Array.prototype.sort
+function compareDateTime(a: DateTime, b: DateTime) {
+  if (a < b) {
+    return -1
+  } else if (a > b) {
+    return 1
+  } else {
+    return 0
+  }
+}
+
 function sortRowsByStationNameAndDate(rows: MoreCast2Row[]) {
   // Group the rows by station name to start
   const groupedRows = groupBy(rows, 'stationName')
   // Now sort the rows by 'forDate' within each group
   const groupedSorted: { [key: string]: MoreCast2Row[] } = {}
   for (const [key, value] of Object.entries(groupedRows)) {
-    groupedSorted[key] = value.sort((a, b) => (a.forDate < b.forDate ? -1 : a.forDate > b.forDate ? 1 : 0))
+    groupedSorted[key] = value.sort((a, b) => compareDateTime(a.forDate, b.forDate))
   }
 
   // Finally, sort the keys of the groups alphabetically and then build up a new


### PR DESCRIPTION
To test:

1. Load up the MoreCast2 dev deployment
2. Uncheck 'Show only my groups'
3. Search for Boss1
4. Uncheck 14G and check Smallwood
5. Set the date range for June 12 - 17

The dates should be in the correct order.

If you run locally using main, you would see June 15 as the first row (as seen in the screenshot in the original issue https://github.com/bcgov/wps/issues/2943


# Test Links:
[Landing Page](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-2945.apps.silver.devops.gov.bc.ca/hfi-calculator)
