### PR TITLE
Fix jumping legend

### DIFF
--- a/web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/src/features/fba/components/map/FBAMap.tsx
@@ -316,7 +316,7 @@ const FBAMap = (props: FBAMapProps) => {
   // Generate a message to display about the snow layer in the legend.
   const getSnowDateMessage = () => {
     if (!showSnow) {
-      return ''
+      return null
     }
     if (isNull(props.snowDate)) {
       return 'No data available'

--- a/web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/src/features/fba/components/map/FBAMap.tsx
@@ -316,7 +316,7 @@ const FBAMap = (props: FBAMapProps) => {
   // Generate a message to display about the snow layer in the legend.
   const getSnowDateMessage = () => {
     if (!showSnow) {
-      return null
+      return ''
     }
     if (isNull(props.snowDate)) {
       return 'No data available'

--- a/web/src/features/fba/components/map/Legend.tsx
+++ b/web/src/features/fba/components/map/Legend.tsx
@@ -41,46 +41,50 @@ interface LegendItemProps {
   description?: string | null
 }
 
-const LegendItem: React.FC<LegendItemProps> = ({ label, checked, onChange, subItems, description }) => (
-  <div>
-    <Grid>
-      <Grid container alignItems={'center'}>
-        <Grid item>
-          <Checkbox
-            data-testid={`${label.toLowerCase().split(' ')[0]}-checkbox`}
-            checked={checked}
-            onChange={onChange}
-          />
+const LegendItem: React.FC<LegendItemProps> = ({ label, checked, onChange, subItems, description }) => {
+  // Dirty hack used to force whitespace for the Snow Coverage legend item
+  const hasEmptyDescription = description === ''
+  return (
+    <div>
+      <Grid>
+        <Grid container alignItems={'center'}>
+          <Grid item>
+            <Checkbox
+              data-testid={`${label.toLowerCase().split(' ')[0]}-checkbox`}
+              checked={checked}
+              onChange={onChange}
+            />
+          </Grid>
+          <Grid item>
+            <Typography variant="h2" sx={{ fontSize: '1rem', fontWeight: 'bold' }}>
+              {label}
+            </Typography>
+          </Grid>
         </Grid>
-        <Grid item>
-          <Typography variant="h2" sx={{ fontSize: '1rem', fontWeight: 'bold' }}>
-            {label}
-          </Typography>
+        <Grid container alignItems={'center'}>
+          <Grid item sx={{ transform: 'translate(50%, -50%)' }}>
+            <Typography variant="body1" sx={{ fontSize: '0.75rem' }}>
+              {hasEmptyDescription ? <span>&nbsp;</span> : description}
+            </Typography>
+          </Grid>
         </Grid>
-      </Grid>
-      <Grid container alignItems={'center'}>
-        <Grid item sx={{ transform: 'translate(50%, -50%)' }}>
-          <Typography variant="body1" sx={{ fontSize: '0.75rem' }}>
-            {description}
-          </Typography>
-        </Grid>
-      </Grid>
 
-      {subItems && (
-        <List dense={true} sx={{ marginLeft: '2.5rem', marginTop: '-1rem' }}>
-          {subItems.map(subItem => (
-            <ListItem disablePadding key={subItem.label}>
-              <ListItemIcon>
-                <LegendSymbol sx={{ backgroundColor: subItem.symbol }} />
-              </ListItemIcon>
-              <ListItemText>{subItem.label}</ListItemText>
-            </ListItem>
-          ))}
-        </List>
-      )}
-    </Grid>
-  </div>
-)
+        {subItems && (
+          <List dense={true} sx={{ marginLeft: '2.5rem', marginTop: '-1rem' }}>
+            {subItems.map(subItem => (
+              <ListItem disablePadding key={subItem.label}>
+                <ListItemIcon>
+                  <LegendSymbol sx={{ backgroundColor: subItem.symbol }} />
+                </ListItemIcon>
+                <ListItemText>{subItem.label}</ListItemText>
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </Grid>
+    </div>
+  )
+}
 
 interface LegendProps {
   onToggleLayer: (layerName: string, isVisible: boolean) => void

--- a/web/src/features/fba/components/map/Legend.tsx
+++ b/web/src/features/fba/components/map/Legend.tsx
@@ -50,7 +50,6 @@ const LegendItem: React.FC<LegendItemProps> = ({
   description,
   renderEmptyDescription = false
 }) => {
-  // Dirty hack used to force whitespace for the Snow Coverage legend item
   return (
     <div>
       <Grid>

--- a/web/src/features/fba/components/map/Legend.tsx
+++ b/web/src/features/fba/components/map/Legend.tsx
@@ -39,11 +39,18 @@ interface LegendItemProps {
   onChange: (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void
   subItems?: SubItem[]
   description?: string | null
+  renderEmptyDescription?: boolean
 }
 
-const LegendItem: React.FC<LegendItemProps> = ({ label, checked, onChange, subItems, description }) => {
+const LegendItem: React.FC<LegendItemProps> = ({
+  label,
+  checked,
+  onChange,
+  subItems,
+  description,
+  renderEmptyDescription = false
+}) => {
   // Dirty hack used to force whitespace for the Snow Coverage legend item
-  const hasEmptyDescription = description === ''
   return (
     <div>
       <Grid>
@@ -64,7 +71,7 @@ const LegendItem: React.FC<LegendItemProps> = ({ label, checked, onChange, subIt
         <Grid container alignItems={'center'}>
           <Grid item sx={{ transform: 'translate(50%, -50%)' }}>
             <Typography variant="body1" sx={{ fontSize: '0.75rem' }}>
-              {hasEmptyDescription ? <span>&nbsp;</span> : description}
+              {description ?? (renderEmptyDescription && <span>&nbsp;</span>)}
             </Typography>
           </Grid>
         </Grid>
@@ -147,6 +154,7 @@ const Legend = ({
         checked={showSnow}
         onChange={() => handleLayerChange('snowVector', showSnow, setShowSnow)}
         description={snowDescription}
+        renderEmptyDescription={true}
       ></LegendItem>
     </LegendGrid>
   )


### PR DESCRIPTION
Dirty hack to display a whitespace below the Snow Coverage legend item.
# Test Links:
[Landing Page](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/)
[MoreCast 2.0](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/morecast-2)
[Percentile Calculator](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3450.apps.silver.devops.gov.bc.ca/hfi-calculator)
