### PR TITLE
Remove memoization of CriticalHours cell

### DIFF
--- a/web/src/features/fbaCalculator/components/CriticalHoursCell.tsx
+++ b/web/src/features/fbaCalculator/components/CriticalHoursCell.tsx
@@ -27,4 +27,4 @@ const CriticalHoursCell = (props: CriticalHoursCellProps) => {
   )
 }
 
-export default React.memo(CriticalHoursCell)
+export default CriticalHoursCell


### PR DESCRIPTION
A memoized component in React will only re-render when its props change. Since React uses a shallow comparison (eg. object reference in this case) to determine if props have changed, simply changing the values of properties in the `CriticalHoursHFI` object does not guarantee the cell will re-render. To guarantee re-rendering we would need a new `CriticalHoursHFI` object to be created and passed as a prop. 

We could refactor so we are passing separate props for start and end times but there is a lot going on with the logic in this table. Removing memoization is a quick and easy way which should have pretty minimal impact on performance.
# Test Links:
[Landing Page](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3107.apps.silver.devops.gov.bc.ca/hfi-calculator)
