### PR TITLE
Update redux instead of local state on double-click

### DIFF
--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -431,7 +431,7 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo, fetchWeatherIndeterm
       // forecast field value with the value of the cell that was double-clicked
       row[forecastField].choice = headerName
       row[forecastField].value = params.value
-      // We've updated local state directly, so now we ned to sync Redux state
+      // We've updated local state directly, so now we need to sync Redux state
       dispatch(storeUserEditedRows([...visibleRows]))
     }
   }

--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -381,7 +381,6 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo, fetchWeatherIndeterm
     }
 
     dispatch(storeUserEditedRows(newRows))
-    setVisibleRows(newRows)
   }
 
   const updateColumnFromModel = (
@@ -408,7 +407,6 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo, fetchWeatherIndeterm
     }
 
     dispatch(storeUserEditedRows(newRows))
-    setVisibleRows(newRows)
   }
 
   // Handle a double-click on a cell in the datagrid. We only handle a double-click when the clicking
@@ -433,8 +431,8 @@ const TabbedDataGrid = ({ morecast2Rows, fromTo, setFromTo, fetchWeatherIndeterm
       // forecast field value with the value of the cell that was double-clicked
       row[forecastField].choice = headerName
       row[forecastField].value = params.value
-      // We've updated local state directly, so now we have to re-render by calling setVisibleRows
-      setVisibleRows([...visibleRows])
+      // We've updated local state directly, so now we ned to sync Redux state
+      dispatch(storeUserEditedRows([...visibleRows]))
     }
   }
 


### PR DESCRIPTION
Update redux store on double-click 
Remove a couple unnecessary local state updates.
# Test Links:
[Landing Page](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3574.apps.silver.devops.gov.bc.ca/hfi-calculator)
