### PR TITLE
Store hourly ffmc from sfms

### DIFF
--- a/api/app/auth.py
+++ b/api/app/auth.py
@@ -21,6 +21,12 @@ async def permissive_oauth2_scheme(request: Request):
         logger.error('Could not validate the credential %s', exception)
         return None
 
+async def sfms_authenticate(request: Request):
+    """ Returns parsed auth token if authorized, None otherwise. """
+    secret = request.headers.get('Secret')
+    if not secret or secret != config.get('SFMS_SECRET'):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    
 
 async def authenticate(token: str = Depends(permissive_oauth2_scheme)):
     """ Returns Decoded token when validation of the token is successful.

--- a/api/app/auto_spatial_advisory/sfms.py
+++ b/api/app/auto_spatial_advisory/sfms.py
@@ -6,11 +6,13 @@ from typing import Final
 from app.schemas.auto_spatial_advisory import SFMSFile, SFMSRunType
 from app.utils.time import get_hour_20, get_vancouver_now
 
-
 def is_hfi_file(filename: str) -> bool:
     "Returns true if filename starts with 'hfi'"
     return filename.startswith("hfi")
 
+def is_ffmc_file(filename: str) -> bool:
+    "Returns true if filename starts with 'hfi'"
+    return filename.startswith("ffmc")
 
 def get_date_part(filename: str) -> str:
     """ Get the date part of the filename.
@@ -64,6 +66,18 @@ def get_target_filename(filename: str) -> str:
     prefix = get_prefix(filename)
     # create the filename
     return os.path.join('sfms', 'uploads', prefix, issue_date.isoformat()[:10], filename)
+
+
+def get_hourly_filename(filename: str) -> str:
+    """ Get the hourly filename, something that looks like this:
+    bucket/sfms/upload/hourlies/[issue date NOT TIME]/hfi20220823-HH.tif
+    """
+    # We are assuming that the local server time, matches the issue date. We assume that
+    # right after a file is generated, this API is called - and as such the current
+    # time IS the issue date.
+    issue_date = get_vancouver_now()
+    # create the filename
+    return os.path.join('sfms', 'uploads', 'hourlies', issue_date.isoformat()[:10], filename)
 
 
 def get_sfms_file_message(filename: str, meta_data: dict) -> SFMSFile:

--- a/api/app/auto_spatial_advisory/sfms.py
+++ b/api/app/auto_spatial_advisory/sfms.py
@@ -10,10 +10,6 @@ def is_hfi_file(filename: str) -> bool:
     "Returns true if filename starts with 'hfi'"
     return filename.startswith("hfi")
 
-def is_ffmc_file(filename: str) -> bool:
-    "Returns true if filename starts with 'hfi'"
-    return filename.startswith("ffmc")
-
 def get_date_part(filename: str) -> str:
     """ Get the date part of the filename.
     Filename example: hfi20220823.tif

--- a/api/app/routers/sfms.py
+++ b/api/app/routers/sfms.py
@@ -9,8 +9,8 @@ from app.auth import sfms_authenticate
 from app.nats_publish import publish
 from app.utils.s3 import get_client
 from app import config
-from app.auto_spatial_advisory.sfms import get_hourly_filename, get_sfms_file_message, get_target_filename, get_date_part, is_ffmc_file, is_hfi_file
-from app.auto_spatial_advisory.nats_config import stream_name, subjects, sfms_file_subject, hourly_ffmc_sfms_file_subject
+from app.auto_spatial_advisory.sfms import get_hourly_filename, get_sfms_file_message, get_target_filename, get_date_part, is_hfi_file
+from app.auto_spatial_advisory.nats_config import stream_name, subjects, sfms_file_subject
 from app.schemas.auto_spatial_advisory import ManualSFMS, SFMSFile
 
 

--- a/api/app/routers/sfms.py
+++ b/api/app/routers/sfms.py
@@ -4,12 +4,13 @@ import logging
 from datetime import datetime, date
 import os
 from tempfile import SpooledTemporaryFile
-from fastapi import APIRouter, UploadFile, Response, Request, BackgroundTasks, Header
+from fastapi import APIRouter, UploadFile, Response, Request, BackgroundTasks, Depends, Header
+from app.auth import sfms_authenticate
 from app.nats_publish import publish
 from app.utils.s3 import get_client
 from app import config
-from app.auto_spatial_advisory.sfms import get_sfms_file_message, get_target_filename, get_date_part, is_hfi_file
-from app.auto_spatial_advisory.nats_config import stream_name, subjects, sfms_file_subject
+from app.auto_spatial_advisory.sfms import get_hourly_filename, get_sfms_file_message, get_target_filename, get_date_part, is_ffmc_file, is_hfi_file
+from app.auto_spatial_advisory.nats_config import stream_name, subjects, sfms_file_subject, hourly_ffmc_sfms_file_subject
 from app.schemas.auto_spatial_advisory import ManualSFMS, SFMSFile
 
 
@@ -60,7 +61,8 @@ def get_meta_data(request: Request) -> dict:
 @router.post('/upload')
 async def upload(file: UploadFile,
                  request: Request,
-                 background_tasks: BackgroundTasks):
+                 background_tasks: BackgroundTasks,
+                 _=Depends(sfms_authenticate)):
     """
     Trigger the SFMS process to run on the provided file.
     The header MUST include the SFMS secret key.
