### PR TITLE
Set max requests and jitter random offset

### DIFF
--- a/api/start.sh
+++ b/api/start.sh
@@ -6,4 +6,4 @@ set -e
 # set some defaults
 GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
 # start the server
-poetry run gunicorn app.main:app --timeout 200 --workers $GUNICORN_WORKERS --worker-class uvicorn.workers.UvicornWorker --bind=0.0.0.0:8080
+poetry run gunicorn app.main:app --timeout 200 --workers $GUNICORN_WORKERS --worker-class uvicorn.workers.UvicornWorker --max_requests 50 --max_requests_jitter 50 --bind=0.0.0.0:8080


### PR DESCRIPTION
Sets [max_requests](max_requests_jitter) and [max_requests_jitter](https://docs.gunicorn.org/en/stable/settings.html#max-requests-jitter) to limit impact of memory leaks. This will reset gunicorn workers every 50 + `rand(0, 50)` requests, with the random offset handled by the jitter param to avoid all workers resetting at once.
# Test Links:
[Landing Page](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3619-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
