### PR TITLE
Allow floats for RH in morecast2

### DIFF
--- a/api/app/schemas/morecast_v2.py
+++ b/api/app/schemas/morecast_v2.py
@@ -69,7 +69,7 @@ class MoreCastForecastInput(BaseModel):
     station_code: int
     for_date: int
     temp: float
-    rh: int
+    rh: float
     precip: float
     wind_speed: float
     wind_direction: int | None = None

--- a/api/app/tests/morecast_v2/test_morecast_v2_endpoint.py
+++ b/api/app/tests/morecast_v2/test_morecast_v2_endpoint.py
@@ -22,7 +22,7 @@ morecast_v2_post_determinates_url = '/api/morecast-v2/determinates/2023-03-15/20
 decode_fn = "jwt.decode"
 
 forecast = MoreCastForecastRequest(token="testToken", forecasts=[MoreCastForecastInput(
-    station_code=1, for_date=1, temp=10.0, rh=40, precip=70.2, wind_speed=20.3, wind_direction=40)])
+    station_code=1, for_date=1, temp=10.0, rh=40.1, precip=70.2, wind_speed=20.3, wind_direction=40)])
 
 stations = StationsRequest(stations=[1, 2])
 


### PR DESCRIPTION
- PE was getting validation errors
- https://docs.pydantic.dev/latest/errors/validation_errors/#int_from_float

![MicrosoftTeams-image (2)](https://github.com/bcgov/wps/assets/1447136/7e886301-a10a-47c7-a4e9-cadbeb78cada)

# Test Links:
[Landing Page](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3046.apps.silver.devops.gov.bc.ca/hfi-calculator)
