### PR TITLE
Round windspeed to integer

### DIFF
--- a/web/src/api/moreCast2API.ts
+++ b/web/src/api/moreCast2API.ts
@@ -190,7 +190,7 @@ export const marshalMoreCast2ForecastRecords = (forecasts: MoreCast2ForecastRow[
       precip: forecast.precip.value,
       rh: forecast.rh.value,
       temp: forecast.temp.value,
-      wind_direction: forecast.windDirection.value,
+      wind_direction: Math.round(forecast.windDirection.value),
       wind_speed: forecast.windSpeed.value,
       grass_curing: forecast.grassCuring.value
     }


### PR DESCRIPTION
Wind direction is the only weather parameter our API model specifies as an integer. 
On the front-end it is still possible to get a float value for wind direction when populating it from a numeric weather model using the drop-down menu.
This PR rounds the wind direction before submitting forecasts to our API to guard against a float slipping through which results in a 422 error and a crash of Morecast.

# Test Links:
[Landing Page](https://wps-pr-3669-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3669-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3669-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3669-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3669-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3669-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3669-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3669-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
