### PR TITLE
Fix invalid pmtiles request

### DIFF
--- a/web/src/features/fba/components/AdvisoryMetadata.tsx
+++ b/web/src/features/fba/components/AdvisoryMetadata.tsx
@@ -34,7 +34,9 @@ const AdvisoryMetadata = ({ runType, setRunType, forDate, issueDate }: AdvisoryM
             renderInput={params => <TextField {...params} label="Forecast or Actual" />}
           />{' '}
           <Typography variant="subtitle2">is for {forDate.toISODate()}</Typography>
-          <Typography variant="subtitle2">issued on {!isNull(issueDate) ? issueDate.toISO() : ''}</Typography>
+          <Typography variant="subtitle2">
+            issued on {!isNull(issueDate) ? issueDate.toISO({ includeOffset: false }) : ''}
+          </Typography>
         </Grid>
       </Grid>
     </Box>

--- a/web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/src/features/fba/components/map/FBAMap.tsx
@@ -195,9 +195,11 @@ const FBAMap = (props: FBAMapProps) => {
     const layerName = 'hfiVector'
     removeLayerByName(map, layerName)
     if (showHighHFI && !isNull(mostRecentRunDate)) {
-      const modelRunDate = props.runType === RunType.FORECAST ? DateTime.fromISO(mostRecentRunDate) : props.forDate
+      // The runDate for forecasts is the mostRecentRunDate. For Actuals, our API expects the runDate to be
+      // the same as the forDate.
+      const runDate = props.runType === RunType.FORECAST ? DateTime.fromISO(mostRecentRunDate) : props.forDate
       const hfiGeojsonSource = new olpmtiles.PMTilesVectorSource({
-        url: buildPMTilesURL(props.forDate, props.runType, modelRunDate)
+        url: buildPMTilesURL(props.forDate, props.runType, runDate)
       })
 
       const latestHFILayer = new VectorTileLayer({

--- a/web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/src/features/fba/components/map/FBAMap.tsx
@@ -12,7 +12,7 @@ import GeoJSON from 'ol/format/GeoJSON'
 import { useSelector } from 'react-redux'
 import React, { useEffect, useRef, useState } from 'react'
 import { ErrorBoundary } from 'components'
-import { selectFireWeatherStations } from 'app/rootReducer'
+import { selectFireWeatherStations, selectRunDates } from 'app/rootReducer'
 import { source as baseMapSource, COG_TILE_SIZE, SFMS_MAX_ZOOM } from 'features/fireWeather/components/maps/constants'
 import Tile from 'ol/layer/Tile'
 import { FireCenter, FireZone, FireZoneArea } from 'api/fbaAPI'
@@ -43,7 +43,6 @@ export interface FBAMapProps {
   selectedFireCenter: FireCenter | undefined
   selectedFireZone: FireZone | undefined
   forDate: DateTime
-  runDate: DateTime
   setSelectedFireZone: React.Dispatch<React.SetStateAction<FireZone | undefined>>
   fireZoneAreas: FireZoneArea[]
   runType: RunType
@@ -83,9 +82,10 @@ const removeLayerByName = (map: ol.Map, layerName: string) => {
 
 const FBAMap = (props: FBAMapProps) => {
   const { stations } = useSelector(selectFireWeatherStations)
-  const [showHighHFI, setShowHighHFI] = useState(false)
+  const [showHighHFI, setShowHighHFI] = useState(true)
   const [map, setMap] = useState<ol.Map | null>(null)
   const mapRef = useRef<HTMLDivElement | null>(null)
+  const { mostRecentRunDate } = useSelector(selectRunDates)
 
   const fireCentreVectorSource = new olpmtiles.PMTilesVectorSource({
     url: `${PMTILES_BUCKET}fireCentres.pmtiles`
@@ -194,9 +194,10 @@ const FBAMap = (props: FBAMapProps) => {
     if (!map) return
     const layerName = 'hfiVector'
     removeLayerByName(map, layerName)
-    if (showHighHFI && !isNull(props.runDate.toISODate())) {
+    if (showHighHFI && !isNull(mostRecentRunDate)) {
+      const modelRunDate = props.runType === RunType.FORECAST ? DateTime.fromISO(mostRecentRunDate) : props.forDate
       const hfiGeojsonSource = new olpmtiles.PMTilesVectorSource({
-        url: buildPMTilesURL(props.forDate, props.runType, props.runDate)
+        url: buildPMTilesURL(props.forDate, props.runType, modelRunDate)
       })
 
       const latestHFILayer = new VectorTileLayer({
@@ -208,7 +209,7 @@ const FBAMap = (props: FBAMapProps) => {
       })
       map.addLayer(latestHFILayer)
     }
-  }, [showHighHFI, props.runDate]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [showHighHFI, mostRecentRunDate]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     // The React ref is used to attach to the div rendered in our

--- a/web/src/features/fba/components/map/fbaMap.test.tsx
+++ b/web/src/features/fba/components/map/fbaMap.test.tsx
@@ -24,7 +24,6 @@ describe('FBAMap', () => {
       <Provider store={store}>
         <FBAMap
           forDate={DateTime.fromISO('2016-05-25')}
-          runDate={DateTime.fromISO('2016-05-25')}
           advisoryThreshold={0}
           selectedFireCenter={undefined}
           selectedFireZone={undefined}

--- a/web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
+++ b/web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
@@ -230,7 +230,6 @@ const FireBehaviourAdvisoryPage: React.FunctionComponent = () => {
           <Grid sx={{ display: 'flex', flex: 1 }} ref={mapRef} item>
             <FBAMap
               forDate={dateOfInterest}
-              runDate={mostRecentRunDate !== null ? DateTime.fromISO(mostRecentRunDate) : dateOfInterest}
               runType={runType}
               selectedFireZone={selectedFireZone}
               selectedFireCenter={fireCenter}


### PR DESCRIPTION
- Read the 'run date' in `FBAMap.tsx` directly from Redux instead of reading it in the patent page and passing it as a prop
- Tweak format of the 'run date' string to prevent the 'bounce' in the UI
# Test Links:
[Landing Page](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3076.apps.silver.devops.gov.bc.ca/hfi-calculator)
