### PR TITLE
Only refresh materialized view when necessary

### DIFF
--- a/api/app/jobs/common_model_fetchers.py
+++ b/api/app/jobs/common_model_fetchers.py
@@ -189,8 +189,7 @@ class ModelValueProcessor:
     def __init__(self, session, station_source: StationSourceEnum = StationSourceEnum.UNSPECIFIED):
         """ Prepare variables we're going to use throughout """
         self.session = session
-        all_stations = get_stations_synchronously(station_source)
-        self.stations = list(station for station in all_stations if station.code == 344)
+        self.stations = get_stations_synchronously(station_source)
         self.station_count = len(self.stations)
 
     def _process_model_run(self, model_run: PredictionModelRunTimestamp, model_type: ModelEnum):

--- a/api/app/jobs/common_model_fetchers.py
+++ b/api/app/jobs/common_model_fetchers.py
@@ -454,14 +454,14 @@ class ModelValueProcessor:
         # Get model runs that are complete (fully downloaded), but not yet interpolated.
         query = get_prediction_model_run_timestamp_records(
             self.session, complete=True, interpolated=False, model_type=model_type)
-        refresh_mat_view = False
+        model_processed = False
         for model_run, model in query:
-            refresh_mat_view = True
+            model_processed = True
             logger.info('model %s', model)
             logger.info('model_run %s', model_run)
             # Process the model run.
             self._process_model_run(model_run, model_type)
             # Mark the model run as interpolated.
             self._mark_model_run_interpolated(model_run)
-        if refresh_mat_view:
+        if model_processed:
             refresh_morecast2_materialized_view(self.session)

--- a/api/app/jobs/common_model_fetchers.py
+++ b/api/app/jobs/common_model_fetchers.py
@@ -14,6 +14,7 @@ from app.db.crud.weather_models import (
     get_weather_station_model_prediction,
     delete_weather_station_model_predictions,
     delete_model_run_predictions,
+    refresh_morecast2_materialized_view,
 )
 from app.weather_models.machine_learning import StationMachineLearning
 from app.weather_models import ModelEnum, construct_interpolated_noon_prediction, interpolate_between_two_points
@@ -188,7 +189,8 @@ class ModelValueProcessor:
     def __init__(self, session, station_source: StationSourceEnum = StationSourceEnum.UNSPECIFIED):
         """ Prepare variables we're going to use throughout """
         self.session = session
-        self.stations = get_stations_synchronously(station_source)
+        all_stations = get_stations_synchronously(station_source)
+        self.stations = list(station for station in all_stations if station.code == 344)
         self.station_count = len(self.stations)
 
     def _process_model_run(self, model_run: PredictionModelRunTimestamp, model_type: ModelEnum):
@@ -453,10 +455,14 @@ class ModelValueProcessor:
         # Get model runs that are complete (fully downloaded), but not yet interpolated.
         query = get_prediction_model_run_timestamp_records(
             self.session, complete=True, interpolated=False, model_type=model_type)
+        refresh_mat_view = False
         for model_run, model in query:
+            refresh_mat_view = True
             logger.info('model %s', model)
             logger.info('model_run %s', model_run)
             # Process the model run.
             self._process_model_run(model_run, model_type)
             # Mark the model run as interpolated.
             self._mark_model_run_interpolated(model_run)
+        if refresh_mat_view:
+            refresh_morecast2_materialized_view(self.session)

--- a/api/app/jobs/env_canada.py
+++ b/api/app/jobs/env_canada.py
@@ -14,7 +14,6 @@ from app.db.crud.weather_models import (
     get_prediction_model,
     get_prediction_run,
     update_prediction_run,
-    refresh_morecast2_materialized_view,
 )
 from app.jobs.common_model_fetchers import (CompletedWithSomeExceptions, ModelValueProcessor, UnhandledPredictionModelType,
                                             apply_data_retention_policy,
@@ -355,7 +354,6 @@ def process_models(station_source: StationSourceEnum = StationSourceEnum.UNSPECI
         # interpolate and machine learn everything that needs interpolating.
         model_value_processor = ModelValueProcessor(session, station_source)
         model_value_processor.process(model_type)
-        refresh_morecast2_materialized_view(session)
 
     # calculate the execution time.
     execution_time = datetime.datetime.now() - start_time

--- a/api/app/jobs/noaa.py
+++ b/api/app/jobs/noaa.py
@@ -14,7 +14,6 @@ from app.db.crud.weather_models import (
     get_prediction_model,
     get_prediction_run,
     update_prediction_run,
-    refresh_morecast2_materialized_view,
 )
 from app.jobs.common_model_fetchers import (CompletedWithSomeExceptions, ModelValueProcessor,
                                             apply_data_retention_policy, check_if_model_run_complete,
@@ -363,7 +362,6 @@ def process_models(station_source: StationSourceEnum = StationSourceEnum.UNSPECI
         # interpolate and machine learn everything that needs interpolating.
         model_value_processor = ModelValueProcessor(session, station_source)
         model_value_processor.process(model_type)
-        refresh_morecast2_materialized_view(session)
 
     # calculate the execution time.
     execution_time = datetime.datetime.now() - start_time


### PR DESCRIPTION
Don't refresh everytime a job runs, only when a model was actually processed.
# Test Links:
[Landing Page](https://wps-pr-3687-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3687-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3687-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3687-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3687-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3687-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3687-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3687-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
