### PR TITLE
SFMS close upload files

### DIFF
--- a/api/app/routers/sfms.py
+++ b/api/app/routers/sfms.py
@@ -90,6 +90,7 @@ async def upload(file: UploadFile,
                                 Key=key,
                                 Body=FileLikeObject(file.file),
                                 Metadata=meta_data)
+        await file.close()
         logger.info('Done uploading file')
     try:
         # We don't want to hold back the response to the client, so we'll publish the message
@@ -142,6 +143,7 @@ async def upload_hourlies(file: UploadFile,
                                     ACL=SFMS_HOURLIES_PERMISSIONS,
                                     Body=FileLikeObject(file.file),
                                     Metadata=meta_data)
+            await file.close()
             logger.info('Done uploading file')
     return Response(status_code=200)
 
@@ -199,6 +201,7 @@ async def upload_manual(file: UploadFile,
                                 Key=key,
                                 Body=FileLikeObject(file.file),
                                 Metadata=meta_data)
+        await file.close()
         logger.info('Done uploading file')
     return add_msg_to_queue(file, key, forecast_or_actual, meta_data, issue_date, background_tasks)
 


### PR DESCRIPTION
Manually close the upload files to mitigate the SIGKILL errors we're seeing presumably from the sfms/upload/hourlies endpoint. Based on [this discussion](https://github.com/tiangolo/fastapi/discussions/6380) it looks like FastAPI just lets the garbage handler deal with unused memory.
# Test Links:
[Landing Page](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3610-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
