### PR TITLE
Allow 200 as well as 201 responses from WF1 Forecast POST endpoint

### DIFF
--- a/api/app/wildfire_one/wfwx_post_api.py
+++ b/api/app/wildfire_one/wfwx_post_api.py
@@ -23,7 +23,8 @@ async def post_forecasts(session: ClientSession,
 
     async with session.post(WF1_FORECAST_POST_URL, json=forecasts_json, headers=headers) as response:
         response_json = await response.json()
-        if response.status != status.HTTP_201_CREATED:
+        if response.status == status.HTTP_201_CREATED or response.status == status.HTTP_200_OK:
+            logger.info('submitted forecasts to wf1 %s.', response_json)
+        else:
             logger.error(f'error submitting forecasts to wf1 {response_json}')
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Error submitting forecast(s) to WF1')
-        logger.info('submitted forecasts to wf1 %s.', response_json)


### PR DESCRIPTION
- The return 200s, not 201s.
- Reproduced and tested locally in the WF1 test environment 

# Test Links:
[Landing Page](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3045.apps.silver.devops.gov.bc.ca/hfi-calculator)
