### PR TITLE
Fix fuel type area in the north

### DIFF
--- a/api/app/tests/fba/test_process_fuel_type_area.py
+++ b/api/app/tests/fba/test_process_fuel_type_area.py
@@ -8,7 +8,7 @@ HFI_RASTER = np.array([[1000, 2000, 3000, 4005], [5000, 10001, 11000, 12000], [3
 def test_get_warped_fuel_type_s3_key():
     bucket = "abcde"
     key = get_fuel_type_s3_key(bucket)
-    assert key == f"/vsis3/{bucket}/ftl/fuel_types_lambert_2000.tif"
+    assert key == f"/vsis3/{bucket}/ftl/fuel_types_from_sfms_epsg_3005.tif"
 
 
 def test_classify_by_threshold_1():

--- a/api/app/tests/fba/test_process_fuel_type_area.py
+++ b/api/app/tests/fba/test_process_fuel_type_area.py
@@ -1,4 +1,4 @@
-from app.auto_spatial_advisory.process_fuel_type_area import get_warped_fuel_type_s3_key, classify_by_threshold
+from app.auto_spatial_advisory.process_fuel_type_area import get_fuel_type_s3_key, classify_by_threshold
 import numpy as np
 
 
@@ -7,7 +7,7 @@ HFI_RASTER = np.array([[1000, 2000, 3000, 4005], [5000, 10001, 11000, 12000], [3
 
 def test_get_warped_fuel_type_s3_key():
     bucket = "abcde"
-    key = get_warped_fuel_type_s3_key(bucket)
+    key = get_fuel_type_s3_key(bucket)
     assert key == f"/vsis3/{bucket}/ftl/fuel_types_lambert_2000.tif"
 
 


### PR DESCRIPTION
Previously we used a fuel type layer that had been projected to match the extent, spatial reference and resolution of HFI rasters. This led to a lot of 'inaccuracy' in northern areas as there seemed to be significant distortion when reprojecting from EPSG: 3005 to  Lambert Conformal Conic. 

The solution I landed on was to maintain the fuel type layer in its current form and re-project the hfi layer to match.
# Test Links:
[Landing Page](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3276.apps.silver.devops.gov.bc.ca/hfi-calculator)
