### PR TITLE
Handle none values more gracefully for FFMC calculations

### DIFF
--- a/api/app/fire_behaviour/cffdrs.py
+++ b/api/app/fire_behaviour/cffdrs.py
@@ -545,12 +545,25 @@ def fine_fuel_moisture_code(ffmc: float, temperature: float, relative_humidity: 
 
     if ffmc is None:
         ffmc = NULL
+    if temperature is None:
+        temperature = NULL
+    if relative_humidity is None:
+        relative_humidity = NULL
+    if precipitation is None:
+        precipitation = NULL
+    if wind_speed is None:
+        logger.error("Failed to calculate ffmc")
+        return None
     result = CFFDRS.instance().cffdrs._ffmcCalc(ffmc_yda=ffmc, temp=temperature, rh=relative_humidity,
                                                 prec=precipitation, ws=wind_speed)
+    if len(result) == 0:
+        logger.error("Failed to calculate ffmc")
+        return None
     if isinstance(result[0], float):
         return result[0]
-    raise CFFDRSException("Failed to calculate ffmc")
-
+    
+    logger.error("Failed to calculate ffmc")
+    return None
 
 def duff_moisture_code(dmc: float, temperature: float, relative_humidity: float,
                        precipitation: float, latitude: float = 55, month: int = 7,

--- a/api/app/fire_behaviour/cffdrs.py
+++ b/api/app/fire_behaviour/cffdrs.py
@@ -591,12 +591,24 @@ def duff_moisture_code(dmc: float, temperature: float, relative_humidity: float,
     :type latitude_adjust: bool, optional
     """
     if dmc is None:
-        dmc = NULL
+        logger.error("Failed to calculate DMC; initial DMC is required.")
+        return None
+    if temperature is None:
+        temperature = NULL
+    if relative_humidity is None:
+        relative_humidity = NULL
+    if precipitation is None:
+        precipitation = NULL
     result = CFFDRS.instance().cffdrs._dmcCalc(dmc, temperature, relative_humidity, precipitation,
                                                latitude, month, latitude_adjust)
+
+    if len(result) == 0:
+        logger.error("Failed to calculate DMC")
+        return None
     if isinstance(result[0], float):
         return result[0]
-    raise CFFDRSException("Failed to calculate dmc")
+    logger.error("Failed to calculate DMC")
+    return None
 
 
 def drought_code(dc: float, temperature: float, relative_humidity: float, precipitation: float,
@@ -623,12 +635,23 @@ def drought_code(dc: float, temperature: float, relative_humidity: float, precip
     :return: None
     """
     if dc is None:
-        dc = NULL
+        logger.error("Failed to calculate DC; initial DC is required.")
+        return None
+    if temperature is None:
+        temperature = NULL
+    if relative_humidity is None:
+        relative_humidity = NULL
+    if precipitation is None:
+        precipitation = NULL
     result = CFFDRS.instance().cffdrs._dcCalc(dc, temperature, relative_humidity, precipitation,
                                               latitude, month, latitude_adjust)
+    if len(result) == 0:
+        logger.error("Failed to calculate DC")
+        return None
     if isinstance(result[0], float):
         return result[0]
-    raise CFFDRSException("Failed to calculate dmc")
+    logger.error("Failed to calculate DC")
+    return None
 
 
 def initial_spread_index(ffmc: float, wind_speed: float, fbp_mod: bool = False):

--- a/api/app/fire_behaviour/cffdrs.py
+++ b/api/app/fire_behaviour/cffdrs.py
@@ -544,7 +544,8 @@ def fine_fuel_moisture_code(ffmc: float, temperature: float, relative_humidity: 
     """
 
     if ffmc is None:
-        ffmc = NULL
+        logger.error("Failed to calculate FFMC; initial FFMC is required.")
+        return None
     if temperature is None:
         temperature = NULL
     if relative_humidity is None:
@@ -552,6 +553,7 @@ def fine_fuel_moisture_code(ffmc: float, temperature: float, relative_humidity: 
     if precipitation is None:
         precipitation = NULL
     if wind_speed is None:
+        # _ffmcCalc with throw if passed a NULL windspeed, so log a message and return None.
         logger.error("Failed to calculate ffmc")
         return None
     result = CFFDRS.instance().cffdrs._ffmcCalc(ffmc_yda=ffmc, temp=temperature, rh=relative_humidity,

--- a/api/app/tests/fire_behavior/test_cffdrs.py
+++ b/api/app/tests/fire_behavior/test_cffdrs.py
@@ -72,3 +72,23 @@ def test_ros_no_params():
         cffdrs.rate_of_spread(FuelTypeEnum.C7, None, None, None, None, pc=100, pdf=None,
                               cc=None, cbh=10)
 
+@pytest.mark.parametrize(
+    "ffmc,temperature,precipitation,relative_humidity,wind_speed",
+    [
+        (None, 10, 9, 8, 7),
+        (11, None, 9, 8, 7),
+        (11, 10, None, 8, 7),
+        (11, 10, 9, None, 7),
+        (11, 10, 9, 8, None),
+        (None, None, None, 8, 7),
+        (None, None, None, None, None),
+    ],
+)
+def test_failing_ffmc(ffmc, temperature, precipitation, relative_humidity, wind_speed):
+    """ Test that we can handle None values when attempting to calculate ffmc """
+    res = cffdrs.fine_fuel_moisture_code(ffmc=ffmc, 
+                                        temperature=temperature,
+                                        precipitation=precipitation,
+                                        relative_humidity=relative_humidity,
+                                        wind_speed=wind_speed)
+    assert res is None

--- a/api/app/tests/fire_behavior/test_cffdrs.py
+++ b/api/app/tests/fire_behavior/test_cffdrs.py
@@ -6,7 +6,7 @@ import pytest
 import math
 from app.schemas.fba_calc import FuelTypeEnum
 from app.fire_behaviour import cffdrs
-from app.fire_behaviour.cffdrs import (pandas_to_r_converter, hourly_fine_fuel_moisture_code, CFFDRSException)
+from app.fire_behaviour.cffdrs import pandas_to_r_converter, hourly_fine_fuel_moisture_code, CFFDRSException
 
 
 start_date = datetime(2023, 8, 17)
@@ -33,44 +33,49 @@ def test_pandas_to_r_converter():
 def test_hourly_ffmc_calculates_values():
     ffmc_old = 80.0
     df = hourly_fine_fuel_moisture_code(df_hourly, ffmc_old)
-    
+
     assert not df['hffmc'].isnull().any()
 
 
 def test_hourly_ffmc_no_temperature():
     ffmc_old = 80.0
-    df_hourly = pd.DataFrame({'datetime': [hourly_datetimes[0], hourly_datetimes[1]], 'celsius': [12, 1], 'precipitation': [0, 1], 'ws': [14, 12], 'rh':[50, 50]})
+    df_hourly = pd.DataFrame(
+        {
+            'datetime': [hourly_datetimes[0], hourly_datetimes[1]],
+            'celsius': [12, 1],
+            'precipitation': [0, 1],
+            'ws': [14, 12],
+            'rh': [50, 50],
+        }
+    )
 
     with pytest.raises(CFFDRSException):
         hourly_fine_fuel_moisture_code(df_hourly, ffmc_old)
-    
+
 
 def test_ros():
-    """ ROS runs """
-    ros =cffdrs.rate_of_spread(FuelTypeEnum.C7, 1, 1, 1, 1, pc=100, pdf=None,
-                                 cc=None, cbh=10)
+    """ROS runs"""
+    ros = cffdrs.rate_of_spread(FuelTypeEnum.C7, 1, 1, 1, 1, pc=100, pdf=None, cc=None, cbh=10)
     assert math.isclose(ros, 1.2966988409822604e-05)
 
 
 def test_ros_no_isi():
-    """ ROS fails """
+    """ROS fails"""
     with pytest.raises(cffdrs.CFFDRSException):
-        cffdrs.rate_of_spread(FuelTypeEnum.C7, None, 1, 1, 1, pc=100, pdf=None,
-                              cc=None, cbh=10)
+        cffdrs.rate_of_spread(FuelTypeEnum.C7, None, 1, 1, 1, pc=100, pdf=None, cc=None, cbh=10)
 
 
 def test_ros_no_bui():
-    """ ROS fails """
+    """ROS fails"""
     with pytest.raises(cffdrs.CFFDRSException):
-        cffdrs.rate_of_spread(FuelTypeEnum.C7, 1, None, 1, 1, pc=100, pdf=None,
-                              cc=None, cbh=10)
+        cffdrs.rate_of_spread(FuelTypeEnum.C7, 1, None, 1, 1, pc=100, pdf=None, cc=None, cbh=10)
 
 
 def test_ros_no_params():
-    """ ROS fails """
+    """ROS fails"""
     with pytest.raises(cffdrs.CFFDRSException):
-        cffdrs.rate_of_spread(FuelTypeEnum.C7, None, None, None, None, pc=100, pdf=None,
-                              cc=None, cbh=10)
+        cffdrs.rate_of_spread(FuelTypeEnum.C7, None, None, None, None, pc=100, pdf=None, cc=None, cbh=10)
+
 
 @pytest.mark.parametrize(
     "ffmc,temperature,precipitation,relative_humidity,wind_speed",
@@ -85,10 +90,31 @@ def test_ros_no_params():
     ],
 )
 def test_failing_ffmc(ffmc, temperature, precipitation, relative_humidity, wind_speed):
-    """ Test that we can handle None values when attempting to calculate ffmc """
-    res = cffdrs.fine_fuel_moisture_code(ffmc=ffmc, 
-                                        temperature=temperature,
-                                        precipitation=precipitation,
-                                        relative_humidity=relative_humidity,
-                                        wind_speed=wind_speed)
+    """Test that we can handle None values when attempting to calculate ffmc"""
+    res = cffdrs.fine_fuel_moisture_code(
+        ffmc=ffmc,
+        temperature=temperature,
+        precipitation=precipitation,
+        relative_humidity=relative_humidity,
+        wind_speed=wind_speed,
+    )
+    assert res is None
+
+
+@pytest.mark.parametrize(
+    'dmc,temperature,relative_humidity,precipitation',
+    [(None, 10, 90, 1), (100, None, 90, 1), (100, 10, None, 1), (100, 10, 90, None)],
+)
+def test_failing_dmc(dmc, temperature, relative_humidity, precipitation):
+    """Test that we can handle None values when attempting to calculate dmc"""
+    res = cffdrs.duff_moisture_code(dmc, temperature, relative_humidity, precipitation)
+    assert res is None
+
+
+@pytest.mark.parametrize(
+    'dc,temperature,relative_humidity,precipitation', [(None, 10, 90, 1), (100, None, 90, 1), (100, 10, 90, None)]
+)
+def test_failing_dc(dc, temperature, relative_humidity, precipitation):
+    """Test that we can handle None values when attempting to calculate dc"""
+    res = cffdrs.drought_code(dc, temperature, relative_humidity, precipitation)
     assert res is None


### PR DESCRIPTION
We weren't handling None to NULL conversions in our calls to CFFDRS' R function, `fine_fuel_moisture_code`, `drought_code` and `drought_moisture_code`.
This PR explicitly converts parameters to NULL if they are None similar to other functions, as well as checks for different types of failed result output from the R library.

Note: the windspeed is mandatory to fail fast on because the R library throws an exception if handed a NULL.
# Test Links:
[Landing Page](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3629-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
