### PR TITLE
Limit frontend perf tracing, set user in backend

### DIFF
--- a/api/app/auth.py
+++ b/api/app/auth.py
@@ -4,6 +4,7 @@ from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordBearer
 import jwt
 from jwt import InvalidTokenError
+from sentry_sdk import set_user
 from app import config
 from app.db.crud.api_access_audits import create_api_access_audit_log
 
@@ -61,6 +62,7 @@ async def authentication_required(token=Depends(authenticate)):
             status_code=status.HTTP_401_UNAUTHORIZED,
             headers={'WWW-Authenticate': 'Bearer'}
         )
+    set_user({"email": token.get('email', None)})
     return token
 
 

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -15,7 +15,7 @@ const render = () => {
     environment: SENTRY_ENV,
     integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
     // Performance Monitoring
-    tracesSampleRate: 1.0, //  Capture 100% of the transactions
+    tracesSampleRate: 0.5, //  Capture 100% of the transactions
     // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
     tracePropagationTargets: [API_BASE_URL],
     // Session Replay


### PR DESCRIPTION
Limit our perf credit spending on frontend performance tracking for sentry, set sentry user email in backend