### PR TITLE
Grass curing tab

### DIFF
--- a/api/alembic/versions/2b3755392ad8_percent_grass_curing.py
+++ b/api/alembic/versions/2b3755392ad8_percent_grass_curing.py
@@ -24,7 +24,7 @@ def upgrade():
     sa.Column('percent_grass_curing', sa.Float(), nullable=False),
     sa.Column('for_date', TZTimeStamp(), nullable=False),
     sa.PrimaryKeyConstraint('id'),
-    comment='Record containing information about percent grass curing from the CFWIS.'
+    comment='Record containing information about percent grass curing from the CWFIS.'
     )
     op.create_index(op.f('ix_percent_grass_curing_for_date'), 'percent_grass_curing', ['for_date'], unique=False)
     op.create_index(op.f('ix_percent_grass_curing_id'), 'percent_grass_curing', ['id'], unique=False)

--- a/api/app/db/crud/grass_curing.py
+++ b/api/app/db/crud/grass_curing.py
@@ -1,10 +1,11 @@
 """ CRUD operations relating to processing grass curing
 """
+from datetime import date
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 from app.db.models.grass_curing import PercentGrassCuring
-
 
 async def save_percent_grass_curing(session: AsyncSession, percent_grass_curing: PercentGrassCuring):
     """ Add a new PercentGrassCuring record.
@@ -26,3 +27,25 @@ async def get_last_percent_grass_curing_for_date(session: AsyncSession):
     stmt = select(func.max(PercentGrassCuring.for_date))
     result = await session.execute(stmt)
     return result.scalar()
+
+
+def get_percent_grass_curing_by_station_for_date_range(session: Session, start_date: date, end_date: date, station_codes: list[int]):
+    """ Given a list of stations, a start date and an end date, return the percent grass curing from processed CWFIS data
+        for each station and each date in the specidifed range.
+
+    :param session: A session object for asynchronous database access.
+    :type session: AsyncSession
+    :param start_date: The first date to return data for.
+    :type start_date: datetime.date
+    :param ned_date: The last date to return data for.
+    :type start_date: datetime.date
+    :param station_codes: A list of station codes.
+    :type station_codes: List[int]
+    """
+
+    stmt = select(PercentGrassCuring)\
+        .filter(PercentGrassCuring.for_date.between(start_date, end_date))\
+        .filter(PercentGrassCuring.station_code.in_(station_codes))\
+        .order_by(PercentGrassCuring.station_code)
+    return session.execute(stmt)
+        

--- a/api/app/db/models/grass_curing.py
+++ b/api/app/db/models/grass_curing.py
@@ -7,7 +7,7 @@ class PercentGrassCuring(Base):
     """ Daily percent grass curing per weather station. """
     __tablename__ = 'percent_grass_curing'
     __table_args__ = (
-        {'comment': 'Record containing information about percent grass curing from the CFWIS.'}
+        {'comment': 'Record containing information about percent grass curing from the CWFIS.'}
     )
 
     id = Column(Integer, Sequence('percent_grass_curing_id_seq'),

--- a/api/app/jobs/grass_curing.py
+++ b/api/app/jobs/grass_curing.py
@@ -34,7 +34,7 @@ class GrassCuringJob():
     """ Job that downloads and processes percent grass curing data from the CWFIS. """
 
     async def _get_grass_curing_wcs_raster(self, path: str):
-        """ Gets the current percent grass curing as a tif from the CFWIS Web Coverage Service. """
+        """ Gets the current percent grass curing as a tif from the CWFIS Web Coverage Service. """
         session = requests.session()
         param_dict= {
             "service": "WCS",
@@ -117,7 +117,7 @@ class GrassCuringJob():
                                                                 percent_grass_curing=value,
                                                                 station_code=station )
                     await save_percent_grass_curing(session, percent_grass_curing)
-        logger.info(f"Finished processing percent grass curing data from CFWIS for {today}.")
+        logger.info(f"Finished processing percent grass curing data from CWFIS for {today}.")
             
 
     async def _run_grass_curing(self):

--- a/api/app/schemas/morecast_v2.py
+++ b/api/app/schemas/morecast_v2.py
@@ -28,6 +28,7 @@ class WeatherDeterminate(str, Enum):
     NAM_BIAS = 'NAM_BIAS'
     RDPS = 'RDPS'
     RDPS_BIAS = 'RDPS_BIAS'
+    GRASS_CURING_CWFIS = 'Grass_Curing_CWFIS'
 
     # non prediction models
     FORECAST = 'Forecast'
@@ -141,8 +142,9 @@ class WeatherIndeterminate(BaseModel):
 
 class IndeterminateDailiesResponse(BaseModel):
     actuals: List[WeatherIndeterminate]
-    predictions: List[WeatherIndeterminate]
     forecasts: List[WeatherIndeterminate]
+    grass_curing: List[WeatherIndeterminate]
+    predictions: List[WeatherIndeterminate]
 
 
 class SimulateIndeterminateIndices(BaseModel):

--- a/web/src/api/moreCast2API.test.ts
+++ b/web/src/api/moreCast2API.test.ts
@@ -64,7 +64,7 @@ describe('moreCast2API', () => {
       DateTime.fromObject({ year: 2021, month: 1, day: 1 }),
       DateTime.fromObject({ year: 2021, month: 1, day: 2 })
     )
-    expect(JSON.stringify(res)).toBe(JSON.stringify({ actuals: [], forecasts: [], predictions: [] }))
+    expect(JSON.stringify(res)).toBe(JSON.stringify({ actuals: [], forecasts: [], grassCuring: [], predictions: [] }))
   })
 
   it('should fetch weather indeterminates with stations requested', async () => {

--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -84,7 +84,8 @@ export enum WeatherDeterminate {
   NAM_BIAS = 'NAM_BIAS',
   NULL = 'NULL',
   RDPS = 'RDPS',
-  RDPS_BIAS = 'RDPS_BIAS'
+  RDPS_BIAS = 'RDPS_BIAS',
+  GRASS_CURING_CWFIS = 'Grass_Curing_CWFIS'
 }
 
 export type WeatherDeterminateType =
@@ -101,6 +102,7 @@ export type WeatherDeterminateType =
   | 'NULL'
   | 'RDPS'
   | 'RDPS_BIAS'
+  | 'Grass_Curing_CWFIS'
 
 export const WeatherDeterminateChoices = [
   WeatherDeterminate.ACTUAL,
@@ -144,12 +146,14 @@ export interface WeatherIndeterminate {
 export interface WeatherIndeterminatePayload {
   actuals: WeatherIndeterminate[]
   forecasts: WeatherIndeterminate[]
+  grassCuring: WeatherIndeterminate[]
   predictions: WeatherIndeterminate[]
 }
 
 export interface WeatherIndeterminateResponse {
   actuals: WeatherIndeterminate[]
   forecasts: WeatherIndeterminate[]
+  grass_curing: WeatherIndeterminate[]
   predictions: WeatherIndeterminate[]
 }
 
@@ -227,6 +231,7 @@ export async function fetchWeatherIndeterminates(
     return {
       actuals: [],
       forecasts: [],
+      grassCuring: [],
       predictions: []
     }
   }
@@ -237,6 +242,7 @@ export async function fetchWeatherIndeterminates(
   const payload: WeatherIndeterminatePayload = {
     actuals: data.actuals,
     forecasts: data.forecasts,
+    grassCuring: data.grass_curing,
     predictions: data.predictions
   }
 

--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -41,6 +41,7 @@ export type ModelType =
   | 'PERSISTENCE'
   | 'RDPS'
   | 'RDPS_BIAS'
+  | 'Grass_Curing_CWFIS'
 
 export const ModelChoices: ModelType[] = [
   ModelChoice.GDPS,

--- a/web/src/features/moreCast2/components/DataGridColumns.tsx
+++ b/web/src/features/moreCast2/components/DataGridColumns.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Typography } from '@mui/material'
 import { GridColumnVisibilityModel, GridColDef } from '@mui/x-data-grid'
 import { WeatherDeterminate, WeatherDeterminateChoices } from 'api/moreCast2API'
 import {
@@ -120,7 +121,10 @@ export const getColumnGroupingModel = (
   const model = [
     {
       groupId: 'ID',
-      children: [{ field: 'stationName' }, { field: 'forDate' }]
+      children: [{ field: 'stationName' }, { field: 'forDate' }],
+      renderHeaderGroup: () => {
+        return <Typography style={{ fontWeight: 'bold' }}>ID</Typography>
+      }
     },
     {
       groupId: 'Temp',
@@ -152,7 +156,10 @@ export const getColumnGroupingModel = (
     },
     {
       groupId: 'Grass Curing',
-      children: [{ field: 'grassCuringForecast' }, { field: 'grassCuringCWFIS' }]
+      children: [{ field: 'grassCuringForecast' }, { field: 'grassCuringCWFIS' }],
+      renderHeaderGroup: () => {
+        return <Typography style={{ fontWeight: 'bold' }}>Grass Curing</Typography>
+      }
     }
   ]
   return model

--- a/web/src/features/moreCast2/components/DataGridColumns.tsx
+++ b/web/src/features/moreCast2/components/DataGridColumns.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { GridColumnVisibilityModel, GridColDef, GridColumnGroupingModel } from '@mui/x-data-grid'
+import { GridColumnVisibilityModel, GridColDef } from '@mui/x-data-grid'
 import { WeatherDeterminate, WeatherDeterminateChoices } from 'api/moreCast2API'
 import {
   MORECAST2_FIELDS,
   MORECAST2_FORECAST_FIELDS,
   MORECAST2_INDEX_FIELDS,
-  MORECAST2_STATION_DATE_FIELDS
+  MORECAST2_STATION_DATE_FIELDS,
+  MORECAST2_GRASS_CURING_CWFIS_FIELD,
+  MORECAST2_GRASS_CURING_FORCAST_FIELD
 } from 'features/moreCast2/components/MoreCast2Column'
 import GroupHeader from 'features/moreCast2/components/GroupHeader'
 import { handleShowHideChangeType } from 'features/moreCast2/components/TabbedDataGrid'
@@ -18,20 +20,6 @@ export interface ColumnVis {
 
 export class DataGridColumns {
   public static initGridColumnVisibilityModel() {
-    const model: GridColumnVisibilityModel = {}
-    const weatherParameterColumns = this.getWeatherParameterColumns()
-    weatherParameterColumns.forEach(columnName => {
-      // temperature columns are visible by default
-      if (columnName.startsWith('temp')) {
-        model[columnName] = true
-      } else {
-        model[columnName] = false
-      }
-    })
-    return model
-  }
-
-  public static initGridColumnVisibilityModelNew() {
     // First check local storage for existing column visibility
     const groupedColumnVisibility = localStorage.getItem('groupedColumnVisibility')
     if (groupedColumnVisibility) {
@@ -85,6 +73,11 @@ export class DataGridColumns {
     MORECAST2_FIELDS.forEach(field => {
       tabColumns = [...tabColumns, ...field.generateColDefs(WeatherDeterminate.FORECAST)]
     })
+    const gcForecastField = MORECAST2_GRASS_CURING_FORCAST_FIELD.generateForecastColDef()
+    const gcCwfisField = MORECAST2_GRASS_CURING_CWFIS_FIELD.generateColDef()
+    tabColumns.push(gcForecastField)
+    tabColumns.push(gcCwfisField)
+
     return tabColumns
   }
 
@@ -156,37 +149,14 @@ export const getColumnGroupingModel = (
       children: columnGroupingModelChildGenerator('windSpeed'),
       renderHeaderGroup: () =>
         renderGroupHeader('Wind Speed', 'windSpeed', showHideColumnsModel['windSpeed'], handleShowHideChange)
+    },
+    {
+      groupId: 'Grass Curing',
+      children: [{ field: 'grassCuringForecast' }, { field: 'grassCuringCWFIS' }]
     }
   ]
   return model
 }
-
-export const columnGroupingModel: GridColumnGroupingModel = [
-  {
-    groupId: 'ID',
-    children: [{ field: 'stationName' }, { field: 'forDate' }]
-  },
-  {
-    groupId: 'Temp',
-    children: columnGroupingModelChildGenerator('temp')
-  },
-  {
-    groupId: 'RH',
-    children: columnGroupingModelChildGenerator('rh')
-  },
-  {
-    groupId: 'Precip',
-    children: columnGroupingModelChildGenerator('precip')
-  },
-  {
-    groupId: 'Wind Dir',
-    children: columnGroupingModelChildGenerator('windDirection')
-  },
-  {
-    groupId: 'Wind Speed',
-    children: columnGroupingModelChildGenerator('windSpeed')
-  }
-]
 
 // Returns an array of objects of the shape { field: weather parameter + weather determinate }. For example,
 // eg. { field: 'tempACTUAL' }  These objects are used in the column grouping model to help manage grouping

--- a/web/src/features/moreCast2/components/DataGridColumns.tsx
+++ b/web/src/features/moreCast2/components/DataGridColumns.tsx
@@ -8,7 +8,7 @@ import {
   MORECAST2_INDEX_FIELDS,
   MORECAST2_STATION_DATE_FIELDS,
   MORECAST2_GRASS_CURING_CWFIS_FIELD,
-  MORECAST2_GRASS_CURING_FORCAST_FIELD
+  MORECAST2_GRASS_CURING_FORECAST_FIELD
 } from 'features/moreCast2/components/MoreCast2Column'
 import GroupHeader from 'features/moreCast2/components/GroupHeader'
 import { handleShowHideChangeType } from 'features/moreCast2/components/TabbedDataGrid'
@@ -74,7 +74,7 @@ export class DataGridColumns {
     MORECAST2_FIELDS.forEach(field => {
       tabColumns = [...tabColumns, ...field.generateColDefs(WeatherDeterminate.FORECAST)]
     })
-    const gcForecastField = MORECAST2_GRASS_CURING_FORCAST_FIELD.generateForecastColDef()
+    const gcForecastField = MORECAST2_GRASS_CURING_FORECAST_FIELD.generateForecastColDef()
     const gcCwfisField = MORECAST2_GRASS_CURING_CWFIS_FIELD.generateColDef()
     tabColumns.push(gcForecastField)
     tabColumns.push(gcCwfisField)

--- a/web/src/features/moreCast2/components/ForecastDataGrid.tsx
+++ b/web/src/features/moreCast2/components/ForecastDataGrid.tsx
@@ -15,6 +15,10 @@ import { LinearProgress } from '@mui/material'
 import { DataGridColumns } from 'features/moreCast2/components/DataGridColumns'
 import ApplyToColumnMenu from 'features/moreCast2/components/ApplyToColumnMenu'
 import { ModelChoice, ModelType } from 'api/moreCast2API'
+import { fillStationGrassCuringForward } from 'features/moreCast2/util'
+import { storeUserEditedRows } from 'features/moreCast2/slices/dataSlice'
+import { AppDispatch } from 'app/store'
+import { useDispatch } from 'react-redux'
 
 const PREFIX = 'ForecastDataGrid'
 
@@ -65,6 +69,15 @@ const ForecastDataGrid = ({
   columnGroupingModel,
   allMoreCast2Rows
 }: ForecastDataGridProps) => {
+  const dispatch: AppDispatch = useDispatch()
+
+  const processRowUpdate = async (newRow: MoreCast2Row) => {
+    const filledRows = fillStationGrassCuringForward(newRow, allMoreCast2Rows)
+    dispatch(storeUserEditedRows(filledRows))
+
+    return newRow
+  }
+
   return (
     <Root className={classes.root} data-testid={`morecast2-data-grid`}>
       <DataGrid
@@ -81,6 +94,7 @@ const ForecastDataGrid = ({
         columns={DataGridColumns.getTabColumns()}
         isCellEditable={params => params.row[params.field] !== ModelChoice.ACTUAL}
         rows={allMoreCast2Rows}
+        processRowUpdate={processRowUpdate}
       />
       <ApplyToColumnMenu
         colDef={clickedColDef}

--- a/web/src/features/moreCast2/components/MoreCast2Column.tsx
+++ b/web/src/features/moreCast2/components/MoreCast2Column.tsx
@@ -81,8 +81,8 @@ export class DateForecastField implements ColDefGenerator {
   }
 }
 
-export class GrassCuringCWFISield implements ColDefGenerator {
-  private static instance: GrassCuringCWFISield
+export class GrassCuringCWFISField implements ColDefGenerator {
+  private static instance: GrassCuringCWFISField
   private colDefBuilder: ColumnDefBuilder
 
   readonly field = 'grassCuringCWFIS'
@@ -107,12 +107,12 @@ export class GrassCuringCWFISield implements ColDefGenerator {
     return [this.generateColDef()]
   }
 
-  public static getInstance(): GrassCuringCWFISield {
-    if (!GrassCuringCWFISield.instance) {
-      GrassCuringCWFISield.instance = new GrassCuringCWFISield()
+  public static getInstance(): GrassCuringCWFISField {
+    if (!GrassCuringCWFISField.instance) {
+      GrassCuringCWFISField.instance = new GrassCuringCWFISField()
     }
 
-    return GrassCuringCWFISield.instance
+    return GrassCuringCWFISField.instance
   }
 }
 
@@ -199,4 +199,4 @@ export const MORECAST2_INDEX_FIELDS: ForecastColDefGenerator[] = [
 
 export const MORECAST2_GRASS_CURING_FORECAST_FIELD: ForecastColDefGenerator = gcForecastField
 
-export const MORECAST2_GRASS_CURING_CWFIS_FIELD: ColDefGenerator = GrassCuringCWFISield.getInstance()
+export const MORECAST2_GRASS_CURING_CWFIS_FIELD: ColDefGenerator = GrassCuringCWFISField.getInstance()

--- a/web/src/features/moreCast2/components/MoreCast2Column.tsx
+++ b/web/src/features/moreCast2/components/MoreCast2Column.tsx
@@ -197,6 +197,6 @@ export const MORECAST2_INDEX_FIELDS: ForecastColDefGenerator[] = [
   dgrField
 ]
 
-export const MORECAST2_GRASS_CURING_FORCAST_FIELD: ForecastColDefGenerator = gcForecastField
+export const MORECAST2_GRASS_CURING_FORECAST_FIELD: ForecastColDefGenerator = gcForecastField
 
 export const MORECAST2_GRASS_CURING_CWFIS_FIELD: ColDefGenerator = GrassCuringCWFISield.getInstance()

--- a/web/src/features/moreCast2/components/MoreCast2Column.tsx
+++ b/web/src/features/moreCast2/components/MoreCast2Column.tsx
@@ -81,8 +81,8 @@ export class DateForecastField implements ColDefGenerator {
   }
 }
 
-export class GrassCuringFCWFISield implements ColDefGenerator {
-  private static instance: GrassCuringFCWFISield
+export class GrassCuringCWFISield implements ColDefGenerator {
+  private static instance: GrassCuringCWFISield
   private colDefBuilder: ColumnDefBuilder
 
   readonly field = 'grassCuringCWFIS'
@@ -107,12 +107,12 @@ export class GrassCuringFCWFISield implements ColDefGenerator {
     return [this.generateColDef()]
   }
 
-  public static getInstance(): GrassCuringFCWFISield {
-    if (!GrassCuringFCWFISield.instance) {
-      GrassCuringFCWFISield.instance = new GrassCuringFCWFISield()
+  public static getInstance(): GrassCuringCWFISield {
+    if (!GrassCuringCWFISield.instance) {
+      GrassCuringCWFISield.instance = new GrassCuringCWFISield()
     }
 
-    return GrassCuringFCWFISield.instance
+    return GrassCuringCWFISield.instance
   }
 }
 
@@ -199,4 +199,4 @@ export const MORECAST2_INDEX_FIELDS: ForecastColDefGenerator[] = [
 
 export const MORECAST2_GRASS_CURING_FORCAST_FIELD: ForecastColDefGenerator = gcForecastField
 
-export const MORECAST2_GRASS_CURING_CWFIS_FIELD: ColDefGenerator = GrassCuringFCWFISield.getInstance()
+export const MORECAST2_GRASS_CURING_CWFIS_FIELD: ColDefGenerator = GrassCuringCWFISield.getInstance()

--- a/web/src/features/moreCast2/components/MoreCast2Column.tsx
+++ b/web/src/features/moreCast2/components/MoreCast2Column.tsx
@@ -81,6 +81,41 @@ export class DateForecastField implements ColDefGenerator {
   }
 }
 
+export class GrassCuringFCWFISield implements ColDefGenerator {
+  private static instance: GrassCuringFCWFISield
+  private colDefBuilder: ColumnDefBuilder
+
+  readonly field = 'grassCuringCWFIS'
+  readonly headerName = 'CWFIS'
+  readonly type = 'number'
+  readonly precision = 0
+  private constructor() {
+    this.colDefBuilder = new ColumnDefBuilder(
+      this.field,
+      this.headerName,
+      this.type,
+      this.precision,
+      new GridComponentRenderer()
+    )
+  }
+
+  public generateColDef = () => {
+    return this.colDefBuilder.generateColDefWith(this.field, this.headerName, this.precision)
+  }
+
+  public generateColDefs = () => {
+    return [this.generateColDef()]
+  }
+
+  public static getInstance(): GrassCuringFCWFISield {
+    if (!GrassCuringFCWFISield.instance) {
+      GrassCuringFCWFISield.instance = new GrassCuringFCWFISield()
+    }
+
+    return GrassCuringFCWFISield.instance
+  }
+}
+
 export class IndeterminateField implements ColDefGenerator, ForecastColDefGenerator {
   private colDefBuilder: ColumnDefBuilder
 
@@ -118,6 +153,8 @@ export const rhForecastField = new IndeterminateField('rh', RH_HEADER, 'number',
 export const windDirForecastField = new IndeterminateField('windDirection', WIND_DIR_HEADER, 'number', 0, true)
 export const windSpeedForecastField = new IndeterminateField('windSpeed', WIND_SPEED_HEADER, 'number', 1, true)
 export const precipForecastField = new IndeterminateField('precip', PRECIP_HEADER, 'number', 1, true)
+export const gcForecastField = new IndeterminateField('grassCuring', GC_HEADER, 'number', 0, false)
+
 export const buiField = new IndeterminateField('buiCalc', 'BUI', 'number', 0, false)
 export const isiField = new IndeterminateField('isiCalc', 'ISI', 'number', 1, false)
 export const fwiField = new IndeterminateField('fwiCalc', 'FWI', 'number', 0, false)
@@ -125,7 +162,6 @@ export const ffmcField = new IndeterminateField('ffmcCalc', 'FFMC', 'number', 1,
 export const dmcField = new IndeterminateField('dmcCalc', 'DMC', 'number', 0, false)
 export const dcField = new IndeterminateField('dcCalc', 'DC', 'number', 0, false)
 export const dgrField = new IndeterminateField('dgrCalc', 'DGR', 'number', 0, false)
-export const gcField = new IndeterminateField('grassCuring', GC_HEADER, 'number', 0, false)
 
 export const MORECAST2_STATION_DATE_FIELDS: ColDefGenerator[] = [
   StationForecastField.getInstance(),
@@ -148,7 +184,7 @@ export const MORECAST2_FORECAST_FIELDS: ForecastColDefGenerator[] = [
   windDirForecastField,
   windSpeedForecastField,
   precipForecastField,
-  gcField
+  gcForecastField
 ]
 
 export const MORECAST2_INDEX_FIELDS: ForecastColDefGenerator[] = [
@@ -160,3 +196,7 @@ export const MORECAST2_INDEX_FIELDS: ForecastColDefGenerator[] = [
   fwiField,
   dgrField
 ]
+
+export const MORECAST2_GRASS_CURING_FORCAST_FIELD: ForecastColDefGenerator = gcForecastField
+
+export const MORECAST2_GRASS_CURING_CWFIS_FIELD: ColDefGenerator = GrassCuringFCWFISield.getInstance()

--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -390,7 +390,8 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
 
   // Handle a double-click on a cell in the datagrid. We only handle a double-click when the clicking
   // occurs on a cell in a weather model field/column and row where a forecast is being created (ie. the
-  // row has no actual value for the weather parameter of interest)
+  // row has no actual value for the weather parameter of interest). Do nothing when double-clicking on
+  // grass curing related fields.
   const handleCellDoubleClick = (params: GridCellParams) => {
     const headerName = params.colDef.headerName as WeatherDeterminateType
     if (

--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -80,7 +80,7 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
   const [visibleRows, setVisibleRows] = useState<MoreCast2Row[]>([])
 
   const [columnVisibilityModel, setColumnVisibilityModel] = useState<GridColumnVisibilityModel>(
-    DataGridColumns.initGridColumnVisibilityModelNew()
+    DataGridColumns.initGridColumnVisibilityModel()
   )
 
   const [tempVisible, setTempVisible] = useState(true)
@@ -89,6 +89,7 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
   const [windDirectionVisible, setWindDirectionVisible] = useState(false)
   const [windSpeedVisible, setWindSpeedVisible] = useState(false)
   const [forecastSummaryVisible, setForecastSummaryVisible] = useState(false)
+  const [grassCuringVisible, setGrassCuringVisible] = useState(false)
 
   const [snackbarMessage, setSnackbarMessage] = useState('')
   const [snackbarOpen, setSnackbarOpen] = useState(false)
@@ -290,6 +291,12 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
   }, [windSpeedVisible]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    grassCuringVisible && setForecastSummaryVisible(false)
+    const updatedColumnVisibilityModel = getVisibleColumnsByWeatherParam('grassCuring', grassCuringVisible)
+    setColumnVisibilityModel(updatedColumnVisibilityModel)
+  }, [grassCuringVisible]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
     // if the forecast summary is visible, we need to toggle off the weather parameter buttons
     if (forecastSummaryVisible) {
       setTempVisible(false)
@@ -297,18 +304,7 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
       setPrecipVisible(false)
       setWindDirectionVisible(false)
       setWindSpeedVisible(false)
-      setColumnVisibilityModel(
-        DataGridColumns.updateGridColumnVisibilityModel(
-          [
-            { columnName: 'temp', visible: false },
-            { columnName: 'rh', visible: false },
-            { columnName: 'precip', visible: false },
-            { columnName: 'windDirection', visible: false },
-            { columnName: 'windSpeed', visible: false }
-          ],
-          columnVisibilityModel
-        )
-      )
+      setGrassCuringVisible(false)
     }
   }, [forecastSummaryVisible]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -397,7 +393,12 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
   // row has no actual value for the weather parameter of interest)
   const handleCellDoubleClick = (params: GridCellParams) => {
     const headerName = params.colDef.headerName as WeatherDeterminateType
-    if (!headerName || headerName === WeatherDeterminate.ACTUAL || headerName === WeatherDeterminate.FORECAST) {
+    if (
+      !headerName ||
+      headerName === WeatherDeterminate.ACTUAL ||
+      headerName === WeatherDeterminate.FORECAST ||
+      params.field.indexOf('grass') > -1
+    ) {
       // A forecast or actual column was clicked, or there is no value for headerName, nothing to do
       return
     }
@@ -495,6 +496,13 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
           selected={precipVisible}
         >
           Precip
+        </SelectableButton>
+        <SelectableButton
+          dataTestId="grass-curing-tab-button"
+          onClick={() => setGrassCuringVisible(!grassCuringVisible)}
+          selected={grassCuringVisible}
+        >
+          Grass Curing
         </SelectableButton>
         <SelectableButton
           dataTestId="summary-tab-button"

--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -397,7 +397,7 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo }: TabbedDataGridProp
       !headerName ||
       headerName === WeatherDeterminate.ACTUAL ||
       headerName === WeatherDeterminate.FORECAST ||
-      params.field.indexOf('grass') > -1
+      params.field.includes('grass')
     ) {
       // A forecast or actual column was clicked, or there is no value for headerName, nothing to do
       return

--- a/web/src/features/moreCast2/interfaces.ts
+++ b/web/src/features/moreCast2/interfaces.ts
@@ -49,6 +49,7 @@ export interface MoreCast2Row extends BaseRow {
   // Grass curing
   grassCuringActual: number
   grassCuringForecast?: PredictionItem
+  grassCuringCWFIS?: PredictionItem
 
   // Forecast properties
   precipForecast?: PredictionItem

--- a/web/src/features/moreCast2/rowFilters.test.ts
+++ b/web/src/features/moreCast2/rowFilters.test.ts
@@ -19,6 +19,7 @@ export const buildValidForecastRow = (
   forecastRow.rhForecast = { choice: choice, value: 2 }
   forecastRow.windSpeedForecast = { choice: choice, value: 2 }
   forecastRow.grassCuringForecast = { choice: choice, value: NaN }
+  forecastRow.grassCuringCWFIS = { choice: 'Grass_Curing_CWFIS', value: NaN }
   forecastRow.id = id
 
   return forecastRow

--- a/web/src/features/moreCast2/slices/dataSlice.test.ts
+++ b/web/src/features/moreCast2/slices/dataSlice.test.ts
@@ -100,7 +100,10 @@ describe('dataSlice', () => {
     })
     it('should set loading = false when getWeatherIndeterminatesSuccess is called', () => {
       expect(
-        dataSliceReducer(initialState, getWeatherIndeterminatesSuccess({ actuals: [], forecasts: [], predictions: [] }))
+        dataSliceReducer(
+          initialState,
+          getWeatherIndeterminatesSuccess({ actuals: [], forecasts: [], grassCuring: [], predictions: [] })
+        )
       ).toEqual({
         ...initialState,
         loading: false
@@ -132,6 +135,7 @@ describe('dataSlice', () => {
         }
       ]
       const forecasts: [] = []
+      const grassCuring: [] = []
       const predictions: WeatherIndeterminate[] = [
         {
           id: 'test3',
@@ -159,12 +163,14 @@ describe('dataSlice', () => {
       const payload: WeatherIndeterminatePayload = {
         actuals,
         forecasts,
+        grassCuring,
         predictions
       }
       expect(dataSliceReducer(initialState, getWeatherIndeterminatesSuccess(payload))).toEqual({
         ...initialState,
         actuals: payload.actuals,
         forecasts: payload.forecasts,
+        grassCuring: payload.grassCuring,
         predictions: payload.predictions
       })
     })
@@ -225,6 +231,7 @@ describe('dataSlice', () => {
       const rows = createMoreCast2Rows(
         [],
         [weatherIndeterminateGenerator(1, 'test1', WeatherDeterminate.FORECAST, FROM_DATE_STRING)],
+        [],
         []
       )
       expect(dataSliceReducer(initialState, storeUserEditedRows(rows)).userEditedRows).toEqual(rows)
@@ -232,7 +239,7 @@ describe('dataSlice', () => {
 
     it('should updated the edited rows', () => {
       const forecast = weatherIndeterminateGenerator(1, 'test1', WeatherDeterminate.FORECAST, FROM_DATE_STRING)
-      const rows = createMoreCast2Rows([], [forecast], [])
+      const rows = createMoreCast2Rows([], [forecast], [], [])
       expect(dataSliceReducer(initialState, storeUserEditedRows(rows)).userEditedRows).toEqual(rows)
 
       const updatedForecast = {
@@ -245,7 +252,7 @@ describe('dataSlice', () => {
         fire_weather_index: 1,
         danger_rating: 1
       }
-      const updatedRows = createMoreCast2Rows([], [updatedForecast], [])
+      const updatedRows = createMoreCast2Rows([], [updatedForecast], [], [])
       expect(dataSliceReducer(initialState, storeUserEditedRows(updatedRows)).userEditedRows).toEqual(updatedRows)
     })
   })
@@ -331,8 +338,11 @@ describe('dataSlice', () => {
       const forecasts = [
         weatherIndeterminateGenerator(stationCode, stationName, WeatherDeterminate.NULL, FROM_DATE_STRING)
       ]
+      const grassCuring = [
+        weatherIndeterminateGenerator(stationCode, stationName, WeatherDeterminate.GRASS_CURING_CWFIS, FROM_DATE_STRING)
+      ]
       const predictions = predictionGenerator(stationCode, stationName, FROM_DATE_STRING)
-      const rows = createMoreCast2Rows(actuals, forecasts, predictions)
+      const rows = createMoreCast2Rows(actuals, forecasts, grassCuring, predictions)
       expect(rows.length).toBe(1)
       const row = rows[0]
       expect(row.stationCode).toBe(stationCode)
@@ -352,8 +362,11 @@ describe('dataSlice', () => {
       const forecasts = [
         weatherIndeterminateGenerator(stationCode, stationName, WeatherDeterminate.NULL, FROM_DATE_STRING, NaN)
       ]
+      const grassCuring = [
+        weatherIndeterminateGenerator(stationCode, stationName, WeatherDeterminate.GRASS_CURING_CWFIS, FROM_DATE_STRING)
+      ]
       const predictions = predictionGenerator(stationCode, stationName, FROM_DATE_STRING)
-      const rows = createMoreCast2Rows(actuals, forecasts, predictions)
+      const rows = createMoreCast2Rows(actuals, forecasts, grassCuring, predictions)
       const row = rows[0]
       expect(row.precipForecast?.choice).toBe(WeatherDeterminate.NULL)
       expect(row.precipForecast?.value).toBe(0)
@@ -367,8 +380,11 @@ describe('dataSlice', () => {
       const forecasts = [
         weatherIndeterminateGenerator(stationCode, stationName, WeatherDeterminate.NULL, FROM_DATE_STRING, NaN)
       ]
+      const grassCuring = [
+        weatherIndeterminateGenerator(stationCode, stationName, WeatherDeterminate.GRASS_CURING_CWFIS, FROM_DATE_STRING)
+      ]
       const predictions = predictionGenerator(stationCode, stationName, FROM_DATE_STRING)
-      const rows = createMoreCast2Rows(actuals, forecasts, predictions)
+      const rows = createMoreCast2Rows(actuals, forecasts, grassCuring, predictions)
       const row = rows[0]
       expect(row.precipForecast?.choice).toBe(WeatherDeterminate.NULL)
       expect(row.precipForecast?.value).toBe(NaN)
@@ -382,8 +398,11 @@ describe('dataSlice', () => {
       const forecasts = [
         weatherIndeterminateGenerator(stationCode, stationName, WeatherDeterminate.NULL, FROM_DATE_STRING, 1)
       ]
+      const grassCuring = [
+        weatherIndeterminateGenerator(stationCode, stationName, WeatherDeterminate.GRASS_CURING_CWFIS, FROM_DATE_STRING)
+      ]
       const predictions = predictionGenerator(stationCode, stationName, FROM_DATE_STRING)
-      const rows = createMoreCast2Rows(actuals, forecasts, predictions)
+      const rows = createMoreCast2Rows(actuals, forecasts, grassCuring, predictions)
       const row = rows[0]
       expect(row.precipForecast?.choice).toBe(WeatherDeterminate.NULL)
       expect(row.precipForecast?.value).toBe(1)

--- a/web/src/features/moreCast2/slices/dataSlice.ts
+++ b/web/src/features/moreCast2/slices/dataSlice.ts
@@ -24,6 +24,7 @@ interface State {
   error: string | null
   actuals: WeatherIndeterminate[]
   forecasts: WeatherIndeterminate[]
+  grassCuring: WeatherIndeterminate[]
   predictions: WeatherIndeterminate[]
   userEditedRows: MoreCast2Row[]
 }
@@ -33,6 +34,7 @@ export const initialState: State = {
   error: null,
   actuals: [],
   forecasts: [],
+  grassCuring: [],
   predictions: [],
   userEditedRows: []
 }
@@ -45,6 +47,7 @@ const dataSlice = createSlice({
       state.error = null
       state.actuals = []
       state.forecasts = []
+      state.grassCuring = []
       state.predictions = []
       state.userEditedRows = []
       state.loading = true
@@ -57,6 +60,7 @@ const dataSlice = createSlice({
       state.error = null
       state.actuals = action.payload.actuals
       state.forecasts = action.payload.forecasts
+      state.grassCuring = action.payload.grassCuring
       state.predictions = action.payload.predictions
       state.loading = false
     },
@@ -100,7 +104,7 @@ export default dataSlice.reducer
 
 /**
  * Use the morecast2API to get WeatherIndeterminates from the backend. Fills in missing
- * actuals and predictions. Results are stored the Redux store.
+ * actuals and predictions. Results are stored in the Redux store.
  * @param stations The list of stations to retreive data for.
  * @param fromDate The start date from which to retrieve data from (inclusive).
  * @param toDate The end date from which to retrieve data from (inclusive).
@@ -130,13 +134,22 @@ export const getWeatherIndeterminates =
         stationMap,
         WeatherDeterminate.NULL
       )
+      let grassCuring = fillMissingWeatherIndeterminates(
+        data.grassCuring,
+        fromDate,
+        toDate,
+        stationMap,
+        WeatherDeterminate.GRASS_CURING_CWFIS
+      )
       let predictions = fillMissingPredictions(data.predictions, fromDate, toDate, stationMap)
       actuals = addUniqueIds(actuals)
       forecasts = addUniqueIds(forecasts)
+      grassCuring = addUniqueIds(grassCuring)
       predictions = addUniqueIds(predictions)
       const payload = {
         actuals,
         forecasts,
+        grassCuring,
         predictions
       }
       dispatch(getWeatherIndeterminatesSuccess(payload))
@@ -168,11 +181,12 @@ export const getSimulatedIndices =
 export const createMoreCast2Rows = (
   actuals: WeatherIndeterminate[],
   forecasts: WeatherIndeterminate[],
+  grassCuring: WeatherIndeterminate[],
   predictions: WeatherIndeterminate[]
 ): MoreCast2Row[] => {
   // Since ids are a composite of a station code and date, grouping by id ensures that each group represents
   // the weather indeterminates for a single station and date
-  const groupedById = groupBy([...actuals, ...forecasts, ...predictions], 'id')
+  const groupedById = groupBy([...actuals, ...forecasts, ...grassCuring, ...predictions], 'id')
 
   const rows: MoreCast2Row[] = []
 
@@ -254,7 +268,13 @@ export const createMoreCast2Rows = (
             value: getNumberOrNaN(value.fire_weather_index)
           }
           row.grassCuringForecast = {
-            choice: forecastOrNull(ModelChoice.NULL),
+            choice: forecastOrNull(value.determinate),
+            value: getNumberOrNaN(value.grass_curing)
+          }
+          break
+        case WeatherDeterminate.GRASS_CURING_CWFIS:
+          row.grassCuringCWFIS = {
+            choice: forecastOrNull(value.determinate),
             value: getNumberOrNaN(value.grass_curing)
           }
           break
@@ -371,7 +391,7 @@ export const addUniqueIds = (items: WeatherIndeterminate[]) => {
 
 /**
  * Given an array of WeatherIndeterminates, a date range, a map of station codes to stations names and
- * a WeatherDeterminate, ensure a WeatherIndetermiante is present for each day for each station.
+ * a WeatherDeterminate, ensure a WeatherIndeterminate is present for each day for each station.
  * @param items An array of WeatherIndeterminates that may need additional empty actuals added.
  * @param fromDate The start date for which actuals are required (inclusive).
  * @param toDate The end date for which actuals are required (inclusive).
@@ -513,6 +533,7 @@ export const selectAllMoreCast2Rows = createSelector([selectWeatherIndeterminate
   const rows = createMoreCast2Rows(
     weatherIndeterminates.actuals,
     weatherIndeterminates.forecasts,
+    weatherIndeterminates.grassCuring,
     weatherIndeterminates.predictions
   )
   const sortedRows = sortRowsByStationNameAndDate(rows)

--- a/web/src/features/moreCast2/slices/dataSlice.ts
+++ b/web/src/features/moreCast2/slices/dataSlice.ts
@@ -12,7 +12,7 @@ import {
   fetchCalculatedIndices
 } from 'api/moreCast2API'
 import { AppThunk } from 'app/store'
-import { createDateInterval, rowIDHasher, fillGrassCuring } from 'features/moreCast2/util'
+import { createDateInterval, rowIDHasher, fillGrassCuringForecast, fillGrassCuringCWFIS } from 'features/moreCast2/util'
 import { DateTime } from 'luxon'
 import { logError } from 'utils/error'
 import { MoreCast2Row } from 'features/moreCast2/interfaces'
@@ -366,7 +366,8 @@ export const createMoreCast2Rows = (
       row.precipForecast.value = 0
     }
   }
-  const newRows = fillGrassCuring(rows)
+  let newRows = fillGrassCuringForecast(rows)
+  newRows = fillGrassCuringCWFIS(newRows)
 
   return newRows
 }

--- a/web/src/features/moreCast2/util.test.ts
+++ b/web/src/features/moreCast2/util.test.ts
@@ -3,7 +3,8 @@ import { ModelChoice } from 'api/moreCast2API'
 import {
   createDateInterval,
   createWeatherModelLabel,
-  fillGrassCuring,
+  fillGrassCuringForecast,
+  fillGrassCuringCWFIS,
   fillStationGrassCuringForward,
   mapForecastChoiceLabels,
   parseForecastsHelper,
@@ -252,11 +253,35 @@ const rows = [
   actual3A
 ]
 
-describe('fillGrassCuring', () => {
+describe('fillGrassCuringCWFIS', () => {
+  it('should map the most recent CWFIS grass curing value to all future rows', () => {
+    forecast1A.grassCuringCWFIS!.value = 50
+    fillGrassCuringCWFIS(rows)
+    expect(forecast1A.grassCuringCWFIS!.value).toBe(50)
+    expect(forecast1B.grassCuringCWFIS!.value).toBe(50)
+    expect(forecast1C.grassCuringCWFIS!.value).toBe(50)
+  })
+  it('should not map the most recent CWFIS grass curing value to past rows', () => {
+    forecast1A.grassCuringCWFIS!.value = NaN
+    forecast1B.grassCuringCWFIS!.value = 50
+    fillGrassCuringCWFIS(rows)
+    expect(forecast1A.grassCuringCWFIS!.value).toBe(NaN)
+    expect(forecast1B.grassCuringCWFIS!.value).toBe(50)
+  })
+  it('should not map CWFIS values from one station to another station', () => {
+    forecast1A.grassCuringCWFIS!.value = 50
+    forecast1B.grassCuringCWFIS!.value = NaN
+    fillGrassCuringCWFIS(rows)
+    expect(forecast2A.grassCuringCWFIS!.value).toBe(NaN)
+    expect(forecast3A.grassCuringCWFIS!.value).toBe(NaN)
+  })
+})
+
+describe('fillGrassCuringForecast', () => {
   it('should map the most recent grass curing value for each station to each forecast, without overwriting existing submitted values', () => {
     forecast1A.grassCuringForecast!.value = NaN
     forecast1B.grassCuringForecast!.value = 50
-    fillGrassCuring(rows)
+    fillGrassCuringForecast(rows)
     expect(forecast1A.grassCuringForecast!.value).toBe(NaN)
     expect(forecast1B.grassCuringForecast!.value).toBe(50)
     expect(forecast1C.grassCuringForecast!.value).toBe(50)
@@ -266,7 +291,7 @@ describe('fillGrassCuring', () => {
   it('should not update values in the past', () => {
     forecast1A.grassCuringForecast!.value = 60
     forecast1B.grassCuringForecast!.value = 50
-    fillGrassCuring(rows)
+    fillGrassCuringForecast(rows)
     expect(forecast1A.grassCuringForecast!.value).toBe(60)
     expect(forecast1B.grassCuringForecast!.value).toBe(50)
     expect(forecast1C.grassCuringForecast!.value).toBe(50)

--- a/web/src/features/moreCast2/util.test.ts
+++ b/web/src/features/moreCast2/util.test.ts
@@ -254,6 +254,16 @@ const rows = [
 
 describe('fillGrassCuring', () => {
   it('should map the most recent grass curing value for each station to each forecast, without overwriting existing submitted values', () => {
+    forecast1A.grassCuringForecast!.value = NaN
+    forecast1B.grassCuringForecast!.value = 50
+    fillGrassCuring(rows)
+    expect(forecast1A.grassCuringForecast!.value).toBe(NaN)
+    expect(forecast1B.grassCuringForecast!.value).toBe(50)
+    expect(forecast1C.grassCuringForecast!.value).toBe(50)
+    expect(forecast2A.grassCuringForecast!.value).toBe(70)
+    expect(forecast3A.grassCuringForecast!.value).toBe(NaN)
+  })
+  it('should not update values in the past', () => {
     forecast1A.grassCuringForecast!.value = 60
     forecast1B.grassCuringForecast!.value = 50
     fillGrassCuring(rows)

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -150,7 +150,12 @@ export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   for (const row of rows) {
     const stationInfo = stationGrassMap.get(row.stationCode)
     // fill the grass curing forecast value, as long as it doesn't already have a value
-    if (stationInfo && row.grassCuringForecast && isNaN(row.grassCuringForecast.value)) {
+    if (
+      stationInfo &&
+      row.grassCuringForecast &&
+      isNaN(row.grassCuringForecast.value) &&
+      row.forDate > stationInfo.date
+    ) {
       row.grassCuringForecast.value = stationInfo.grassCuring
     }
   }

--- a/web/src/features/moreCast2/util.ts
+++ b/web/src/features/moreCast2/util.ts
@@ -128,7 +128,39 @@ export const mapForecastChoiceLabels = (newRows: MoreCast2Row[], storedRows: Mor
  * @param rows - MoreCast2Row[]
  * @returns MoreCast2Row[]
  */
-export const fillGrassCuring = (rows: MoreCast2Row[]): MoreCast2Row[] => {
+export const fillGrassCuringCWFIS = (rows: MoreCast2Row[]): MoreCast2Row[] => {
+  const stationGrassMap = new Map<number, { date: DateTime; grassCuringCWFIS: number }>()
+  // Iterate through all rows first so we know we have all the CWFIS grass curing values for each station
+  // regardless of row order.
+  for (const row of rows) {
+    const { stationCode, forDate, grassCuringCWFIS } = row
+    const grassCuring = grassCuringCWFIS && !isNaN(grassCuringCWFIS.value) ? grassCuringCWFIS.value : NaN
+
+    if (!isNaN(grassCuring)) {
+      const existingStation = stationGrassMap.get(stationCode)
+
+      if (!existingStation || forDate > existingStation.date) {
+        stationGrassMap.set(stationCode, { date: forDate, grassCuringCWFIS: grassCuring })
+      }
+    }
+  }
+
+  for (const row of rows) {
+    const stationInfo = stationGrassMap.get(row.stationCode)
+    // Fill the grass curing CWFIS value as long as it doesn't already have a value.
+    if (stationInfo && row.grassCuringCWFIS && isNaN(row.grassCuringCWFIS.value) && row.forDate > stationInfo.date) {
+      row.grassCuringCWFIS.value = stationInfo.grassCuringCWFIS
+    }
+  }
+  return rows
+}
+
+/**
+ * Fills all stations grass curing values with the last entered value for each station
+ * @param rows - MoreCast2Row[]
+ * @returns MoreCast2Row[]
+ */
+export const fillGrassCuringForecast = (rows: MoreCast2Row[]): MoreCast2Row[] => {
   const stationGrassMap = new Map<number, { date: DateTime; grassCuring: number }>()
   // iterate through all rows first so we know we have all the grass curing values for each station
   // regardless of row order


### PR DESCRIPTION
Adds the Grass Curing tab which displays the 'forecast' percent grass curing value and the value extracted from the Canadian Wildland Fire Information oSystem (CWFIS).

Fixes a minor where grass curing values would populate backwards in time when manually entering a new value.

No double-click support.
No Show/Hide columns support.
# Test Links:
[Landing Page](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3423.apps.silver.devops.gov.bc.ca/hfi-calculator)
