### PR TITLE
Story/actuals in summaries tab

### DIFF
--- a/web/src/components/DateRangeSelector.tsx
+++ b/web/src/components/DateRangeSelector.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, IconButton, InputAdornment, TextField } from '@mui/material'
+import { Button, Dialog, Icon, InputAdornment, TextField } from '@mui/material'
 import * as materialIcons from '@mui/icons-material'
 import DateRangePickerWrapper from 'components/dateRangePicker/DateRangePickerWrapper'
 import { DateRange } from 'components/dateRangePicker/types'
@@ -50,9 +50,9 @@ const DateRangeSelector = ({ dateRange, dateDisplayFormat, size, label, setDateR
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
-                <IconButton edge="end" size="large">
+                <Icon>
                   <materialIcons.DateRange />
-                </IconButton>
+                </Icon>
               </InputAdornment>
             )
           }}

--- a/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
+++ b/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
@@ -120,8 +120,8 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
       valueFormatter: (params: Pick<GridValueFormatterParams, 'value'>) => {
         return this.valueFormatterWith(params, precision)
       },
-      valueGetter: (params: Pick<GridValueGetterParams, 'value'>) =>
-        this.gridComponentRenderer.predictionItemValueGetter(params, precision),
+      valueGetter: (params: Pick<GridValueGetterParams, 'row' | 'value'>) =>
+        this.gridComponentRenderer.valueGetter(params, precision, field),
       valueSetter: (params: Pick<GridValueSetterParams, 'row' | 'value'>) =>
         this.valueSetterWith(params, field, precision)
     }
@@ -131,8 +131,11 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
     this.gridComponentRenderer.predictionItemValueFormatter(params, precision)
   public valueGetterWith = (params: Pick<GridValueGetterParams, 'value'>, precision: number) =>
     this.gridComponentRenderer.cellValueGetter(params, precision)
-  public predictionitemValueGetterWith = (params: Pick<GridValueGetterParams, 'value'>, precision: number) =>
-    this.gridComponentRenderer.predictionItemValueGetter(params, precision)
+  public predictionitemValueGetterWith = (
+    params: Pick<GridValueGetterParams, 'row' | 'value'>,
+    field: string,
+    precision: number
+  ) => this.gridComponentRenderer.valueGetter(params, precision, field)
   public valueSetterWith = (params: Pick<GridValueSetterParams, 'row' | 'value'>, field: string, precision: number) =>
     this.gridComponentRenderer.predictionItemValueSetter(params, field, precision)
 }

--- a/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
+++ b/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
@@ -14,7 +14,6 @@ export const DEFAULT_FORECAST_COLUMN_WIDTH = 120
 
 // Defines the order in which weather models display in the datagrid.
 export const ORDERED_COLUMN_HEADERS: WeatherDeterminateType[] = [
-  WeatherDeterminate.ACTUAL,
   WeatherDeterminate.HRDPS,
   WeatherDeterminate.HRDPS_BIAS,
   WeatherDeterminate.RDPS,
@@ -131,11 +130,8 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
     this.gridComponentRenderer.predictionItemValueFormatter(params, precision)
   public valueGetterWith = (params: Pick<GridValueGetterParams, 'value'>, precision: number) =>
     this.gridComponentRenderer.cellValueGetter(params, precision)
-  public predictionitemValueGetterWith = (
-    params: Pick<GridValueGetterParams, 'row' | 'value'>,
-    field: string,
-    precision: number
-  ) => this.gridComponentRenderer.valueGetter(params, precision, field)
+  public valueGetter = (params: Pick<GridValueGetterParams, 'row' | 'value'>, field: string, precision: number) =>
+    this.gridComponentRenderer.valueGetter(params, precision, field)
   public valueSetterWith = (params: Pick<GridValueSetterParams, 'row' | 'value'>, field: string, precision: number) =>
     this.gridComponentRenderer.predictionItemValueSetter(params, field, precision)
 }

