### PR TITLE
Trigger SFMS deployment on image update

### DIFF
--- a/openshift/templates/sfms.yaml
+++ b/openshift/templates/sfms.yaml
@@ -69,6 +69,8 @@ objects:
       labels:
         app: ${APP_NAME}-${SUFFIX}
       name: ${APP_NAME}-${SUFFIX}
+      annotations:
+        image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"wps-api-prod:prod"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].sfms"}]'
     spec:
       replicas: ${{REPLICAS}}
       selector:

--- a/openshift/templates/sfms.yaml
+++ b/openshift/templates/sfms.yaml
@@ -70,7 +70,7 @@ objects:
         app: ${APP_NAME}-${SUFFIX}
       name: ${APP_NAME}-${SUFFIX}
       annotations:
-        image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"wps-api-prod:prod"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].sfms"}]'
+        image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"${IMAGE_REGISTRY}/${PROJ_TOOLS}/wps-api-${SUFFIX}:${SUFFIX}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].sfms"}]'
     spec:
       replicas: ${{REPLICAS}}
       selector:

--- a/openshift/templates/sfms.yaml
+++ b/openshift/templates/sfms.yaml
@@ -70,7 +70,7 @@ objects:
         app: ${APP_NAME}-${SUFFIX}
       name: ${APP_NAME}-${SUFFIX}
       annotations:
-        image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"${IMAGE_REGISTRY}/${PROJ_TOOLS}/wps-api-${SUFFIX}:${SUFFIX}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].sfms"}]'
+        image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"${PROJ_TOOLS}/wps-api-${SUFFIX}:${SUFFIX}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].sfms"}]'
     spec:
       replicas: ${{REPLICAS}}
       selector:


### PR DESCRIPTION
Sets a trigger to update the sfms deployment when the image content changes, based on: https://docs.openshift.com/container-platform/4.12/openshift_images/triggering-updates-on-imagestream-changes.html#images-triggering-updates-imagestream-changes-kubernetes-cli_triggering-updates-on-imagestream-changes
# Test Links:
[Landing Page](https://wps-pr-3693-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3693-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3693-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3693-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3693-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3693-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3693-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3693-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
