### PR TITLE
Label pruner job for deletion, bump dev crunchydb pvc size

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
-          EPHEMERAL_STORAGE=True BUCKET=gpdqha DATA_SIZE=1Gi WAL_SIZE=1Gi bash openshift/scripts/oc_provision_crunchy.sh ${SUFFIX} apply
+          EPHEMERAL_STORAGE=True BUCKET=gpdqha DATA_SIZE=5Gi WAL_SIZE=5Gi bash openshift/scripts/oc_provision_crunchy.sh ${SUFFIX} apply
 
   build-web-image:
     # Declared ahead of build-api-image ; it runs slightly slower than the api build, and putting
@@ -200,7 +200,7 @@ jobs:
         run: |
           oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_DEV_TOKEN }}"
           PROJ_DEV="e1e498-dev" bash openshift/scripts/oc_provision_grass_curing_cronjob.sh ${SUFFIX} apply
-      
+
       - name: RDPS SFMS cronjob
         shell: bash
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,7 @@
         "GDPS",
         "grib",
         "gribs",
+        "hourlies",
         "HRDPS",
         "ndarray",
         "numba",

--- a/openshift/scripts/oc_provision_hourly_prune_cronjob.sh
+++ b/openshift/scripts/oc_provision_hourly_prune_cronjob.sh
@@ -31,6 +31,7 @@ SCHEDULE="${SCHEDULE:-0 2 * * *}"
 # Process template
 OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/prune_hourlies_cronjob.yaml \
 -p SUFFIX=${SUFFIX} \
+-p APP_LABEL=${APP_NAME}-${SUFFIX} \
 -p SCHEDULE=\"${SCHEDULE}\" \
 ${PROJ_TOOLS:+ "-p PROJ_TOOLS=${PROJ_TOOLS}"}"
 

--- a/openshift/templates/prune_hourlies_cronjob.yaml
+++ b/openshift/templates/prune_hourlies_cronjob.yaml
@@ -19,6 +19,8 @@ parameters:
     description: "The TAG name for this environment, e.g., dev, test, prod"
     required: true
     value: "prod"
+  - name: APP_LABEL
+    required: true
 objects:
   - kind: CronJob
     apiVersion: batch/v1
@@ -35,7 +37,7 @@ objects:
         metadata:
           labels:
             cronjob: prune-hourlies-${NAME}-${SUFFIX}
-            app: prune-hourlies-${NAME}-${SUFFIX}
+            app: ${APP_LABEL}
         spec:
           template:
             spec:


### PR DESCRIPTION
Based on recent excessive logging problems email thread:
- Apply the label we use to filter resources in our cleanup script to the pruner job that was missing there
- Bump the dev deployment PVC size for crunchydb since it was filling up after a few days of job runs.