### PR TITLE
Dynamic highlighting of selected fire zone unit

### DIFF
--- a/web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/src/features/fba/components/map/FBAMap.tsx
@@ -22,6 +22,7 @@ import {
   fireCentreStyler,
   fireCentreLabelStyler,
   fireShapeStyler,
+  fireShapeHighlightStyler,
   fireShapeLabelStyler,
   stationStyler,
   hfiStyler,
@@ -95,9 +96,7 @@ const FBAMap = (props: FBAMapProps) => {
         .find(l => l.getProperties()?.name === layerName)
 
       if (layerName === 'fireShapeVector') {
-        fireShapeVTL.setStyle(
-          fireShapeStyler(cloneDeep(props.fireShapeAreas), props.advisoryThreshold, props.selectedFireShape, isVisible)
-        )
+        fireShapeVTL.setStyle(fireShapeStyler(cloneDeep(props.fireShapeAreas), props.advisoryThreshold, isVisible))
       } else if (layer) {
         layer.setVisible(isVisible)
       }
@@ -108,19 +107,26 @@ const FBAMap = (props: FBAMapProps) => {
     new VectorTileLayer({
       source: fireCentreVectorSource,
       style: fireCentreStyler,
-      zIndex: 50
+      zIndex: 49
     })
   )
   const [fireShapeVTL] = useState(
     new VectorTileLayer({
       source: fireShapeVectorSource,
-      style: fireShapeStyler(
+      style: fireShapeStyler(cloneDeep(props.fireShapeAreas), props.advisoryThreshold, showShapeStatus),
+      zIndex: 50,
+      properties: { name: 'fireShapeVector' }
+    })
+  )
+  const [fireShapeHighlightVTL] = useState(
+    new VectorTileLayer({
+      source: fireShapeVectorSource,
+      style: fireShapeHighlightStyler(
         cloneDeep(props.fireShapeAreas),
         props.advisoryThreshold,
-        props.selectedFireShape,
-        showShapeStatus
+        props.selectedFireShape
       ),
-      zIndex: 49,
+      zIndex: 51,
       properties: { name: 'fireShapeVector' }
     })
   )
@@ -199,16 +205,13 @@ const FBAMap = (props: FBAMapProps) => {
   useEffect(() => {
     if (!map) return
 
-    fireShapeVTL.setStyle(
-      fireShapeStyler(
-        cloneDeep(props.fireShapeAreas),
-        props.advisoryThreshold,
-        props.selectedFireShape,
-        showShapeStatus
-      )
-    )
+    fireShapeVTL.setStyle(fireShapeStyler(cloneDeep(props.fireShapeAreas), props.advisoryThreshold, showShapeStatus))
     fireShapeLabelVTL.setStyle(fireShapeLabelStyler(props.selectedFireShape))
+    fireShapeHighlightVTL.setStyle(
+      fireShapeHighlightStyler(cloneDeep(props.fireShapeAreas), props.advisoryThreshold, props.selectedFireShape)
+    )
     fireShapeVTL.changed()
+    fireShapeHighlightVTL.changed()
     fireShapeLabelVTL.changed()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.selectedFireShape, props.fireShapeAreas, props.advisoryThreshold])
@@ -279,6 +282,7 @@ const FBAMap = (props: FBAMapProps) => {
         }),
         fireCentreVTL,
         fireShapeVTL,
+        fireShapeHighlightVTL,
         fireCentreLabelVTL,
         fireShapeLabelVTL
       ],


### PR DESCRIPTION
Adds a new vector tile layer, above the other polygon vector tile layers, that displays the border (aka stroke) of the selected fire zone unit.

I chose to add a new layer in order to enhance contrast. I initially tried changing the border/stroke of the `fireShapeVTL` layer from green to orange/red, but the border ends up being  a mixture of black and orange/red as the border of neighbouring features bleeds through and reduces contrast. By adding a new layer over top there is no 'bleed through'.

I've left a thick, black border when selected for fire zone units not under advisory/warning. Will check in with RP about an appropriate color.

EDIT: RP has approved the black border.

# Test Links:
[Landing Page](https://wps-pr-3772-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3772-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3772-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3772-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3772-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3772-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3772-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3772-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
