### PR TITLE
Fix dropdown icon in HFI

### DIFF
--- a/web/src/features/hfiCalculator/components/FireCentreDropdown.tsx
+++ b/web/src/features/hfiCalculator/components/FireCentreDropdown.tsx
@@ -30,10 +30,6 @@ const Root = styled('div')({
     '& .MuiAutocomplete-popupIndicator': {
       color: 'white'
     },
-    '& .MuiAutocomplete-endAdornment': {
-      right: -3,
-      top: -3
-    },
     '& .MuiInputLabel-root': {
       color: 'white'
     },


### PR DESCRIPTION
Fixes the arrow icon in the HFI Calc fire centre dropdown.
# Test Links:
[Landing Page](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3433.apps.silver.devops.gov.bc.ca/hfi-calculator)
