### PR TITLE
Temporarily disable patroni healthcheck

### DIFF
--- a/openshift/templates/patroni.yaml
+++ b/openshift/templates/patroni.yaml
@@ -199,13 +199,13 @@ objects:
                   memory: ${MEMORY_LIMIT}
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
-              readinessProbe:
-                initialDelaySeconds: 5
-                timeoutSeconds: 5
-                failureThreshold: 4
-                exec:
-                  command:
-                    - /usr/share/scripts/patroni/health_check.sh
+              # readinessProbe:
+              #   initialDelaySeconds: 5
+              #   timeoutSeconds: 5
+              #   failureThreshold: 4
+              #   exec:
+              #     command:
+              #       - /usr/share/scripts/patroni/health_check.sh
               volumeMounts:
                 - mountPath: /home/postgres/pgdata
                   name: postgresql


### PR DESCRIPTION
- So patroni pods will spin up after outage
# Test Links:
[Landing Page](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3146.apps.silver.devops.gov.bc.ca/hfi-calculator)
