### PR TITLE
Calculate precip by 24 hour period

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -170,11 +170,11 @@ jobs:
       #     oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
       #     PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_hrdps_cronjob.sh ${SUFFIX} apply
 
-      # - name: Environment Canada RDPS cronjob
-      #   shell: bash
-      #   run: |
-      #     oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
-      #     PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
+      - name: Environment Canada RDPS cronjob
+        shell: bash
+        run: |
+          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
+          PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_ec_rdps_cronjob.sh ${SUFFIX} apply
 
       - name: NOAA GFS cronjob
         shell: bash

--- a/api/alembic/versions/7217281a3218_add_24_hour_precip_field_to_.py
+++ b/api/alembic/versions/7217281a3218_add_24_hour_precip_field_to_.py
@@ -1,0 +1,24 @@
+"""Add 24 hour precip field to WeatherStationModelPrediction
+
+Revision ID: 7217281a3218
+Revises: 4916cd5313de
+Create Date: 2023-07-25 10:53:19.447483
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7217281a3218'
+down_revision = '4916cd5313de'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('weather_station_model_predictions', sa.Column('precip_24h', sa.Float(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('weather_station_model_predictions', 'precip_24h')

--- a/api/alembic/versions/7217281a3218_add_24_hour_precip_field_to_.py
+++ b/api/alembic/versions/7217281a3218_add_24_hour_precip_field_to_.py
@@ -19,6 +19,30 @@ depends_on = None
 def upgrade():
     op.add_column('weather_station_model_predictions', sa.Column('precip_24h', sa.Float(), nullable=True))
 
+    op.execute("""CREATE MATERIALIZED VIEW morecast_2_materialized_view_precip AS 
+            SELECT weather_station_model_predictions.prediction_timestamp, prediction_models.abbreviation, weather_station_model_predictions.station_code, weather_station_model_predictions.rh_tgl_2, weather_station_model_predictions.tmp_tgl_2, weather_station_model_predictions.bias_adjusted_temperature, weather_station_model_predictions.bias_adjusted_rh, weather_station_model_predictions.precip_24h, weather_station_model_predictions.wdir_tgl_10, weather_station_model_predictions.wind_tgl_10, weather_station_model_predictions.update_date 
+            FROM weather_station_model_predictions 
+            JOIN prediction_model_run_timestamps 
+            ON weather_station_model_predictions.prediction_model_run_timestamp_id = prediction_model_run_timestamps.id JOIN prediction_models 
+            ON prediction_model_run_timestamps.prediction_model_id = prediction_models.id 
+            JOIN ( 
+            SELECT max(weather_station_model_predictions.prediction_timestamp) AS latest_prediction, weather_station_model_predictions.station_code AS station_code, 
+            date(weather_station_model_predictions.prediction_timestamp) AS unique_day 
+            FROM weather_station_model_predictions 
+            WHERE date_part('hour', weather_station_model_predictions.prediction_timestamp) = 20 
+            GROUP BY weather_station_model_predictions.station_code, date(weather_station_model_predictions.prediction_timestamp) 
+            ) AS latest 
+            ON weather_station_model_predictions.prediction_timestamp = latest.latest_prediction AND weather_station_model_predictions.station_code = latest.station_code 
+            ORDER BY weather_station_model_predictions.update_date DESC;""")
+
+    op.create_index(op.f('ix_mat_view_precip_prediction_timestamp'),
+                    'morecast_2_materialized_view_precip', ['prediction_timestamp'], unique=False)
+    op.create_index(op.f('ix_mat_view_precip_station_code'),
+                    'morecast_2_materialized_view_precip', ['station_code'], unique=False)
+
 
 def downgrade():
     op.drop_column('weather_station_model_predictions', 'precip_24h')
+    op.drop_index(op.f('ix_mat_view_precip_prediction_timestamp'), table_name='morecast_2_materialized_view_precip')
+    op.drop_index(op.f('ix_mat_view_precip_station_code'), table_name='morecast_2_materialized_view_precip')
+    op.execute('DROP MATERIALIZED VIEW morecast_2_materialized_view_precip')

--- a/api/app/db/crud/weather_models.py
+++ b/api/app/db/crud/weather_models.py
@@ -474,3 +474,12 @@ def refresh_morecast2_materialized_view(session: Session):
     logger.info("Refreshing morecast_2_materialized_view")
     session.execute(text("REFRESH MATERIALIZED VIEW morecast_2_materialized_view"))
     logger.info(f"Finished mat view refresh with elapsed time: {datetime.datetime.now() - start}")
+
+
+def get_previous_prediction_model_run(session: Session, prediction_model_run: PredictionModelRunTimestamp):
+    """ Get the prediction model run that ran immediately prior to the prediciontal model run passed as a paraemter. """
+    return session.query(PredictionModelRunTimestamp).\
+        filter(PredictionModelRunTimestamp.prediction_model_id == prediction_model_run.prediction_model_id).\
+        filter(PredictionModelRunTimestamp.id < prediction_model_run.id).\
+        order_by(PredictionModelRunTimestamp.prediction_run_timestamp.desc()).\
+        first()

--- a/api/app/db/models/weather_models.py
+++ b/api/app/db/models/weather_models.py
@@ -239,3 +239,22 @@ class MoreCast2MaterializedView(Base):
     update_date = Column(TZTimeStamp, nullable=False, index=True)
     wdir_tgl_10 = Column(Float, nullable=False)
     wind_tgl_10 = Column(Float, nullable=False)
+
+
+class MoreCast2PrecipMaterializedView(Base):
+    """ A materialized view to support efficient retrieval of weather model prediction data by
+        stations and dates."""
+    __tablename__ = 'morecast_2_materialized_view_precip'
+    id = Column(Integer, Sequence('morecast_forecast_id_seq'),
+                primary_key=True, nullable=False, index=True)
+    abbreviation = Column(String, nullable=False)
+    bias_adjusted_rh = Column(Float, nullable=False)
+    bias_adjusted_temperature = Column(Float, nullable=False)
+    precip_24h = Column(Float, nullable=False)
+    prediction_timestamp = Column(TZTimeStamp, nullable=False, index=True)
+    station_code = Column(Integer, nullable=True, index=True)
+    rh_tgl_2 = Column(Float, nullable=False)
+    tmp_tgl_2 = Column(Float, nullable=False)
+    update_date = Column(TZTimeStamp, nullable=False, index=True)
+    wdir_tgl_10 = Column(Float, nullable=False)
+    wind_tgl_10 = Column(Float, nullable=False)

--- a/api/app/db/models/weather_models.py
+++ b/api/app/db/models/weather_models.py
@@ -214,6 +214,8 @@ class WeatherStationModelPrediction(Base):
     # Date this record was updated.
     update_date = Column(TZTimeStamp, nullable=False,
                          default=time_utils.get_utc_now(), index=True)
+    # Precipitation predicted for the previous 24 hour period based on the current weather model run.
+    precip_24h = Column(Float, nullable=True)
 
     def __str__(self):
         return ('{self.station_code} {self.prediction_timestamp} {self.tmp_tgl_2} {self.apcp_sfc_0} '

--- a/api/app/jobs/common_model_fetchers.py
+++ b/api/app/jobs/common_model_fetchers.py
@@ -15,7 +15,7 @@ from app.db.crud.weather_models import (get_processed_file_record,
                                         get_weather_station_model_prediction,
                                         delete_model_run_grid_subset_predictions,
                                         delete_weather_station_model_predictions,
-                                        refresh_morecast2_materialized_view,
+                                        refresh_morecast2_materialized_view_precip,
                                         get_previous_prediction_model_run)
 from app.weather_models.machine_learning import StationMachineLearning
 from app.weather_models import ModelEnum, construct_interpolated_noon_prediction
@@ -405,4 +405,4 @@ class ModelValueProcessor:
             self._process_model_run(model_run)
             # Mark the model run as interpolated.
             self._mark_model_run_interpolated(model_run)
-        refresh_morecast2_materialized_view(self.session)
+        refresh_morecast2_materialized_view_precip(self.session)

--- a/api/app/jobs/common_model_fetchers.py
+++ b/api/app/jobs/common_model_fetchers.py
@@ -3,8 +3,8 @@ from typing import List
 import logging
 import requests
 import numpy
+from datetime import timedelta
 from pyproj import Geod
-from scipy.interpolate import griddata
 from geoalchemy2.shape import to_shape
 from sqlalchemy.orm import Session
 from app.db.crud.weather_models import (get_processed_file_record,
@@ -15,7 +15,8 @@ from app.db.crud.weather_models import (get_processed_file_record,
                                         get_weather_station_model_prediction,
                                         delete_model_run_grid_subset_predictions,
                                         delete_weather_station_model_predictions,
-                                        refresh_morecast2_materialized_view)
+                                        refresh_morecast2_materialized_view,
+                                        get_previous_prediction_model_run)
 from app.weather_models.machine_learning import StationMachineLearning
 from app.weather_models import ModelEnum, construct_interpolated_noon_prediction
 from app.schemas.stations import WeatherStation
@@ -248,8 +249,7 @@ class ModelValueProcessor:
         if prediction.tmp_tgl_2 is None:
             logger.warning('tmp_tgl_2 is None for ModelRunGridSubsetPrediction.id == %s', prediction.id)
         else:
-            station_prediction.tmp_tgl_2 = griddata(
-                points, prediction.tmp_tgl_2, coordinate, method='linear')[0]
+            station_prediction.tmp_tgl_2 = prediction.tmp_tgl_2[0]
 
         # 2020 Dec 10, Sybrand: Encountered situation where rh_tgl_2 was None, add this workaround for it.
         # NOTE: Not sure why this value would ever be None. This could happen if for whatever reason, the
@@ -259,24 +259,24 @@ class ModelValueProcessor:
             logger.warning('rh_tgl_2 is None for ModelRunGridSubsetPrediction.id == %s', prediction.id)
             station_prediction.rh_tgl_2 = None
         else:
-            station_prediction.rh_tgl_2 = griddata(
-                points, prediction.rh_tgl_2, coordinate, method='linear')[0]
+            station_prediction.rh_tgl_2 = prediction.rh_tgl_2[0]
         # Check that apcp_sfc_0 is None, since accumulated precipitation
         # does not exist for 00 hour.
         if prediction.apcp_sfc_0 is None:
             station_prediction.apcp_sfc_0 = 0.0
         else:
-            station_prediction.apcp_sfc_0 = griddata(
-                points, prediction.apcp_sfc_0, coordinate, method='linear')[0]
+            station_prediction.apcp_sfc_0 = prediction.apcp_sfc_0[0]
         # Calculate the delta_precipitation based on station's previous prediction_timestamp
         # for the same model run
         self.session.flush()
+        station_prediction.precip_24h = self._calculate_past_24_hour_precip(
+            station, model_run, prediction, station_prediction)
         station_prediction.delta_precip = self._calculate_delta_precip(
             station, model_run, prediction, station_prediction)
 
         # Get the closest wind speed
         if prediction.wind_tgl_10 is not None:
-            station_prediction.wind_tgl_10 = prediction.wind_tgl_10[get_closest_index(coordinate, points)]
+            station_prediction.wind_tgl_10 = prediction.wind_tgl_10[0]
         # Get the closest wind direcion
         if prediction.wdir_tgl_10 is not None:
             station_prediction.wdir_tgl_10 = prediction.wdir_tgl_10[get_closest_index(coordinate, points)]
@@ -292,6 +292,31 @@ class ModelValueProcessor:
         station_prediction.update_date = time_utils.get_utc_now()
         # Add this prediction to the session (we'll commit it later.)
         self.session.add(station_prediction)
+
+    def _calculate_past_24_hour_precip(self, station: WeatherStation, model_run: PredictionModelRunTimestamp,
+                                       prediction: ModelRunGridSubsetPrediction, station_prediction: WeatherStationModelPrediction):
+        """ Calculate the predicted precipitation over the previous 24 hours within the specified model run.
+        If the model run does not contain a prediction timestamp for 24 hours prior to the current prediction,
+        return the predicted precipitation from the previous run of the same model for the same time frame. """
+        start_prediction_timestamp = prediction.prediction_timestamp - timedelta(days=1)
+        # Check if a prediction exists for this model run 24 hours in the past
+        previous_prediction_from_same_model_run = get_weather_station_model_prediction(self.session, station.code,
+                                                                                       model_run.id, start_prediction_timestamp)
+        # If a prediction from 24 hours ago from the same model run exists, return the difference in cumulative precipitation
+        # between now and then as our total for the past 24 hours.
+        if previous_prediction_from_same_model_run is not None:
+            return station_prediction.apcp_sfc_0 - previous_prediction_from_same_model_run.apcp_sfc_0
+        # We're within 24 hours of the start of a model run, retrieve the precip_24h for the previous
+        # model run if it exists, else return None
+        # First, find the previous prediction model run so we can query using its id
+        previous_model_run = get_previous_prediction_model_run(self.session, model_run)
+        if previous_model_run is not None:
+            # Try looking up a precip_24h from the previous model run.
+            previous_prediction_from_previous_model_run = get_weather_station_model_prediction(
+                self.session, station.code, previous_model_run.id, prediction.prediction_timestamp)
+            if previous_prediction_from_previous_model_run is not None:
+                return previous_prediction_from_previous_model_run.precip_24h
+        return None
 
     def _calculate_delta_precip(self, station, model_run, prediction, station_prediction):
         """ Calculate the station_prediction's delta_precip based on the previous precip

