### PR TITLE
Grass curing column change

### DIFF
--- a/web/src/features/moreCast2/util.test.ts
+++ b/web/src/features/moreCast2/util.test.ts
@@ -253,9 +253,13 @@ const rows = [
 ]
 
 describe('fillGrassCuring', () => {
-  it('should map the most recent grass curing value for each station to each forecast', () => {
+  it('should map the most recent grass curing value for each station to each forecast, without overwriting existing submitted values', () => {
+    forecast1A.grassCuringForecast!.value = 60
+    forecast1B.grassCuringForecast!.value = 50
     fillGrassCuring(rows)
-    expect(forecast1A.grassCuringForecast!.value).toBe(80)
+    expect(forecast1A.grassCuringForecast!.value).toBe(60)
+    expect(forecast1B.grassCuringForecast!.value).toBe(50)
+    expect(forecast1C.grassCuringForecast!.value).toBe(50)
     expect(forecast2A.grassCuringForecast!.value).toBe(70)
     expect(forecast3A.grassCuringForecast!.value).toBe(NaN)
   })
@@ -265,7 +269,7 @@ describe('fillStationGrassCuringForward', () => {
     forecast1B.grassCuringForecast!.value = 43
     fillStationGrassCuringForward(forecast1B, rows)
     expect(forecast1C.grassCuringForecast!.value).toBe(43)
-    expect(forecast1A.grassCuringForecast!.value).toBe(80)
+    expect(forecast1A.grassCuringForecast!.value).toBe(60)
     expect(forecast2A.grassCuringForecast!.value).toBe(70)
   })
 })

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -149,7 +149,7 @@ export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
 
   for (const row of rows) {
     const stationInfo = stationGrassMap.get(row.stationCode)
-    // fill the grass curing forecasted value, as long as it doesn't already have a value
+    // fill the grass curing forecast value, as long as it doesn't already have a value
     if (stationInfo && row.grassCuringForecast && isNaN(row.grassCuringForecast.value)) {
       row.grassCuringForecast.value = stationInfo.grassCuring
     }

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -149,8 +149,8 @@ export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
 
   for (const row of rows) {
     const stationInfo = stationGrassMap.get(row.stationCode)
-
-    if (stationInfo && row.grassCuringForecast) {
+    // fill the grass curing forecasted value, as long as it doesn't already have a value
+    if (stationInfo && row.grassCuringForecast && isNaN(row.grassCuringForecast.value)) {
       row.grassCuringForecast.value = stationInfo.grassCuring
     }
   }


### PR DESCRIPTION
Making sure we don't autofill over existing values that have been submitted
# Test Links:
[Landing Page](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3389.apps.silver.devops.gov.bc.ca/hfi-calculator)
