### PR TITLE
Calculate precip by 24 hour period

### DIFF
--- a/api/alembic/versions/7217281a3218_add_24_hour_precip_field_to_.py
+++ b/api/alembic/versions/7217281a3218_add_24_hour_precip_field_to_.py
@@ -1,0 +1,24 @@
+"""Add 24 hour precip field to WeatherStationModelPrediction
+
+Revision ID: 7217281a3218
+Revises: 4916cd5313de
+Create Date: 2023-07-25 10:53:19.447483
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7217281a3218'
+down_revision = '4916cd5313de'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('weather_station_model_predictions', sa.Column('precip_24h', sa.Float(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('weather_station_model_predictions', 'precip_24h')

--- a/api/app/db/crud/weather_models.py
+++ b/api/app/db/crud/weather_models.py
@@ -474,3 +474,12 @@ def refresh_morecast2_materialized_view(session: Session):
     logger.info("Refreshing morecast_2_materialized_view")
     session.execute(text("REFRESH MATERIALIZED VIEW morecast_2_materialized_view"))
     logger.info(f"Finished mat view refresh with elapsed time: {datetime.datetime.now() - start}")
+
+
+def get_previous_prediction_model_run(session: Session, prediction_model_run: PredictionModelRunTimestamp):
+    """ Get the prediction model run that ran immediately prior to the prediciontal model run passed as a paraemter. """
+    return session.query(PredictionModelRunTimestamp).\
+        filter(PredictionModelRunTimestamp.prediction_model_id == prediction_model_run.prediction_model_id).\
+        filter(PredictionModelRunTimestamp.id < prediction_model_run.id).\
+        order_by(PredictionModelRunTimestamp.prediction_run_timestamp.desc()).\
+        first()

--- a/api/app/db/models/weather_models.py
+++ b/api/app/db/models/weather_models.py
@@ -214,6 +214,8 @@ class WeatherStationModelPrediction(Base):
     # Date this record was updated.
     update_date = Column(TZTimeStamp, nullable=False,
                          default=time_utils.get_utc_now(), index=True)
+    # Precipitation predicted for the previous 24 hour period based on the current weather model run.
+    precip_24h = Column(Float, nullable=True)
 
     def __str__(self):
         return ('{self.station_code} {self.prediction_timestamp} {self.tmp_tgl_2} {self.apcp_sfc_0} '

--- a/api/app/jobs/common_model_fetchers.py
+++ b/api/app/jobs/common_model_fetchers.py
@@ -3,8 +3,8 @@ from typing import List
 import logging
 import requests
 import numpy
+from datetime import timedelta
 from pyproj import Geod
-from scipy.interpolate import griddata
 from geoalchemy2.shape import to_shape
 from sqlalchemy.orm import Session
 from app.db.crud.weather_models import (get_processed_file_record,
@@ -15,7 +15,8 @@ from app.db.crud.weather_models import (get_processed_file_record,
                                         get_weather_station_model_prediction,
                                         delete_model_run_grid_subset_predictions,
                                         delete_weather_station_model_predictions,
-                                        refresh_morecast2_materialized_view)
+                                        refresh_morecast2_materialized_view,
+                                        get_previous_prediction_model_run)
 from app.weather_models.machine_learning import StationMachineLearning
 from app.weather_models import ModelEnum, construct_interpolated_noon_prediction
 from app.schemas.stations import WeatherStation
@@ -248,8 +249,7 @@ class ModelValueProcessor:
         if prediction.tmp_tgl_2 is None:
             logger.warning('tmp_tgl_2 is None for ModelRunGridSubsetPrediction.id == %s', prediction.id)
         else:
-            station_prediction.tmp_tgl_2 = griddata(
-                points, prediction.tmp_tgl_2, coordinate, method='linear')[0]
+            station_prediction.tmp_tgl_2 = prediction.tmp_tgl_2[0]
 
         # 2020 Dec 10, Sybrand: Encountered situation where rh_tgl_2 was None, add this workaround for it.
         # NOTE: Not sure why this value would ever be None. This could happen if for whatever reason, the
@@ -259,24 +259,24 @@ class ModelValueProcessor:
             logger.warning('rh_tgl_2 is None for ModelRunGridSubsetPrediction.id == %s', prediction.id)
             station_prediction.rh_tgl_2 = None
         else:
-            station_prediction.rh_tgl_2 = griddata(
-                points, prediction.rh_tgl_2, coordinate, method='linear')[0]
+            station_prediction.rh_tgl_2 = prediction.rh_tgl_2[0]
         # Check that apcp_sfc_0 is None, since accumulated precipitation
         # does not exist for 00 hour.
         if prediction.apcp_sfc_0 is None:
             station_prediction.apcp_sfc_0 = 0.0
         else:
-            station_prediction.apcp_sfc_0 = griddata(
-                points, prediction.apcp_sfc_0, coordinate, method='linear')[0]
+            station_prediction.apcp_sfc_0 = prediction.apcp_sfc_0[0]
         # Calculate the delta_precipitation based on station's previous prediction_timestamp
         # for the same model run
         self.session.flush()
+        station_prediction.precip_24h = self._calculate_past_24_hour_precip(
+            station, model_run, prediction, station_prediction)
         station_prediction.delta_precip = self._calculate_delta_precip(
             station, model_run, prediction, station_prediction)
 
         # Get the closest wind speed
         if prediction.wind_tgl_10 is not None:
-            station_prediction.wind_tgl_10 = prediction.wind_tgl_10[get_closest_index(coordinate, points)]
+            station_prediction.wind_tgl_10 = prediction.wind_tgl_10[0]
         # Get the closest wind direcion
         if prediction.wdir_tgl_10 is not None:
             station_prediction.wdir_tgl_10 = prediction.wdir_tgl_10[get_closest_index(coordinate, points)]
@@ -292,6 +292,31 @@ class ModelValueProcessor:
         station_prediction.update_date = time_utils.get_utc_now()
         # Add this prediction to the session (we'll commit it later.)
         self.session.add(station_prediction)
+
+    def _calculate_past_24_hour_precip(self, station: WeatherStation, model_run: PredictionModelRunTimestamp,
+                                       prediction: ModelRunGridSubsetPrediction, station_prediction: WeatherStationModelPrediction):
+        """ Calculate the predicted precipitation over the previous 24 hours within the specified model run.
+        If the model run does not contain a prediction timestamp for 24 hours prior to the current prediction,
+        return the predicted precipitation from the previous run of the same model for the same time frame. """
+        start_prediction_timestamp = prediction.prediction_timestamp - timedelta(days=1)
+        # Check if a prediction exists for this model run 24 hours in the past
+        previous_prediction_from_same_model_run = get_weather_station_model_prediction(self.session, station.code,
+                                                                                       model_run.id, start_prediction_timestamp)
+        # If a prediction from 24 hours ago from the same model run exists, return the difference in cumulative precipitation
+        # between now and then as our total for the past 24 hours.
+        if previous_prediction_from_same_model_run is not None:
+            return station_prediction.apcp_sfc_0 - previous_prediction_from_same_model_run.apcp_sfc_0
+        # We're within 24 hours of the start of a model run, retrieve the precip_24h for the previous
+        # model run if it exists, else return None
+        # First, find the previous prediction model run so we can query using its id
+        previous_model_run = get_previous_prediction_model_run(self.session, model_run)
+        if previous_model_run is not None:
+            # Try looking up a precip_24h from the previous model run.
+            previous_prediction_from_previous_model_run = get_weather_station_model_prediction(
+                self.session, station.code, previous_model_run.id, prediction.prediction_timestamp)
+            if previous_prediction_from_previous_model_run is not None:
+                return previous_prediction_from_previous_model_run.precip_24h
+        return None
 
     def _calculate_delta_precip(self, station, model_run, prediction, station_prediction):
         """ Calculate the station_prediction's delta_precip based on the previous precip


### PR DESCRIPTION
Groundwork for displaying precip for the previous 24 hour period.

A new column has been added to the WeatherStationModelPrediction model to hold the calculated 24 hour precip value.

# Test Links:
[Landing Page](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3033.apps.silver.devops.gov.bc.ca/hfi-calculator)
