### PR TITLE
Bumps pgbouncer version to 1.21.0 that includes support for prepared statements

### DIFF
--- a/api/app/db/database.py
+++ b/api/app/db/database.py
@@ -1,6 +1,7 @@
 """ Setup database to perform CRUD transactions
 """
 import logging
+import uuid
 from typing import Generator, AsyncGenerator
 from contextlib import contextmanager, asynccontextmanager
 from sqlalchemy import create_engine
@@ -39,8 +40,16 @@ _read_engine = create_engine(
     pool_pre_ping=True, connect_args=connect_args)
 
 # TODO: figure out connection pooling? pre-ping etc.?
-_async_read_engine = create_async_engine(ASYNC_DB_READ_STRING, connect_args={"timeout": 30})
-_async_write_engine = create_async_engine(ASYNC_DB_WRITE_STRING)
+_async_read_engine = create_async_engine(
+    ASYNC_DB_READ_STRING, 
+    connect_args={"timeout": 30,
+                  "prepared_statement_name_func": lambda: f"__asyncpg_{uuid.uuid4()}__"
+                  })
+_async_write_engine = create_async_engine(
+    ASYNC_DB_WRITE_STRING, 
+    connect_args={
+                    "prepared_statement_name_func": lambda: f"__asyncpg_{uuid.uuid4()}__"
+})
 
 # bind session to database
 # avoid using these variables anywhere outside of context manager - if

--- a/api/app/db/database.py
+++ b/api/app/db/database.py
@@ -48,8 +48,8 @@ _async_read_engine = create_async_engine(
 _async_write_engine = create_async_engine(
     ASYNC_DB_WRITE_STRING, 
     connect_args={
-                    "prepared_statement_name_func": lambda: f"__asyncpg_{uuid.uuid4()}__"
-})
+        "prepared_statement_name_func": lambda: f"__asyncpg_{uuid.uuid4()}__"
+        })
 
 # bind session to database
 # avoid using these variables anywhere outside of context manager - if

--- a/api/app/db/database.py
+++ b/api/app/db/database.py
@@ -1,7 +1,6 @@
 """ Setup database to perform CRUD transactions
 """
 import logging
-import uuid
 from typing import Generator, AsyncGenerator
 from contextlib import contextmanager, asynccontextmanager
 from sqlalchemy import create_engine
@@ -40,16 +39,8 @@ _read_engine = create_engine(
     pool_pre_ping=True, connect_args=connect_args)
 
 # TODO: figure out connection pooling? pre-ping etc.?
-_async_read_engine = create_async_engine(
-    ASYNC_DB_READ_STRING, 
-    connect_args={"timeout": 30,
-                  "prepared_statement_name_func": lambda: f"__asyncpg_{uuid.uuid4()}__"
-                  })
-_async_write_engine = create_async_engine(
-    ASYNC_DB_WRITE_STRING, 
-    connect_args={
-        "prepared_statement_name_func": lambda: f"__asyncpg_{uuid.uuid4()}__"
-        })
+_async_read_engine = create_async_engine(ASYNC_DB_READ_STRING, connect_args={"timeout": 30})
+_async_write_engine = create_async_engine(ASYNC_DB_WRITE_STRING)
 
 # bind session to database
 # avoid using these variables anywhere outside of context manager - if

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -153,7 +153,7 @@ objects:
             global:
               pool_mode: transaction
               ignore_startup_parameters: options
-              max_prepared_statements: 10
+              max_prepared_statements: "10"
           port: 5432
           replicas: 1
           resources:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -111,7 +111,7 @@ objects:
             storageClassName: netapp-block-standard
       backups:
         pgbackrest:
-          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer/ubi8-1.21-0
+          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:ubi8-2.41-4
           manual:
             repoName: repo1
             options:
@@ -138,6 +138,7 @@ objects:
 
       proxy:
         pgBouncer:
+          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer/ubi8-1.21-0
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -152,6 +153,7 @@ objects:
             global:
               pool_mode: transaction
               ignore_startup_parameters: options
+              max_prepared_statements: 10
           port: 5432
           replicas: 1
           resources:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -152,7 +152,6 @@ objects:
             global:
               pool_mode: transaction
               ignore_startup_parameters: options
-              max_prepared_statements: 10
           port: 5432
           replicas: 1
           resources:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -152,7 +152,7 @@ objects:
             global:
               pool_mode: transaction
               ignore_startup_parameters: options
-              max_prepared_statements: 10
+              max_prepared_statements: "10"
           port: 5432
           replicas: 1
           resources:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -138,7 +138,7 @@ objects:
 
       proxy:
         pgBouncer:
-          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer/ubi8-1.21-0
+          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer:ubi8-1.21-0
           affinity:
             podAntiAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -152,7 +152,7 @@ objects:
             global:
               pool_mode: transaction
               ignore_startup_parameters: options
-              max_prepared_statements: "10"
+              max_prepared_statements: 10
           port: 5432
           replicas: 1
           resources:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -111,7 +111,7 @@ objects:
             storageClassName: netapp-block-standard
       backups:
         pgbackrest:
-          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:ubi8-2.41-4
+          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer/ubi8-1.21-0
           manual:
             repoName: repo1
             options:
@@ -152,6 +152,7 @@ objects:
             global:
               pool_mode: transaction
               ignore_startup_parameters: options
+              max_prepared_statements: 10
           port: 5432
           replicas: 1
           resources:


### PR DESCRIPTION
We started getting errors about asyncpg prepared statements like:

`prepared statement "__asyncpg_stmt2_" already exists`

Turns out pre version 1.21.0, `pgbouncer` didn't support caching prepared statements.

According to the discussion here, `sqlalchemy`/`asyncpg` has no support for turning off prepared statements: https://github.com/sqlalchemy/sqlalchemy/issues/6467

This PR pulls in the `pgbouncer` version 1.21.0 for supporting an LRU cache of prepared statements across transactions.

More background information here:
- https://www.crunchydata.com/blog/prepared-statements-in-transaction-mode-for-pgbouncer
- https://www.pgbouncer.org/config.html#max_prepared_statements

# Test Links:
[Landing Page](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3539.apps.silver.devops.gov.bc.ca/hfi-calculator)
