### PR TITLE
Revert dev deployment cpu limits

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
-          EPHEMERAL_STORAGE=True CPU_REQUEST=75m CPU_LIMIT=2000m bash openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
+          EPHEMERAL_STORAGE=True bash openshift/scripts/oc_provision_db.sh ${SUFFIX} apply
 
   prepare-dev-database-backups:
     name: Prepare Dev Database Backups


### PR DESCRIPTION
Undoes erroneous change to CPU limits from: https://github.com/bcgov/wps/issues/3204
# Test Links:
[Landing Page](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3249.apps.silver.devops.gov.bc.ca/hfi-calculator)
