### PR TITLE
Limit dev deployment SFMS API memory to 1GB

### DIFF
--- a/openshift/templates/sfms.yaml
+++ b/openshift/templates/sfms.yaml
@@ -34,10 +34,10 @@ parameters:
     value: 500m
   - name: MEMORY_REQUEST
     description: Requested memory
-    value: 3Gi
+    value: 500Mi
   - name: MEMORY_LIMIT
     description: Memory upper limit
-    value: 6Gi
+    value: 1Gi
   - name: REPLICAS
     description: Number of replicas (pods)
     value: "2"


### PR DESCRIPTION
We're only using ~400Mi according to `kubectl top pods`
# Test Links:
[Landing Page](https://wps-pr-3737-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3737-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3737-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3737-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3737-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3737-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3737-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3737-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
