### PR TITLE
Add units to forecast data grid group headers

### DIFF
--- a/web/src/features/moreCast2/components/DataGridColumns.tsx
+++ b/web/src/features/moreCast2/components/DataGridColumns.tsx
@@ -20,6 +20,15 @@ export interface ColumnVis {
   visible: boolean
 }
 
+export enum GroupHeaderName {
+  GC = 'GC (%)',
+  PRECIP = 'Precip (mm)',
+  RH = 'RH (%)',
+  TEMP = 'Temp (°C)',
+  WindDir = 'Wind Direction (°)',
+  WindSpeed = 'Wind Speed (km/h)'
+}
+
 export class DataGridColumns {
   public static initGridColumnVisibilityModel(columnClickHandlerProps: ColumnClickHandlerProps) {
     const model: GridColumnVisibilityModel = {}
@@ -125,34 +134,46 @@ export const getTabColumnGroupModel = (
       groupId: 'Temp',
       children: columnGroupingModelChildGenerator('temp'),
       headerClassName: 'temp',
-      renderHeaderGroup: () => renderGroupHeader('Temp', 'temp', showHideColumnsModel['temp'], handleShowHideChange)
+      renderHeaderGroup: () =>
+        renderGroupHeader(GroupHeaderName.TEMP, 'temp', showHideColumnsModel['temp'], handleShowHideChange)
     },
     {
       groupId: 'RH',
       children: columnGroupingModelChildGenerator('rh'),
       headerClassName: 'rh',
-      renderHeaderGroup: () => renderGroupHeader('RH', 'rh', showHideColumnsModel['rh'], handleShowHideChange)
+      renderHeaderGroup: () =>
+        renderGroupHeader(GroupHeaderName.RH, 'rh', showHideColumnsModel['rh'], handleShowHideChange)
     },
     {
       groupId: 'Precip',
       children: columnGroupingModelChildGenerator('precip'),
       headerClassName: 'precip',
       renderHeaderGroup: () =>
-        renderGroupHeader('Precip', 'precip', showHideColumnsModel['precip'], handleShowHideChange)
+        renderGroupHeader(GroupHeaderName.PRECIP, 'precip', showHideColumnsModel['precip'], handleShowHideChange)
     },
     {
       groupId: 'Wind Dir',
       children: columnGroupingModelChildGenerator('windDirection'),
       headerClassName: 'windDirection',
       renderHeaderGroup: () =>
-        renderGroupHeader('Wind Dir', 'windDirection', showHideColumnsModel['windDirection'], handleShowHideChange)
+        renderGroupHeader(
+          GroupHeaderName.WindDir,
+          'windDirection',
+          showHideColumnsModel['windDirection'],
+          handleShowHideChange
+        )
     },
     {
       groupId: 'Wind Speed',
       children: columnGroupingModelChildGenerator('windSpeed'),
       headerClassName: 'windSpeed',
       renderHeaderGroup: () =>
-        renderGroupHeader('Wind Speed', 'windSpeed', showHideColumnsModel['windSpeed'], handleShowHideChange)
+        renderGroupHeader(
+          GroupHeaderName.WindSpeed,
+          'windSpeed',
+          showHideColumnsModel['windSpeed'],
+          handleShowHideChange
+        )
     },
     {
       groupId: 'Grass Curing',
@@ -168,7 +189,7 @@ export const getTabColumnGroupModel = (
       ],
       headerClassName: 'gc',
       renderHeaderGroup: () => {
-        return <Typography style={{ fontWeight: 'bold' }}>Grass Curing</Typography>
+        return <Typography style={{ fontWeight: 'bold' }}>{GroupHeaderName.GC}</Typography>
       }
     }
   ]


### PR DESCRIPTION
Only updating the group headers in the `ForecastDataGrid`. I don't think it is necessary in the `ForecastSummaryDataGrid` (and we run out of room in the headers.
# Test Links:
[Landing Page](https://wps-pr-3715-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3715-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3715-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3715-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3715-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3715-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3715-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3715-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
