### PR TITLE
Simulate indices on double-click

### DIFF
--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -432,15 +432,14 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
       // There is no actual value, so we are in a forecast row and can proceed with updating the
       // forecast field value with the value of the cell that was double-clicked
       const forecastField = `${prefix}Forecast` as keyof MoreCast2Row
-      const newRows = cloneDeep(allRows)
-      const editedRowIndex = newRows.findIndex(row => row.id === params.row.id)
+      const newVisibleRows = cloneDeep(visibleRows)
+      const editedRowIndex = newVisibleRows.findIndex(row => row.id === params.row.id)
       if (editedRowIndex > -1) {
-        const editedRow = newRows[editedRowIndex]
+        const editedRow = newVisibleRows[editedRowIndex]
         const editedPredictionItem = editedRow[forecastField] as PredictionItem
         editedPredictionItem.choice = headerName
-        editedPredictionItem.value = params.value as number
-        storedDraftForecast.updateStoredDraftForecasts([editedRow], getDateTimeNowPST())
-        setAllRows(newRows)
+        editedPredictionItem.value = Number(params.value)
+        updateColumnHelper(newVisibleRows)
       }
     }
   }


### PR DESCRIPTION
Make sure we simulate indices when populating a forecast by double-clicking on a weather model prediction cell.
# Test Links:
[Landing Page](https://wps-pr-3677-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3677-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3677-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3677-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3677-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3677-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3677-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3677-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