--- a/api/app/weather_models/fetch/predictions.py
+++ b/api/app/weather_models/fetch/predictions.py
@@ -15,8 +15,8 @@ from app.schemas.weather_models import (WeatherStationModelPredictionValues, Wea
                                         ModelRunPredictions,
                                         WeatherStationModelRunsPredictions)
 from app.db.models.weather_models import WeatherStationModelPrediction
-from app.db.crud.weather_models import (get_latest_station_model_prediction_per_day, get_latest_station_prediction_per_day, get_station_model_predictions,
-                                        get_station_model_prediction_from_previous_model_run, get_latest_station_prediction_mat_view)
+from app.db.crud.weather_models import (get_latest_station_model_prediction_per_day, get_station_model_predictions,
+                                        get_station_model_prediction_from_previous_model_run, get_latest_station_prediction_from_materialized_view)
 import app.stations
 from app.utils.time import get_days_from_range
 from app.weather_models import ModelEnum
@@ -138,7 +138,7 @@ async def fetch_latest_model_run_predictions_by_station_code_and_date_range(sess
         day_start = vancouver_tz.localize(datetime.datetime.combine(day, time.min))
         day_end = vancouver_tz.localize(datetime.datetime.combine(day, time.max))
 
-        daily_result = get_latest_station_prediction_mat_view(
+        daily_result = get_latest_station_prediction_from_materialized_view(
             session, active_station_codes, day_start, day_end)
         for timestamp, model_abbrev, station_code, rh, temp, bias_adjusted_temp, bias_adjusted_rh, precip_24hours, wind_dir, wind_speed, update_date in daily_result:
 


### PR DESCRIPTION
- Groundwork for displaying precip for the previous 24 hour period.
- A new column has been added to the WeatherStationModelPrediction model to hold the calculated 24 hour precip value.
- New materialized view for testing purposes. Will consolidate to a single mat view before deployment and merge

I confirmed with a forecaster that we want to be showing the predicted precip for the previous 24 hour period. I'll try and explain how this is working using an HRDPS model run at 00:00 hours. When processing the numerical weather model data we're actually just interested in data for each day at 20:00 UTC. For the 00:00 HRDPS model run, this happens at the 020 hour mark and the 044 hour mark of the 48 hours that the model creates predictions for.

I'm making an assumption that I think is sound. I'm assuming that when calculating precip for a 24 hour period, we need to be doing this within the context of the specific model run. This leads to a problem where at the first 20:00 mark, there is no prior prediction within the current model run that is 24 hours in the past. The decision I'm suggesting is that we use the 24 hour precip calculated from the previous model run. When we're processing the 044 hour data, we take the accumulated precip and subtract the accumulated precip from the 020 hour data.

# Test Links:
[Landing Page](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3034.apps.silver.devops.gov.bc.ca/hfi-calculator)
