### PR TITLE
Clear zone unit status when no data available

### DIFF
--- a/web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
+++ b/web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
@@ -140,9 +140,9 @@ const FireBehaviourAdvisoryPage: React.FunctionComponent = () => {
 
   useEffect(() => {
     const doiISODate = dateOfInterest.toISODate()
-    if (!isNull(mostRecentRunDate) && !isNull(doiISODate) && !isUndefined(mostRecentRunDate)) {
-      dispatch(fetchFireShapeAreas(runType, mostRecentRunDate.toString(), doiISODate))
-      dispatch(fetchProvincialSummary(runType, mostRecentRunDate.toString(), doiISODate))
+    if (!isNull(doiISODate)) {
+      dispatch(fetchFireShapeAreas(runType, mostRecentRunDate, doiISODate))
+      dispatch(fetchProvincialSummary(runType, mostRecentRunDate, doiISODate))
     }
   }, [mostRecentRunDate]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/web/src/features/fba/slices/fireZoneAreasSlice.ts
+++ b/web/src/features/fba/slices/fireZoneAreasSlice.ts
@@ -4,6 +4,7 @@ import { AppThunk } from 'app/store'
 import { logError } from 'utils/error'
 import { FireShapeArea, FireShapeAreaListResponse, getFireShapeAreas } from 'api/fbaAPI'
 import { RunType } from 'features/fba/pages/FireBehaviourAdvisoryPage'
+import { isNull, isUndefined } from 'lodash'
 
 interface State {
   loading: boolean
@@ -43,9 +44,9 @@ export const { getFireShapeAreasStart, getFireShapeAreasFailed, getFireShapeArea
 export default fireShapeAreasSlice.reducer
 
 export const fetchFireShapeAreas =
-  (runType: RunType, run_datetime: string, for_date: string): AppThunk =>
+  (runType: RunType, run_datetime: string | null, for_date: string): AppThunk =>
   async dispatch => {
-    if (run_datetime != undefined && run_datetime !== ``) {
+    if (!isUndefined(run_datetime) && !isNull(run_datetime)) {
       try {
         dispatch(getFireShapeAreasStart())
         const fireShapeAreas = await getFireShapeAreas(runType, run_datetime, for_date)
@@ -56,7 +57,7 @@ export const fetchFireShapeAreas =
       }
     } else {
       try {
-        dispatch(getFireShapeAreasFailed('run_datetime cannot be undefined!'))
+        dispatch(getFireShapeAreasSuccess({ shapes: [] }))
       } catch (err) {
         dispatch(getFireShapeAreasFailed((err as Error).toString()))
         logError(err)

--- a/web/src/features/fba/slices/provincialSummarySlice.ts
+++ b/web/src/features/fba/slices/provincialSummarySlice.ts
@@ -1,7 +1,7 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { AppThunk } from 'app/store'
 import { logError } from 'utils/error'
-import { groupBy } from 'lodash'
+import { groupBy, isNull, isUndefined } from 'lodash'
 import { FireShapeAreaDetail, getProvincialSummary, ProvincialSummaryResponse } from 'api/fbaAPI'
 import { RunType } from 'features/fba/pages/FireBehaviourAdvisoryPage'
 import { RootState } from 'app/rootReducer'
@@ -45,9 +45,9 @@ export const { getProvincialSummaryStart, getProvincialSummaryFailed, getProvinc
 export default provincialSummarySlice.reducer
 
 export const fetchProvincialSummary =
-  (runType: RunType, run_datetime: string, for_date: string): AppThunk =>
+  (runType: RunType, run_datetime: string | null, for_date: string): AppThunk =>
   async dispatch => {
-    if (run_datetime != undefined && run_datetime !== ``) {
+    if (!isUndefined(run_datetime) && !isNull(run_datetime)) {
       try {
         dispatch(getProvincialSummaryStart())
         const fireShapeAreas = await getProvincialSummary(runType, run_datetime, for_date)
@@ -58,7 +58,7 @@ export const fetchProvincialSummary =
       }
     } else {
       try {
-        dispatch(getProvincialSummaryFailed('run_datetime cannot be undefined!'))
+        dispatch(getProvincialSummarySuccess({ provincial_summary: [] }))
       } catch (err) {
         dispatch(getProvincialSummaryFailed((err as Error).toString()))
         logError(err)


### PR DESCRIPTION
A null check was blocking us from updating fireShapeArea and provincialSummary when `mostRecentRunDate` was null.
# Test Links:
[Landing Page](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[MoreCast](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[C-Haines](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3649-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