@@ -75,9 +77,6 @@ async def upload(file: UploadFile,
     ```
     """
     logger.info('sfms/upload/')
-    secret = request.headers.get('Secret')
-    if not secret or secret != config.get('SFMS_SECRET'):
-        return Response(status_code=401)
     # Get an async S3 client.
     async with get_client() as (client, bucket):
         # We save the Last-modified and Create-time as metadata in the object store - just
@@ -107,6 +106,38 @@ async def upload(file: UploadFile,
         # NOTE: Ideally, we'd be able to rely on the caller to retry the upload if we fail to
         # put a message on the queue. But, we can't do that because the caller isn't very smart,
         # and can't be given that level of responsibility.
+    return Response(status_code=200)
+
+@router.post('/upload/hourlies')
+async def upload_hourlies(file: UploadFile,
+                 request: Request,
+                 _=Depends(sfms_authenticate)):
+    """
+    Trigger the SFMS process to run on the provided file for hourlies.
+    The header MUST include the SFMS secret key.
+
+    ```
+    curl -X 'POST' \\
+        'https://psu.nrs.gov.bc.ca/api/sfms/upload/hourlies' \\
+        -H 'accept: application/json' \\
+        -H 'Content-Type: multipart/form-data' \\
+        -H 'Secret: secret' \\
+        -F 'file=@hfi20220812.tif;type=image/tiff'
+    ```
+    """
+    logger.info('sfms/upload/hourlies')
+    # Get an async S3 client.
+    async with get_client() as (client, bucket):
+        # We save the Last-modified and Create-time as metadata in the object store - just
+        # in case we need to know about it in the future.
+        key = get_hourly_filename(file.filename)
+        logger.info('Uploading file "%s" to "%s"', file.filename, key)
+        meta_data = get_meta_data(request)
+        await client.put_object(Bucket=bucket,
+                                Key=key,
+                                Body=FileLikeObject(file.file),
+                                Metadata=meta_data)
+        logger.info('Done uploading file')
     return Response(status_code=200)
 
 

--- a/api/app/tests/sfms/test_sfms.py
+++ b/api/app/tests/sfms/test_sfms.py
@@ -1,4 +1,4 @@
-from app.auto_spatial_advisory.sfms import is_hfi_file
+from app.auto_spatial_advisory.sfms import is_hfi_file, is_ffmc_file
 
 
 def test_is_hfi_file():
@@ -7,3 +7,10 @@ def test_is_hfi_file():
 
 def test_is_not_hfi_file():
     assert is_hfi_file('at20220824.tiff') is False
+
+def test_is_ffmc_file():
+    assert is_ffmc_file('ffmc20220824.tiff') is True
+
+
+def test_is_not_ffmc_file():
+    assert is_ffmc_file('hfi20220824.tiff') is False

--- a/api/app/tests/sfms/test_sfms.py
+++ b/api/app/tests/sfms/test_sfms.py
@@ -1,4 +1,4 @@
-from app.auto_spatial_advisory.sfms import is_hfi_file, is_ffmc_file
+from app.auto_spatial_advisory.sfms import is_hfi_file
 
 
 def test_is_hfi_file():
@@ -7,10 +7,3 @@ def test_is_hfi_file():
 
 def test_is_not_hfi_file():
     assert is_hfi_file('at20220824.tiff') is False
-
-def test_is_ffmc_file():
-    assert is_ffmc_file('ffmc20220824.tiff') is True
-
-
-def test_is_not_ffmc_file():
-    assert is_ffmc_file('hfi20220824.tiff') is False

--- a/api/app/tests/sfms/test_sfms_upload.py
+++ b/api/app/tests/sfms/test_sfms_upload.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, patch
 from datetime import datetime, timezone
 from fastapi.testclient import TestClient
-from app.auto_spatial_advisory.sfms import get_prefix
+from app.auto_spatial_advisory.sfms import get_hourly_filename, get_prefix
 from app.routers.sfms import get_target_filename
 from app import config
 
@@ -114,6 +114,12 @@ def test_get_target_filename_day_difference(_):
     assert get_target_filename(today) == 'sfms/uploads/actual/2022-08-23/hfi20220823.tif'
     # It's 5 pm, so anything for tomorrow, is a forecast.
     assert get_target_filename(tomorrow) == 'sfms/uploads/forecast/2022-08-23/hfi20220824.tif'
+
+
+@patch('app.auto_spatial_advisory.sfms.get_vancouver_now', return_value=get_pdt_17())
+def test_get_hourly_filename(_):
+    """ Test get_hourly_filename function """
+    assert get_hourly_filename(today) == 'sfms/uploads/hourlies/2022-08-23/hfi20220823.tif'
 
 
 @patch('app.routers.sfms.get_client')

--- a/api/app/tests/sfms/test_sfms_upload.py
+++ b/api/app/tests/sfms/test_sfms_upload.py
@@ -11,6 +11,7 @@ from app.main import app
 
 
 URL = '/api/sfms/upload'
+HOURLY_FFMC_URL = '/api/sfms/upload/hourlies'
 
 yesterday: Final = 'hfi20220822.tif'
 today: Final = 'hfi20220823.tif'
@@ -188,3 +189,30 @@ def test_endpoint_wrong_secret(mock_publish: AsyncMock, mock_get_client: AsyncMo
     assert mock_s3_client.put_object.called is False
     # Publish should not have been called.
     assert mock_publish.called is False
+
+
+
+@patch('app.routers.sfms.get_client')
+@patch('app.routers.sfms.publish')
+def test_hourly_ffmc_endpoint(mock_publish: AsyncMock, mock_get_client: AsyncMock):
+    """ Test that if all is well - the endpoint returns 200, the file is uploaded to S3. """
+    mock_s3_client = AsyncMock()
+
+    @asynccontextmanager
+    async def _mock_get_client_for_router():
+        yield mock_s3_client, 'some_bucket'
+
+    mock_get_client.return_value = _mock_get_client_for_router()
+    client = TestClient(app)
+    response = client.post(HOURLY_FFMC_URL,
+                           files={'file': ('hfi20220904.tiff', b'')},
+                           headers={
+                               'Secret': config.get('SFMS_SECRET'),
+                               'Last-modified': datetime.now().isoformat(),
+                               'Create-time': datetime.now().isoformat()})
+    # We should get a 200 response if the file is uploaded successfully.
+    assert response.status_code == 200
+    # We should have called put_object once.
+    assert mock_s3_client.put_object.called
+    # We should not publish hourly ffmc
+    assert mock_publish.called == False


### PR DESCRIPTION
- Adds hourly upload endpoint for hourly FFMC uploads
- Assumes hourly FFMC includes hour in filename, or we can fallback to creation timestamp to avoid adding more code

# Test Links:
[Landing Page](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3550.apps.silver.devops.gov.bc.ca/hfi-calculator)
