### PR TITLE
Install libudunits2-dev as dependency for cffdrs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,9 +16,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install ubuntu pre-requisites (api)
         # The python gdal and R component relies on libgdal-dev being installed.
+        # cffdrs requires libudunits2-dev
         run: |
           sudo apt-get update
-          sudo apt-get -y install libgdal-dev
+          sudo apt-get -y install libgdal-dev libudunits2-dev
       - name: Setup Python ${{ matrix.python-version }} (api)
         uses: actions/setup-python@v5
         with:
@@ -88,10 +89,11 @@ jobs:
           fetch-depth: 0
       - name: Install ubuntu pre-requisites (api)
         # The python gdal and R component relies on libgdal-dev being installed.
+        # cffdrs requires libudunits2-dev
         # The api uses wkhtmltopdf to generate pdf's.
         run: |
           sudo apt-get update
-          sudo apt-get -y install libgdal-dev wkhtmltopdf
+          sudo apt-get -y install libgdal-dev wkhtmltopdf libudunits2-dev
       - name: Setup Python ${{ matrix.python-version }} (api)
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/post_merge_integration.yml
+++ b/.github/workflows/post_merge_integration.yml
@@ -17,9 +17,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install ubuntu pre-requisites (api)
         # The python gdal and R component relies on libgdal-dev being installed.
+        # cffdrs requires libudunits2-dev
         run: |
           sudo apt-get update
-          sudo apt-get -y install libgdal-dev
+          sudo apt-get -y install libgdal-dev libudunits2-dev
       - name: Setup Python ${{ matrix.python-version }} (api)
         uses: actions/setup-python@v5
         with:
@@ -89,10 +90,11 @@ jobs:
           fetch-depth: 0
       - name: Install ubuntu pre-requisites (api)
         # The python gdal and R component relies on libgdal-dev being installed.
+        # cffdrs requires libudunits2-dev
         # The api uses wkhtmltopdf to generate pdf's.
         run: |
           sudo apt-get update
-          sudo apt-get -y install libgdal-dev wkhtmltopdf
+          sudo apt-get -y install libgdal-dev wkhtmltopdf libudunits2-dev
       - name: Setup Python ${{ matrix.python-version }} (api)
         uses: actions/setup-python@v5
         with:

--- a/Dockerfile.vscode
+++ b/Dockerfile.vscode
@@ -22,6 +22,8 @@ RUN apt-get -y update
 RUN apt-get -y install unixodbc-dev
 # Install old (2.4.*; current debian) version of gdal
 RUN apt-get -y install libgdal-dev
+# Dependency required for installation of cffdrs
+RUN apt-get -y install libudunits2-dev
 
 # Install R
 RUN apt-get update --fix-missing && apt-get -y install r-base

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,7 +21,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update
 RUN apt-get -y install unixodbc-dev
 # Install old (2.4.*; current debian) version of gdal
-RUN apt-get -y install libgdal-dev
+# cffdrs requires libudunits2-dev
+RUN apt-get -y install libgdal-dev libudunits2-dev
 
 # Install R
 RUN apt-get update --fix-missing && apt-get -y install r-base

--- a/docs/MANUAL_SETUP.md
+++ b/docs/MANUAL_SETUP.md
@@ -118,6 +118,8 @@ sudo apt install python3 python3-pip
 sudo apt install python-is-python3
 # install osgeo/gdal
 sudo apt install libgdal-dev
+# isntall libudunits2-dev as required dependency of cffdrs
+sudo apt install libudunits2-dev
 # install R and pre-req for cffdrs
 sudo apt install r-base
 R

--- a/openshift/wps-api-base/docker/Dockerfile
+++ b/openshift/wps-api-base/docker/Dockerfile
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # - gdal (for geospatial)
 # - R (for cffdrs)
 # - xfonts-75dpi, xfonts-base (for wkhtmltopdf)
-RUN apt-get update --fix-missing && apt-get -y install python3 python3-pip python3-dev python-is-python3 libgdal-dev r-base xfonts-base xfonts-75dpi curl git build-essential libsqlite3-dev zlib1g-dev
+RUN apt-get update --fix-missing && apt-get -y install python3 python3-pip python3-dev python-is-python3 libgdal-dev libudunits2-dev r-base xfonts-base xfonts-75dpi curl git build-essential libsqlite3-dev zlib1g-dev
 
 RUN curl -sSL https://install.python-poetry.org > /tmp/install.python-poetry.org
 RUN curl -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb > /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb

--- a/openshift/wps-api-base/openshift/build.yaml
+++ b/openshift/wps-api-base/openshift/build.yaml
@@ -82,7 +82,7 @@ objects:
           # - gdal (for geospatial)
           # - R (for cffdrs)
           # - xfonts-75dpi, xfonts-base (for wkhtmltopdf)
-          RUN apt-get update --fix-missing && apt-get -y install python3 python3-pip python3-dev python-is-python3 libgdal-dev r-base xfonts-base xfonts-75dpi curl git build-essential libsqlite3-dev zlib1g-dev
+          RUN apt-get update --fix-missing && apt-get -y install python3 python3-pip python3-dev python-is-python3 libgdal-dev libudunits2-dev r-base xfonts-base xfonts-75dpi curl git build-essential libsqlite3-dev zlib1g-dev
 
           RUN curl -sSL https://install.python-poetry.org > /tmp/install.python-poetry.org
           RUN curl -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb > /tmp/wkhtmltox_0.12.6.1-2.jammy_amd64.deb


### PR DESCRIPTION
The latest version of the cffdrs package was released today (Feb 22) and has a new dependency.