--- a/web/src/features/moreCast2/components/ForecastDataGrid.tsx
+++ b/web/src/features/moreCast2/components/ForecastDataGrid.tsx
@@ -71,8 +71,8 @@ const ForecastDataGrid = ({
         onColumnVisibilityModelChange={newModel => setColumnVisibilityModel(newModel)}
         columnGroupingModel={columnGroupingModel}
         experimentalFeatures={{ columnGrouping: true }}
-        components={{
-          LoadingOverlay: LinearProgress
+        slots={{
+          loadingOverlay: LinearProgress
         }}
         onColumnHeaderClick={handleColumnHeaderClick}
         onCellDoubleClick={onCellDoubleClickHandler}

--- a/web/src/features/moreCast2/components/ForecastSummaryDataGrid.tsx
+++ b/web/src/features/moreCast2/components/ForecastSummaryDataGrid.tsx
@@ -45,8 +45,8 @@ const ForecastSummaryDataGrid = ({
   return (
     <Root className={classes.root} data-testid={`morecast2-data-grid`}>
       <DataGrid
-        components={{
-          LoadingOverlay: LinearProgress
+        slots={{
+          loadingOverlay: LinearProgress
         }}
         initialState={{
           sorting: {

--- a/web/src/features/moreCast2/components/GridComponentRenderer.tsx
+++ b/web/src/features/moreCast2/components/GridComponentRenderer.tsx
@@ -41,7 +41,11 @@ export class GridComponentRenderer {
     return actualField
   }
 
-  public valueGetter = (params: Pick<GridValueGetterParams, 'row' | 'value'>, precision: number, field: string) => {
+  public valueGetter = (
+    params: Pick<GridValueGetterParams, 'row' | 'value'>,
+    precision: number,
+    field: string
+  ): string => {
     const actualField = this.getActualField(field)
     const actual = params.row[actualField]
 

--- a/web/src/features/moreCast2/components/colDefBuilder.test.tsx
+++ b/web/src/features/moreCast2/components/colDefBuilder.test.tsx
@@ -187,7 +187,7 @@ describe('ColDefBuilder', () => {
       expect(colDefBuilder.valueFormatterWith({ value: 1.11 }, 1)).toEqual('1.1')
       expect(colDefBuilder.valueGetterWith({ value: 1.11 }, 1)).toEqual('1.1')
       expect(
-        colDefBuilder.predictionitemValueGetterWith(
+        colDefBuilder.valueGetter(
           {
             row: { testField: { choice: ModelChoice.GDPS, value: 1.11 } },
             value: { choice: ModelChoice.GDPS, value: 1.11 }

--- a/web/src/features/moreCast2/components/colDefBuilder.test.tsx
+++ b/web/src/features/moreCast2/components/colDefBuilder.test.tsx
@@ -155,7 +155,12 @@ describe('ColDefBuilder', () => {
         })
       ).toEqual(<TextField disabled={false} label={ModelChoice.GDPS} size="small" value={1} />)
       expect(forecastColDef.valueFormatter({ value: 1.11 })).toEqual('1.1')
-      expect(forecastColDef.valueGetter({ row: {}, value: { choice: ModelChoice.GDPS, value: 1.11 } })).toEqual('1.1')
+      expect(
+        forecastColDef.valueGetter({
+          row: { testField: { choice: ModelChoice.GDPS, value: 1 } },
+          value: { choice: ModelChoice.GDPS, value: 1.11 }
+        })
+      ).toEqual('1.1')
       expect(
         forecastColDef.valueSetter({ row: { testField: { choice: ModelChoice.GDPS, value: 1 } }, value: 2 })
       ).toEqual({ testField: { choice: ModelChoice.MANUAL, value: 2 } })

--- a/web/src/features/moreCast2/components/colDefBuilder.test.tsx
+++ b/web/src/features/moreCast2/components/colDefBuilder.test.tsx
@@ -155,7 +155,7 @@ describe('ColDefBuilder', () => {
         })
       ).toEqual(<TextField disabled={false} label={ModelChoice.GDPS} size="small" value={1} />)
       expect(forecastColDef.valueFormatter({ value: 1.11 })).toEqual('1.1')
-      expect(forecastColDef.valueGetter({ value: { choice: ModelChoice.GDPS, value: 1.11 } })).toEqual('1.1')
+      expect(forecastColDef.valueGetter({ row: {}, value: { choice: ModelChoice.GDPS, value: 1.11 } })).toEqual('1.1')
       expect(
         forecastColDef.valueSetter({ row: { testField: { choice: ModelChoice.GDPS, value: 1 } }, value: 2 })
       ).toEqual({ testField: { choice: ModelChoice.MANUAL, value: 2 } })
@@ -182,7 +182,14 @@ describe('ColDefBuilder', () => {
       expect(colDefBuilder.valueFormatterWith({ value: 1.11 }, 1)).toEqual('1.1')
       expect(colDefBuilder.valueGetterWith({ value: 1.11 }, 1)).toEqual('1.1')
       expect(
-        colDefBuilder.predictionitemValueGetterWith({ value: { choice: ModelChoice.GDPS, value: 1.11 } }, 1)
+        colDefBuilder.predictionitemValueGetterWith(
+          {
+            row: { testField: { choice: ModelChoice.GDPS, value: 1.11 } },
+            value: { choice: ModelChoice.GDPS, value: 1.11 }
+          },
+          'testField',
+          1
+        )
       ).toEqual('1.1')
       expect(
         colDefBuilder.valueSetterWith(

--- a/web/src/features/moreCast2/components/gridComponentRenderer.test.tsx
+++ b/web/src/features/moreCast2/components/gridComponentRenderer.test.tsx
@@ -107,4 +107,24 @@ describe('GridComponentRenderer', () => {
     )
     expect(itemValue).toEqual('1.1')
   })
+
+  it('should return an actual field', () => {
+    const actualField = gridComponentRenderer.getActualField('testForecast')
+    expect(actualField).toEqual('testActual')
+  })
+
+  it('should return an actual over a prediction if it exists', () => {
+    const itemValue = gridComponentRenderer.valueGetter(
+      {
+        row: {
+          testForecast: { choice: ModelChoice.GDPS, value: 1.11 },
+          testActual: 2.22
+        },
+        value: { choice: ModelChoice.GDPS, value: 1.11 }
+      },
+      1,
+      'testForecast'
+    )
+    expect(itemValue).toEqual('2.2')
+  })
 })

--- a/web/src/features/moreCast2/components/gridComponentRenderer.test.tsx
+++ b/web/src/features/moreCast2/components/gridComponentRenderer.test.tsx
@@ -97,9 +97,13 @@ describe('GridComponentRenderer', () => {
   })
 
   it('should return an existent prediction item value correctly', () => {
-    const itemValue = gridComponentRenderer.predictionItemValueGetter(
-      { value: { choice: ModelChoice.GDPS, value: 1.11 } },
-      1
+    const itemValue = gridComponentRenderer.valueGetter(
+      {
+        row: { testField: { choice: ModelChoice.GDPS, value: 1.11 } },
+        value: { choice: ModelChoice.GDPS, value: 1.11 }
+      },
+      1,
+      'testField'
     )
     expect(itemValue).toEqual('1.1')
   })

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -71,3 +71,11 @@ export const createWeatherModelLabel = (label: string) => {
 
   return label === ModelChoice.NULL ? '' : label
 }
+
+export const createLabel = (isActual: boolean, label: string) => {
+  if (isActual) {
+    return ModelChoice.ACTUAL
+  }
+
+  return createWeatherModelLabel(label)
+}


### PR DESCRIPTION
- Shows actuals in summaries tab
- Coalesces forecast/actual values in same column with labels for tabs, removes actual only column
    - Note: the header title is still "Forecast" here, tried to change it but the cells are too small to fit "Forecast / Actual"
- Fix dom nesting of buttons in `web/src/components/DateRangeSelector.tsx`
- Replace deprecated `components` props with `slots` props in data grid components
# Test Links:
[Landing Page](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3068.apps.silver.devops.gov.bc.ca/hfi-calculator)
