### PR TITLE
MoreCast - Grass curing column

### DIFF
--- a/api/alembic/versions/5845f568a975_adds_grass_curing_to_morecast_forecast.py
+++ b/api/alembic/versions/5845f568a975_adds_grass_curing_to_morecast_forecast.py
@@ -17,7 +17,7 @@ depends_on = None
 
 def upgrade():
     # ### start Alembic commands ###
-    op.add_column('morecast_forecast', sa.Column('grass_curing', sa.Integer(), nullable=True))
+    op.add_column('morecast_forecast', sa.Column('grass_curing', sa.Float(), nullable=True))
     op.create_index(op.f('ix_morecast_forecast_grass_curing'), 'morecast_forecast', ['grass_curing'], unique=False)
     # ### end Alembic commands ###
 

--- a/api/alembic/versions/5845f568a975_adds_grass_curing_to_morecast_forecast.py
+++ b/api/alembic/versions/5845f568a975_adds_grass_curing_to_morecast_forecast.py
@@ -7,7 +7,6 @@ Create Date: 2024-02-02 08:16:57.605162
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '5845f568a975'

--- a/api/alembic/versions/5845f568a975_adds_grass_curing_to_morecast_forecast.py
+++ b/api/alembic/versions/5845f568a975_adds_grass_curing_to_morecast_forecast.py
@@ -1,0 +1,30 @@
+"""adds grass_curing to morecast_forecast
+
+Revision ID: 5845f568a975
+Revises: 403586c146ae
+Create Date: 2024-02-02 08:16:57.605162
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '5845f568a975'
+down_revision = '403586c146ae'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ### start Alembic commands ###
+    op.add_column('morecast_forecast', sa.Column('grass_curing', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_morecast_forecast_grass_curing'), 'morecast_forecast', ['grass_curing'], unique=False)
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    # ### start Alembic commands ###
+    op.drop_index(op.f('ix_morecast_forecast_grass_curing'), table_name='morecast_forecast')
+    op.drop_column('morecast_forecast', 'grass_curing')
+    # ### end Alembic commands ###

--- a/api/app/db/models/morecast_v2.py
+++ b/api/app/db/models/morecast_v2.py
@@ -16,6 +16,7 @@ class MorecastForecastRecord(Base):
     precip = Column(Float, nullable=False, index=True)
     wind_speed = Column(Float, nullable=False, index=True)
     wind_direction = Column(Integer, nullable=True, index=True)
+    grass_curing = Column(Integer, nullable=True, index=True)
     create_timestamp = Column(TZTimeStamp, nullable=False, index=True)
     create_user = Column(String, nullable=False)
     update_timestamp = Column(TZTimeStamp, nullable=False, index=True)

--- a/api/app/db/models/morecast_v2.py
+++ b/api/app/db/models/morecast_v2.py
@@ -16,7 +16,7 @@ class MorecastForecastRecord(Base):
     precip = Column(Float, nullable=False, index=True)
     wind_speed = Column(Float, nullable=False, index=True)
     wind_direction = Column(Integer, nullable=True, index=True)
-    grass_curing = Column(Integer, nullable=True, index=True)
+    grass_curing = Column(Float, nullable=True, index=True)
     create_timestamp = Column(TZTimeStamp, nullable=False, index=True)
     create_user = Column(String, nullable=False)
     update_timestamp = Column(TZTimeStamp, nullable=False, index=True)

--- a/api/app/morecast_v2/forecasts.py
+++ b/api/app/morecast_v2/forecasts.py
@@ -29,6 +29,7 @@ def get_forecasts(db_session: Session, start_time: Optional[datetime], end_time:
                                                                     precip=forecast.precip,
                                                                     wind_speed=forecast.wind_speed,
                                                                     wind_direction=forecast.wind_direction,
+                                                                    grass_curing=forecast.grass_curing,
                                                                     update_timestamp=int(forecast.update_timestamp.timestamp())) for forecast in result]
     return forecasts
 

--- a/api/app/routers/morecast_v2.py
+++ b/api/app/routers/morecast_v2.py
@@ -77,6 +77,7 @@ async def get_forecasts_by_date_range(start_date: date, end_date: date, request:
                                                             precip=forecast.precip,
                                                             wind_speed=forecast.wind_speed,
                                                             wind_direction=forecast.wind_direction,
+                                                            grass_curing=forecast.grass_curing,
                                                             update_timestamp=forecast.update_timestamp.timestamp()) for forecast in result]
     return MorecastForecastResponse(forecasts=morecast_forecast_outputs)
 
@@ -101,6 +102,7 @@ async def save_forecasts(forecasts: MoreCastForecastRequest,
                                                 precip=forecast.precip,
                                                 wind_speed=forecast.wind_speed,
                                                 wind_direction=forecast.wind_direction,
+                                                grass_curing=forecast.grass_curing,
                                                 create_user=username,
                                                 create_timestamp=now,
                                                 update_user=username,
@@ -127,6 +129,7 @@ async def save_forecasts(forecasts: MoreCastForecastRequest,
                                                         precip=forecast.precip,
                                                         wind_speed=forecast.wind_speed,
                                                         wind_direction=forecast.wind_direction,
+                                                        grass_curing=forecast.grass_curing,
                                                         update_timestamp=int(now.timestamp() * 1000)) for forecast in forecasts_list]
     return MorecastForecastResponse(forecasts=morecast_forecast_outputs)
 

--- a/api/app/schemas/morecast_v2.py
+++ b/api/app/schemas/morecast_v2.py
@@ -73,7 +73,7 @@ class MoreCastForecastInput(BaseModel):
     precip: float
     wind_speed: float
     wind_direction: int | None = None
-    grass_curing: int | None = None
+    grass_curing: float | None = None
 
 
 class MoreCastForecastRequest(BaseModel):

--- a/api/app/schemas/morecast_v2.py
+++ b/api/app/schemas/morecast_v2.py
@@ -73,7 +73,7 @@ class MoreCastForecastInput(BaseModel):
     precip: float
     wind_speed: float
     wind_direction: int | None = None
-    grass_curing: float | None = None
+    grass_curing: int | None = None
 
 
 class MoreCastForecastRequest(BaseModel):

--- a/web/src/api/moreCast2API.test.ts
+++ b/web/src/api/moreCast2API.test.ts
@@ -24,7 +24,7 @@ describe('moreCast2API', () => {
     temp: { choice: 'FORECAST', value: 0 },
     windDirection: { choice: 'FORECAST', value: 0 },
     windSpeed: { choice: 'FORECAST', value: 0 },
-    grassCuring: 0
+    grassCuring: { choice: 'FORECAST', value: 0 }
   })
   it('should marshall forecast records correctly', async () => {
     const res = marshalMoreCast2ForecastRecords([

--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -277,7 +277,7 @@ export const mapMoreCast2RowsToIndeterminates = (rows: MoreCast2Row[]): WeatherI
       initial_spread_index: isForecast ? r.isiCalcForecast!.value : r.isiCalcActual,
       build_up_index: isForecast ? r.buiCalcForecast!.value : r.buiCalcActual,
       fire_weather_index: isForecast ? r.fwiCalcForecast!.value : r.fwiCalcActual,
-      danger_rating: isForecast ? null : r.rhActual,
+      danger_rating: isForecast ? null : r.dgrCalcActual,
       grass_curing: isForecast ? r.grassCuringForecast!.value : r.grassCuringActual
     }
   })

--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -187,7 +187,7 @@ export const marshalMoreCast2ForecastRecords = (forecasts: MoreCast2ForecastRow[
       temp: forecast.temp.value,
       wind_direction: forecast.windDirection.value,
       wind_speed: forecast.windSpeed.value,
-      grass_curing: forecast.grassCuring
+      grass_curing: forecast.grassCuring.value
     }
   })
   return forecastRecords
@@ -278,7 +278,7 @@ export const mapMoreCast2RowsToIndeterminates = (rows: MoreCast2Row[]): WeatherI
       build_up_index: isForecast ? r.buiCalcForecast!.value : r.buiCalcActual,
       fire_weather_index: isForecast ? r.fwiCalcForecast!.value : r.fwiCalcActual,
       danger_rating: isForecast ? null : r.rhActual,
-      grass_curing: r.grassCuring
+      grass_curing: isForecast ? r.grassCuringForecast!.value : r.grassCuringActual
     }
   })
   return mappedIndeterminates

--- a/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
+++ b/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
@@ -114,7 +114,7 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
       headerName: headerName,
       sortable: false,
       type: 'number',
-      width: width || DEFAULT_FORECAST_COLUMN_WIDTH,
+      width: width ?? DEFAULT_FORECAST_COLUMN_WIDTH,
       renderHeader: (params: GridColumnHeaderParams) => {
         return isCalcField || isGrassField
           ? this.gridComponentRenderer.renderHeaderWith(params)

--- a/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
+++ b/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
@@ -49,13 +49,11 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
   }
 
   public generateForecastColDef = (headerName?: string) => {
-    const isCalcField = this.field.includes('Calc')
-
     return this.generateForecastColDefWith(
       `${this.field}${WeatherDeterminate.FORECAST}`,
       headerName ? headerName : this.headerName,
       this.precision,
-      isCalcField ? DEFAULT_COLUMN_WIDTH : DEFAULT_FORECAST_COLUMN_WIDTH
+      DEFAULT_FORECAST_COLUMN_WIDTH
     )
   }
 
@@ -103,6 +101,7 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
   }
 
   public generateForecastColDefWith = (field: string, headerName: string, precision: number, width?: number) => {
+    const isGrassField = field.includes('grass')
     const isCalcField = field.includes('Calc')
     return {
       field: field,
@@ -112,14 +111,16 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
       headerName: headerName,
       sortable: false,
       type: 'number',
-      width: width || 120,
+      width: isCalcField || isGrassField ? DEFAULT_COLUMN_WIDTH : width,
       renderHeader: (params: GridColumnHeaderParams) => {
-        return isCalcField
+        return isCalcField || isGrassField
           ? this.gridComponentRenderer.renderHeaderWith(params)
           : this.gridComponentRenderer.renderForecastHeaderWith(params)
       },
       renderCell: (params: Pick<GridRenderCellParams, 'row' | 'formattedValue'>) => {
-        return this.gridComponentRenderer.renderForecastCellWith(params, field)
+        return isCalcField
+          ? this.gridComponentRenderer.renderCellWith(params)
+          : this.gridComponentRenderer.renderForecastCellWith(params, field)
       },
       valueFormatter: (params: Pick<GridValueFormatterParams, 'value'>) => {
         return this.valueFormatterWith(params, precision)

--- a/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
+++ b/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
@@ -103,6 +103,9 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
   public generateForecastColDefWith = (field: string, headerName: string, precision: number, width?: number) => {
     const isGrassField = field.includes('grass')
     const isCalcField = field.includes('Calc')
+    if (isGrassField || isCalcField) {
+      width = DEFAULT_COLUMN_WIDTH
+    }
     return {
       field: field,
       disableColumnMenu: true,
@@ -111,7 +114,7 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
       headerName: headerName,
       sortable: false,
       type: 'number',
-      width: isCalcField || isGrassField ? DEFAULT_COLUMN_WIDTH : width,
+      width: width || DEFAULT_FORECAST_COLUMN_WIDTH,
       renderHeader: (params: GridColumnHeaderParams) => {
         return isCalcField || isGrassField
           ? this.gridComponentRenderer.renderHeaderWith(params)

--- a/web/src/features/moreCast2/components/ForecastSummaryDataGrid.tsx
+++ b/web/src/features/moreCast2/components/ForecastSummaryDataGrid.tsx
@@ -10,7 +10,7 @@ import { storeUserEditedRows, getSimulatedIndices } from 'features/moreCast2/sli
 import { AppDispatch } from 'app/store'
 import { useDispatch } from 'react-redux'
 import { filterRowsForSimulationFromEdited } from 'features/moreCast2/rowFilters'
-import { fillGrassCuringForward } from 'features/moreCast2/util'
+import { fillStationGrassCuringForward } from 'features/moreCast2/util'
 
 const PREFIX = 'ForecastSummaryDataGrid'
 
@@ -51,7 +51,7 @@ const ForecastSummaryDataGrid = ({
   const dispatch: AppDispatch = useDispatch()
 
   const processRowUpdate = async (newRow: MoreCast2Row) => {
-    const filledRows = fillGrassCuringForward(newRow, rows)
+    const filledRows = fillStationGrassCuringForward(newRow, rows)
     dispatch(storeUserEditedRows(filledRows))
 
     const rowsForSimulation = filterRowsForSimulationFromEdited(newRow, filledRows)

--- a/web/src/features/moreCast2/components/ForecastSummaryDataGrid.tsx
+++ b/web/src/features/moreCast2/components/ForecastSummaryDataGrid.tsx
@@ -10,6 +10,7 @@ import { storeUserEditedRows, getSimulatedIndices } from 'features/moreCast2/sli
 import { AppDispatch } from 'app/store'
 import { useDispatch } from 'react-redux'
 import { filterRowsForSimulationFromEdited } from 'features/moreCast2/rowFilters'
+import { fillGrassCuringForward } from 'features/moreCast2/util'
 
 const PREFIX = 'ForecastSummaryDataGrid'
 
@@ -48,15 +49,17 @@ const ForecastSummaryDataGrid = ({
   handleClose
 }: ForecastSummaryDataGridProps) => {
   const dispatch: AppDispatch = useDispatch()
-  const processRowUpdate = async (editedRow: MoreCast2Row) => {
-    dispatch(storeUserEditedRows([editedRow]))
 
-    const rowsForSimulation = filterRowsForSimulationFromEdited(editedRow, rows)
+  const processRowUpdate = async (newRow: MoreCast2Row) => {
+    const filledRows = fillGrassCuringForward(newRow, rows)
+    dispatch(storeUserEditedRows(filledRows))
+
+    const rowsForSimulation = filterRowsForSimulationFromEdited(newRow, filledRows)
     if (rowsForSimulation) {
       dispatch(getSimulatedIndices(rowsForSimulation))
     }
 
-    return editedRow
+    return newRow
   }
 
   return (

--- a/web/src/features/moreCast2/components/GridComponentRenderer.tsx
+++ b/web/src/features/moreCast2/components/GridComponentRenderer.tsx
@@ -64,14 +64,15 @@ export class GridComponentRenderer {
     // We need the prefix to help us grab the correct 'actual' field (eg. tempACTUAL, precipACTUAL, etc.)
     const actualField = this.getActualField(field)
 
-    const isCalcField = field.includes('Calc')
+    const isGrassField = field.includes('grass')
 
     const isActual = !isNaN(params.row[actualField])
+
     return (
       <TextField
-        disabled={isActual || isCalcField}
+        disabled={isActual}
         size="small"
-        label={isCalcField ? '' : createLabel(isActual, params.row[field].choice)}
+        label={isGrassField ? '' : createLabel(isActual, params.row[field].choice)}
         value={params.formattedValue}
       ></TextField>
     )
@@ -83,7 +84,7 @@ export class GridComponentRenderer {
     precision: number
   ) => {
     const oldValue = params.row[field].value
-    const newValue = Number(params.value)
+    const newValue = params.value ? Number(params.value) : NaN
 
     if (isNaN(oldValue) && isNaN(newValue)) {
       return { ...params.row }

--- a/web/src/features/moreCast2/components/MoreCast2Column.tsx
+++ b/web/src/features/moreCast2/components/MoreCast2Column.tsx
@@ -119,6 +119,7 @@ export const ffmcField = new IndeterminateField('ffmcCalc', 'FFMC', 'number', 1,
 export const dmcField = new IndeterminateField('dmcCalc', 'DMC', 'number', 0, false)
 export const dcField = new IndeterminateField('dcCalc', 'DC', 'number', 0, false)
 export const dgrField = new IndeterminateField('dgrCalc', 'DGR', 'number', 0, false)
+export const gcField = new IndeterminateField('grassCuring', 'GC', 'number', 0, false)
 
 export const MORECAST2_STATION_DATE_FIELDS: ColDefGenerator[] = [
   StationForecastField.getInstance(),
@@ -140,7 +141,8 @@ export const MORECAST2_FORECAST_FIELDS: ForecastColDefGenerator[] = [
   rhForecastField,
   windDirForecastField,
   windSpeedForecastField,
-  precipForecastField
+  precipForecastField,
+  gcField
 ]
 
 export const MORECAST2_INDEX_FIELDS: ForecastColDefGenerator[] = [

--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -88,7 +88,8 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
     if (
       !isEqual(params.colDef.field, 'stationName') &&
       !isEqual(params.colDef.field, 'forDate') &&
-      !params.colDef.field.includes('Calc')
+      !params.colDef.field.includes('Calc') &&
+      !params.colDef.field.includes('grass')
     ) {
       setClickedColDef(params.colDef)
       setContextMenu(contextMenu === null ? { mouseX: event.clientX, mouseY: event.clientY } : null)

--- a/web/src/features/moreCast2/interfaces.ts
+++ b/web/src/features/moreCast2/interfaces.ts
@@ -16,7 +16,7 @@ export interface MoreCast2ForecastRow {
   temp: PredictionItem
   windDirection: PredictionItem
   windSpeed: PredictionItem
-  grassCuring: number
+  grassCuring: PredictionItem
 }
 
 export interface BaseRow {

--- a/web/src/features/moreCast2/interfaces.ts
+++ b/web/src/features/moreCast2/interfaces.ts
@@ -46,8 +46,9 @@ export interface MoreCast2Row extends BaseRow {
   fwiCalcForecast?: PredictionItem
   dgrCalcForecast?: PredictionItem
 
-  // Grass curing carryover
-  grassCuring: number
+  // Grass curing
+  grassCuringActual: number
+  grassCuringForecast?: PredictionItem
 
   // Forecast properties
   precipForecast?: PredictionItem

--- a/web/src/features/moreCast2/rowFilters.test.ts
+++ b/web/src/features/moreCast2/rowFilters.test.ts
@@ -18,6 +18,7 @@ export const buildValidForecastRow = (
   forecastRow.tempForecast = { choice: choice, value: 2 }
   forecastRow.rhForecast = { choice: choice, value: 2 }
   forecastRow.windSpeedForecast = { choice: choice, value: 2 }
+  forecastRow.grassCuringForecast = { choice: choice, value: NaN }
   forecastRow.id = id
 
   return forecastRow

--- a/web/src/features/moreCast2/saveForecast.test.ts
+++ b/web/src/features/moreCast2/saveForecast.test.ts
@@ -67,7 +67,7 @@ const baseRow = {
   buiCalcActual: 0,
   fwiCalcActual: 0,
   dgrCalcActual: 0,
-  grassCuring: 0
+  grassCuringActual: 0
 }
 
 const baseRowWithActuals = {
@@ -100,7 +100,8 @@ const buildCompleteForecast = (
   rhForecast: { choice: ModelChoice.GDPS, value: 0 },
   tempForecast: { choice: ModelChoice.GDPS, value: 0 },
   windDirectionForecast: { choice: ModelChoice.GDPS, value: 0 },
-  windSpeedForecast: { choice: ModelChoice.GDPS, value: 0 }
+  windSpeedForecast: { choice: ModelChoice.GDPS, value: 0 },
+  grassCuringForecast: { choice: ModelChoice.NULL, value: 0 }
 })
 
 const buildForecastMissingWindDirection = (
@@ -123,7 +124,7 @@ const buildForecastMissingWindDirection = (
   tempForecast: { choice: ModelChoice.GDPS, value: 0 },
   windDirectionForecast: { choice: ModelChoice.NULL, value: NaN },
   windSpeedForecast: { choice: ModelChoice.GDPS, value: 0 },
-  grassCuring: 0
+  grassCuringForecast: { choice: ModelChoice.NULL, value: 0 }
 })
 
 const buildInvalidForecast = (

--- a/web/src/features/moreCast2/saveForecast.test.ts
+++ b/web/src/features/moreCast2/saveForecast.test.ts
@@ -67,7 +67,7 @@ const baseRow = {
   buiCalcActual: 0,
   fwiCalcActual: 0,
   dgrCalcActual: 0,
-  grassCuringActual: 0
+  grassCuringActual: NaN
 }
 
 const baseRowWithActuals = {
@@ -76,7 +76,8 @@ const baseRowWithActuals = {
   rhActual: 0,
   tempActual: 0,
   windDirectionActual: 0,
-  windSpeedActual: 0
+  windSpeedActual: 0,
+  grassCuringActual: 0
 }
 
 const mockForDate = DateTime.fromISO('2023-02-16T20:00:00+00:00')
@@ -163,7 +164,8 @@ const buildNAForecast = (
   rhForecast: { choice: ModelChoice.NULL, value: NaN },
   tempForecast: { choice: ModelChoice.NULL, value: NaN },
   windDirectionForecast: { choice: ModelChoice.NULL, value: NaN },
-  windSpeedForecast: { choice: ModelChoice.NULL, value: NaN }
+  windSpeedForecast: { choice: ModelChoice.NULL, value: NaN },
+  grassCuringForecast: { choice: ModelChoice.NULL, value: NaN }
 })
 
 const buildForecastWithActuals = (
@@ -185,7 +187,8 @@ const buildForecastWithActuals = (
   rhForecast: { choice: ModelChoice.GDPS, value: 0 },
   tempForecast: { choice: ModelChoice.GDPS, value: 0 },
   windDirectionForecast: { choice: ModelChoice.GDPS, value: 0 },
-  windSpeedForecast: { choice: ModelChoice.GDPS, value: 0 }
+  windSpeedForecast: { choice: ModelChoice.GDPS, value: 0 },
+  grassCuringForecast: { choice: ModelChoice.NULL, value: 0 }
 })
 
 describe('saveForecasts', () => {

--- a/web/src/features/moreCast2/saveForecasts.ts
+++ b/web/src/features/moreCast2/saveForecasts.ts
@@ -1,6 +1,6 @@
 import { ModelChoice } from 'api/moreCast2API'
 import { MoreCast2ForecastRow, MoreCast2Row } from 'features/moreCast2/interfaces'
-import { fillGrassCuring, validForecastPredicate } from 'features/moreCast2/util'
+import { validForecastPredicate } from 'features/moreCast2/util'
 
 // Forecast rows contain all NaN values in their 'actual' fields
 export const isForecastRowPredicate = (row: MoreCast2Row) =>
@@ -21,8 +21,7 @@ export const isForecastValid = (rows: MoreCast2Row[]) => {
 }
 
 export const getRowsToSave = (rows: MoreCast2Row[]): MoreCast2ForecastRow[] => {
-  const filledRows = fillGrassCuring(rows)
-  const forecastRows = getForecastRows(filledRows)
+  const forecastRows = getForecastRows(rows)
   const rowsToSave = forecastRows.filter(validForecastPredicate)
   return rowsToSave.map(r => ({
     id: r.id,
@@ -34,6 +33,6 @@ export const getRowsToSave = (rows: MoreCast2Row[]): MoreCast2ForecastRow[] => {
     temp: r.tempForecast ?? { choice: ModelChoice.NULL, value: NaN },
     windDirection: r.windDirectionForecast ?? { choice: ModelChoice.NULL, value: NaN },
     windSpeed: r.windSpeedForecast ?? { choice: ModelChoice.NULL, value: NaN },
-    grassCuring: r.grassCuring
+    grassCuring: r.grassCuringForecast ?? { choice: ModelChoice.NULL, value: NaN }
   }))
 }

--- a/web/src/features/moreCast2/saveForecasts.ts
+++ b/web/src/features/moreCast2/saveForecasts.ts
@@ -8,7 +8,8 @@ export const isForecastRowPredicate = (row: MoreCast2Row) =>
   isNaN(row.rhActual) &&
   isNaN(row.tempActual) &&
   isNaN(row.windDirectionActual) &&
-  isNaN(row.windSpeedActual)
+  isNaN(row.windSpeedActual) &&
+  isNaN(row.grassCuringActual)
 
 export const getForecastRows = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   return rows ? rows.filter(isForecastRowPredicate) : []

--- a/web/src/features/moreCast2/slices/dataSlice.ts
+++ b/web/src/features/moreCast2/slices/dataSlice.ts
@@ -12,7 +12,7 @@ import {
   fetchCalculatedIndices
 } from 'api/moreCast2API'
 import { AppThunk } from 'app/store'
-import { createDateInterval, rowIDHasher, fillGrassCuringForward } from 'features/moreCast2/util'
+import { createDateInterval, rowIDHasher, fillGrassCuring } from 'features/moreCast2/util'
 import { DateTime } from 'luxon'
 import { logError } from 'utils/error'
 import { MoreCast2Row } from 'features/moreCast2/interfaces'
@@ -346,7 +346,7 @@ export const createMoreCast2Rows = (
       row.precipForecast.value = 0
     }
   }
-  const newRows = fillGrassCuringForward(rows)
+  const newRows = fillGrassCuring(rows)
 
   return newRows
 }

--- a/web/src/features/moreCast2/slices/dataSlice.ts
+++ b/web/src/features/moreCast2/slices/dataSlice.ts
@@ -12,7 +12,7 @@ import {
   fetchCalculatedIndices
 } from 'api/moreCast2API'
 import { AppThunk } from 'app/store'
-import { createDateInterval, rowIDHasher } from 'features/moreCast2/util'
+import { createDateInterval, rowIDHasher, fillGrassCuringForward } from 'features/moreCast2/util'
 import { DateTime } from 'luxon'
 import { logError } from 'utils/error'
 import { MoreCast2Row } from 'features/moreCast2/interfaces'
@@ -189,7 +189,6 @@ export const createMoreCast2Rows = (
       firstItem.latitude,
       firstItem.longitude
     )
-    row.grassCuring = getNumberOrNaN(firstItem.grass_curing)
 
     for (const value of values) {
       switch (value.determinate) {
@@ -206,6 +205,7 @@ export const createMoreCast2Rows = (
           row.buiCalcActual = getNumberOrNaN(value.build_up_index)
           row.fwiCalcActual = getNumberOrNaN(value.fire_weather_index)
           row.dgrCalcActual = getNumberOrNaN(value.danger_rating)
+          row.grassCuringActual = getNumberOrNaN(value.grass_curing)
           break
         case WeatherDeterminate.FORECAST:
         case WeatherDeterminate.NULL:
@@ -252,6 +252,10 @@ export const createMoreCast2Rows = (
           row.fwiCalcForecast = {
             choice: forecastOrNull(ModelChoice.NULL),
             value: getNumberOrNaN(value.fire_weather_index)
+          }
+          row.grassCuringForecast = {
+            choice: forecastOrNull(ModelChoice.NULL),
+            value: getNumberOrNaN(value.grass_curing)
           }
           break
         case WeatherDeterminate.GDPS:
@@ -342,8 +346,9 @@ export const createMoreCast2Rows = (
       row.precipForecast.value = 0
     }
   }
+  const newRows = fillGrassCuringForward(rows)
 
-  return rows
+  return newRows
 }
 
 const forecastOrNull = (determinate: WeatherDeterminateType): ModelChoice.FORECAST | ModelChoice.NULL => {
@@ -615,7 +620,7 @@ export const createEmptyMoreCast2Row = (
     dgrCalcActual: NaN,
 
     //
-    grassCuring: NaN,
+    grassCuringActual: NaN,
 
     // GDPS model predictions
     precipGDPS: NaN,

--- a/web/src/features/moreCast2/util.test.ts
+++ b/web/src/features/moreCast2/util.test.ts
@@ -104,7 +104,7 @@ describe('parseForecastsHelper', () => {
         temp: { choice: ModelChoice.FORECAST, value: 1 },
         windDirection: { choice: ModelChoice.FORECAST, value: 1 },
         windSpeed: { choice: ModelChoice.FORECAST, value: 1 },
-        grassCuring: 1
+        grassCuring: { choice: ModelChoice.FORECAST, value: 1 }
       },
       {
         id: '22022-01-02',
@@ -116,7 +116,7 @@ describe('parseForecastsHelper', () => {
         temp: { choice: ModelChoice.FORECAST, value: 1 },
         windDirection: { choice: ModelChoice.FORECAST, value: 1 },
         windSpeed: { choice: ModelChoice.FORECAST, value: 1 },
-        grassCuring: 1
+        grassCuring: { choice: ModelChoice.FORECAST, value: 1 }
       }
     ])
   })
@@ -133,7 +133,7 @@ describe('parseForecastsHelper', () => {
         temp: { choice: ModelChoice.FORECAST, value: 1 },
         windDirection: { choice: ModelChoice.FORECAST, value: 1 },
         windSpeed: { choice: ModelChoice.FORECAST, value: 1 },
-        grassCuring: 1
+        grassCuring: { choice: ModelChoice.FORECAST, value: 1 }
       }
     ])
   })
@@ -163,7 +163,7 @@ describe('parseForecastsHelper', () => {
         temp: { choice: ModelChoice.FORECAST, value: NaN },
         windDirection: { choice: ModelChoice.FORECAST, value: NaN },
         windSpeed: { choice: ModelChoice.FORECAST, value: NaN },
-        grassCuring: NaN
+        grassCuring: { choice: ModelChoice.FORECAST, value: NaN }
       }
     ])
   })
@@ -228,20 +228,20 @@ describe('fillGrassCuring', () => {
   const actual1A = buildValidActualRow(123, TEST_DATETIME.minus({ days: 1 }))
   const actual2A = buildValidActualRow(321, TEST_DATETIME.minus({ days: 1 }))
   const actual3A = buildValidActualRow(111, TEST_DATETIME.minus({ days: 1 }))
-  actual1A.grassCuring = 80
-  actual2A.grassCuring = 70
+  actual1A.grassCuringActual = 80
+  actual2A.grassCuringActual = 70
 
   const actual1B = buildValidActualRow(123, TEST_DATETIME.minus({ days: 2 }))
   const actual2B = buildValidActualRow(321, TEST_DATETIME.minus({ days: 2 }))
-  actual1B.grassCuring = 8
-  actual2B.grassCuring = 7
+  actual1B.grassCuringActual = 8
+  actual2B.grassCuringActual = 7
 
   const rows = [forecast1A, forecast2A, forecast3A, actual1A, actual1B, actual2A, actual2B, actual3A]
 
   it('should map the most recent grass curing value for each station to each forecast', () => {
     const filledRows = fillGrassCuring(rows)
-    expect(filledRows[0].grassCuring).toBe(80)
-    expect(filledRows[1].grassCuring).toBe(70)
-    expect(filledRows[2].grassCuring).toBe(NaN)
+    expect(filledRows[0].grassCuringForecast!.value).toBe(80)
+    expect(filledRows[1].grassCuringForecast!.value).toBe(70)
+    expect(filledRows[2].grassCuringForecast!.value).toBe(NaN)
   })
 })

--- a/web/src/features/moreCast2/util.test.ts
+++ b/web/src/features/moreCast2/util.test.ts
@@ -4,7 +4,7 @@ import {
   createDateInterval,
   createWeatherModelLabel,
   fillGrassCuring,
-  fillGrassCuringForward,
+  fillStationGrassCuringForward,
   mapForecastChoiceLabels,
   parseForecastsHelper,
   rowIDHasher,
@@ -260,10 +260,10 @@ describe('fillGrassCuring', () => {
     expect(forecast3A.grassCuringForecast!.value).toBe(NaN)
   })
 })
-describe('fillGrassCuringForward', () => {
+describe('fillStationGrassCuringForward', () => {
   it('should fill grass curing forward for each station if a row is edited', () => {
     forecast1B.grassCuringForecast!.value = 43
-    fillGrassCuringForward(forecast1B, rows)
+    fillStationGrassCuringForward(forecast1B, rows)
     expect(forecast1C.grassCuringForecast!.value).toBe(43)
     expect(forecast1A.grassCuringForecast!.value).toBe(80)
     expect(forecast2A.grassCuringForecast!.value).toBe(70)

--- a/web/src/features/moreCast2/util.test.ts
+++ b/web/src/features/moreCast2/util.test.ts
@@ -4,6 +4,7 @@ import {
   createDateInterval,
   createWeatherModelLabel,
   fillGrassCuring,
+  fillGrassCuringForward,
   mapForecastChoiceLabels,
   parseForecastsHelper,
   rowIDHasher,
@@ -221,27 +222,50 @@ describe('mapForecastChoiceLabels', () => {
     expect(labelledRows[1].rhForecast!.choice).toBe('MANUAL')
   })
 })
+
+const forecast1A = buildValidForecastRow(123, TEST_DATETIME, 'FORECAST')
+const forecast1B = buildValidForecastRow(123, TEST_DATETIME.plus({ days: 1 }), 'FORECAST')
+const forecast1C = buildValidForecastRow(123, TEST_DATETIME.plus({ days: 2 }), 'FORECAST')
+const forecast2A = buildValidForecastRow(321, TEST_DATETIME, 'FORECAST')
+const forecast3A = buildValidForecastRow(111, TEST_DATETIME, 'FORECAST')
+const actual1A = buildValidActualRow(123, TEST_DATETIME.minus({ days: 1 }))
+const actual2A = buildValidActualRow(321, TEST_DATETIME.minus({ days: 1 }))
+const actual3A = buildValidActualRow(111, TEST_DATETIME.minus({ days: 1 }))
+actual1A.grassCuringActual = 80
+actual2A.grassCuringActual = 70
+
+const actual1B = buildValidActualRow(123, TEST_DATETIME.minus({ days: 2 }))
+const actual2B = buildValidActualRow(321, TEST_DATETIME.minus({ days: 2 }))
+actual1B.grassCuringActual = 8
+actual2B.grassCuringActual = 7
+
+const rows = [
+  forecast1A,
+  forecast1B,
+  forecast1C,
+  forecast2A,
+  forecast3A,
+  actual1A,
+  actual1B,
+  actual2A,
+  actual2B,
+  actual3A
+]
+
 describe('fillGrassCuring', () => {
-  const forecast1A = buildValidForecastRow(123, TEST_DATETIME, 'FORECAST')
-  const forecast2A = buildValidForecastRow(321, TEST_DATETIME, 'FORECAST')
-  const forecast3A = buildValidForecastRow(111, TEST_DATETIME, 'FORECAST')
-  const actual1A = buildValidActualRow(123, TEST_DATETIME.minus({ days: 1 }))
-  const actual2A = buildValidActualRow(321, TEST_DATETIME.minus({ days: 1 }))
-  const actual3A = buildValidActualRow(111, TEST_DATETIME.minus({ days: 1 }))
-  actual1A.grassCuringActual = 80
-  actual2A.grassCuringActual = 70
-
-  const actual1B = buildValidActualRow(123, TEST_DATETIME.minus({ days: 2 }))
-  const actual2B = buildValidActualRow(321, TEST_DATETIME.minus({ days: 2 }))
-  actual1B.grassCuringActual = 8
-  actual2B.grassCuringActual = 7
-
-  const rows = [forecast1A, forecast2A, forecast3A, actual1A, actual1B, actual2A, actual2B, actual3A]
-
   it('should map the most recent grass curing value for each station to each forecast', () => {
-    const filledRows = fillGrassCuring(rows)
-    expect(filledRows[0].grassCuringForecast!.value).toBe(80)
-    expect(filledRows[1].grassCuringForecast!.value).toBe(70)
-    expect(filledRows[2].grassCuringForecast!.value).toBe(NaN)
+    fillGrassCuring(rows)
+    expect(forecast1A.grassCuringForecast!.value).toBe(80)
+    expect(forecast2A.grassCuringForecast!.value).toBe(70)
+    expect(forecast3A.grassCuringForecast!.value).toBe(NaN)
+  })
+})
+describe('fillGrassCuringForward', () => {
+  it('should fill grass curing forward for each station if a row is edited', () => {
+    forecast1B.grassCuringForecast!.value = 43
+    fillGrassCuringForward(forecast1B, rows)
+    expect(forecast1C.grassCuringForecast!.value).toBe(43)
+    expect(forecast1A.grassCuringForecast!.value).toBe(80)
+    expect(forecast2A.grassCuringForecast!.value).toBe(70)
   })
 })

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -123,6 +123,11 @@ export const mapForecastChoiceLabels = (newRows: MoreCast2Row[], storedRows: Mor
   return newRows
 }
 
+/**
+ * Fills all stations grass curing values with the last entered value for each station
+ * @param rows - MoreCast2Row[]
+ * @returns MoreCast2Row[]
+ */
 export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   const stationGrassMap = new Map<number, { date: DateTime; grassCuring: number }>()
   // iterate through all rows first so we know we have all the grass curing values for each station
@@ -152,7 +157,14 @@ export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   return rows
 }
 
-export const fillGrassCuringForward = (editedRow: MoreCast2Row, allRows: MoreCast2Row[]) => {
+/**
+ * Provided a single row for a station is edited, fills all grass curing values for that station
+ * forward in time.
+ * @param editedRow - MoreCast2Row
+ * @param allRows - MoreCast2Row[]
+ * @returns MoreCast2Row[]
+ */
+export const fillStationGrassCuringForward = (editedRow: MoreCast2Row, allRows: MoreCast2Row[]) => {
   const editedStation = editedRow.stationCode
   const editedDate = editedRow.forDate
   const newGrassCuringValue = editedRow.grassCuringForecast!.value

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -119,12 +119,13 @@ export const mapForecastChoiceLabels = (newRows: MoreCast2Row[], storedRows: Mor
   return newRows
 }
 
-export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
+export const fillGrassCuringForward = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   const stationGrassMap = new Map<number, { date: DateTime; grassCuring: number }>()
   // iterate through all rows first so we know we have all the grass curing values for each station
   // regardless of row order
   for (const row of rows) {
-    const { stationCode, forDate, grassCuring } = row
+    const { stationCode, forDate, grassCuringForecast, grassCuringActual } = row
+    const grassCuring = isNaN(grassCuringForecast!.value) ? grassCuringActual : NaN
 
     if (!isNaN(grassCuring)) {
       const existingStation = stationGrassMap.get(stationCode)
@@ -136,12 +137,10 @@ export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   }
 
   for (const row of rows) {
-    if (validForecastPredicate(row)) {
-      const stationInfo = stationGrassMap.get(row.stationCode)
+    const stationInfo = stationGrassMap.get(row.stationCode)
 
-      if (stationInfo) {
-        row.grassCuring = stationInfo.grassCuring
-      }
+    if (stationInfo) {
+      row.grassCuringForecast!.value = stationInfo.grassCuring
     }
   }
   return rows

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -114,12 +114,13 @@ export const mapForecastChoiceLabels = (newRows: MoreCast2Row[], storedRows: Mor
       row.rhForecast = matchingRow.rhForecast
       row.windDirectionForecast = matchingRow.windDirectionForecast
       row.windSpeedForecast = matchingRow.windSpeedForecast
+      row.grassCuringForecast = matchingRow.grassCuringForecast
     }
   }
   return newRows
 }
 
-export const fillGrassCuringForward = (rows: MoreCast2Row[]): MoreCast2Row[] => {
+export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   const stationGrassMap = new Map<number, { date: DateTime; grassCuring: number }>()
   // iterate through all rows first so we know we have all the grass curing values for each station
   // regardless of row order
@@ -144,4 +145,17 @@ export const fillGrassCuringForward = (rows: MoreCast2Row[]): MoreCast2Row[] => 
     }
   }
   return rows
+}
+
+export const fillGrassCuringForward = (editedRow: MoreCast2Row, allRows: MoreCast2Row[]) => {
+  const editedStation = editedRow.stationCode
+  const editedDate = editedRow.forDate
+  const newGrassCuringValue = editedRow.grassCuringForecast!.value
+
+  for (const row of allRows) {
+    if (row.stationCode === editedStation && row.forDate > editedDate) {
+      row.grassCuringForecast!.value = newGrassCuringValue
+    }
+  }
+  return allRows
 }

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -36,7 +36,10 @@ export const parseForecastsHelper = (
         choice: ModelChoice.FORECAST,
         value: forecast.wind_speed
       },
-      grassCuring: forecast.grass_curing
+      grassCuring: {
+        choice: ModelChoice.FORECAST,
+        value: forecast.grass_curing
+      }
     }
     rows.push(row)
   })
@@ -126,7 +129,9 @@ export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   // regardless of row order
   for (const row of rows) {
     const { stationCode, forDate, grassCuringForecast, grassCuringActual } = row
-    const grassCuring = isNaN(grassCuringForecast!.value) ? grassCuringActual : NaN
+
+    const grassCuring =
+      grassCuringForecast && !isNaN(grassCuringForecast.value) ? grassCuringForecast.value : grassCuringActual
 
     if (!isNaN(grassCuring)) {
       const existingStation = stationGrassMap.get(stationCode)
@@ -140,8 +145,8 @@ export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   for (const row of rows) {
     const stationInfo = stationGrassMap.get(row.stationCode)
 
-    if (stationInfo) {
-      row.grassCuringForecast!.value = stationInfo.grassCuring
+    if (stationInfo && row.grassCuringForecast) {
+      row.grassCuringForecast.value = stationInfo.grassCuring
     }
   }
   return rows


### PR DESCRIPTION
- Adds grass curing column to Forecast Summary tab
- stores grass curing in wps database
- default persists grass curing on load, propagates grass curing forward on manual change
- makes GC nullable in the DataGrid
- closes #3139 
# Test Links:
[Landing Page](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3374.apps.silver.devops.gov.bc.ca/hfi-calculator)
