### PR TITLE
Limit hourlies endpoint to only store ffmc files

### DIFF
--- a/api/app/auto_spatial_advisory/sfms.py
+++ b/api/app/auto_spatial_advisory/sfms.py
@@ -10,6 +10,10 @@ def is_hfi_file(filename: str) -> bool:
     "Returns true if filename starts with 'hfi'"
     return filename.startswith("hfi")
 
+def is_ffmc_file(filename: str) -> bool:
+    "Returns true if filename starts with 'fine_fuel_moisture_code'"
+    return filename.startswith("fine_fuel_moisture_code")
+
 def get_date_part(filename: str) -> str:
     """ Get the date part of the filename.
     Filename example: hfi20220823.tif

--- a/api/app/tests/sfms/test_sfms.py
+++ b/api/app/tests/sfms/test_sfms.py
@@ -1,4 +1,4 @@
-from app.auto_spatial_advisory.sfms import is_hfi_file
+from app.auto_spatial_advisory.sfms import is_hfi_file, is_ffmc_file
 
 
 def test_is_hfi_file():
@@ -7,3 +7,11 @@ def test_is_hfi_file():
 
 def test_is_not_hfi_file():
     assert is_hfi_file('at20220824.tiff') is False
+
+
+def test_is_ffmc_file():
+    assert is_ffmc_file('fine_fuel_moisture_code20220824.tiff') is True
+
+
+def test_is_not_ffmc_file():
+    assert is_ffmc_file('hfi20220824.tiff') is False


### PR DESCRIPTION
- Checks that the received file on the hourlies endpoint is an ffmc and only puts it on S3 if it is