### PR TITLE
Adding schemathesis to dev deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -187,6 +187,24 @@ jobs:
         run: |
           oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
           PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_noaa_nam_cronjob.sh ${SUFFIX} apply
+
+  run-schemathesis:
+    ## "wps-${SUFFIX}.apps.silver.devops.gov.bc.ca"
+    # wps-pr-3166.apps.silver.devops.gov.bc.ca
+    name: Running schemathesis against OAS
+    if: github.triggering_actor != 'renovate'
+    runs-on: ubuntu-22.04
+    needs: [deploy-dev]
+
+    steps:
+      # Runs Schemathesis tests
+      - uses: schemathesis/action@v1
+        with:
+          # Your API schema location
+          schema: "wps-${SUFFIX}.apps.silver.devops.gov.bc.ca/api/openapi.json"
+          # Set your token from secrets
+          token: ${{ secrets.SCHEMATHESIS_TOKEN }}
+
   # TODO: Delete once pmtiles has run for some time
   # deploy-tileserv:
   #   name: Deploy tileserv to Dev

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -256,8 +256,9 @@ jobs:
     needs: [deploy-dev]
 
     steps:
-      # Runs Schemathesis tests
-      - uses: schemathesis/action@v1
+      - name: Run Schemathesis
+        continue-on-error: true
+        uses: schemathesis/action@v1
         with:
           # Your API schema location
           schema: "https://wps-pr-${{ github.event.number }}.apps.silver.devops.gov.bc.ca/api/openapi.json"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -188,23 +188,6 @@ jobs:
           oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
           PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_noaa_nam_cronjob.sh ${SUFFIX} apply
 
-  run-schemathesis:
-    ## "wps-${SUFFIX}.apps.silver.devops.gov.bc.ca"
-    # wps-pr-3166.apps.silver.devops.gov.bc.ca
-    name: Running schemathesis against OAS
-    if: github.triggering_actor != 'renovate'
-    runs-on: ubuntu-22.04
-    needs: [deploy-dev]
-
-    steps:
-      # Runs Schemathesis tests
-      - uses: schemathesis/action@v1
-        with:
-          # Your API schema location
-          schema: "wps-${SUFFIX}.apps.silver.devops.gov.bc.ca/api/openapi.json"
-          # Set your token from secrets
-          token: ${{ secrets.SCHEMATHESIS_TOKEN }}
-
   # TODO: Delete once pmtiles has run for some time
   # deploy-tileserv:
   #   name: Deploy tileserv to Dev
@@ -265,6 +248,23 @@ jobs:
           rules_file_name: ".zap/rules.tsv"
           # Do not return failure on warnings - TODO: this has to be resolved!
           cmd_options: "-I"
+
+  run-schemathesis:
+    ## "wps-${SUFFIX}.apps.silver.devops.gov.bc.ca"
+    # wps-pr-3166.apps.silver.devops.gov.bc.ca
+    name: Schemathesis Fuzzing
+    if: github.triggering_actor != 'renovate'
+    runs-on: ubuntu-22.04
+    needs: [deploy-dev]
+
+    steps:
+      # Runs Schemathesis tests
+      - uses: schemathesis/action@v1
+        with:
+          # Your API schema location
+          schema: "wps-${SUFFIX}.apps.silver.devops.gov.bc.ca/api/openapi.json"
+          # Set your token from secrets
+          token: ${{ secrets.SCHEMATHESIS_TOKEN }}
 
   deploy-c-haines:
     name: Deploy c-haines cronjob

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -250,8 +250,6 @@ jobs:
           cmd_options: "-I"
 
   run-schemathesis:
-    ## "wps-${SUFFIX}.apps.silver.devops.gov.bc.ca"
-    # wps-pr-3166.apps.silver.devops.gov.bc.ca
     name: Schemathesis Fuzzing
     if: github.triggering_actor != 'renovate'
     runs-on: ubuntu-22.04
@@ -262,7 +260,8 @@ jobs:
       - uses: schemathesis/action@v1
         with:
           # Your API schema location
-          schema: "wps-${SUFFIX}.apps.silver.devops.gov.bc.ca/api/openapi.json"
+          schema: "https://wps-pr-${{ github.event.number }}.apps.silver.devops.gov.bc.ca/api/openapi.json"
+          args: "--experimental=openapi-3.1"
           # Set your token from secrets
           token: ${{ secrets.SCHEMATHESIS_TOKEN }}
 


### PR DESCRIPTION
Adds fuzz testing to our api through our OAS spec using https://schemathesis.io/, see run here: https://github.com/bcgov/wps/actions/runs/6591405650/job/17910233609?pr=3176#step:2:189

We'll need to create a test auth token for most of our API, but having it here with `continue-on-error` shouldn't hurt and we can see any new issues pop up when changing the API.

# Test Links:
[Landing Page](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3176.apps.silver.devops.gov.bc.ca/hfi-calculator)
