### PR TITLE
add metadata and template label to prune hourlies definition

### DIFF
--- a/openshift/templates/prune_hourlies_cronjob.yaml
+++ b/openshift/templates/prune_hourlies_cronjob.yaml
@@ -1,5 +1,13 @@
 kind: "Template"
 apiVersion: "template.openshift.io/v1"
+metadata:
+  name: prune-hourlies-cronjob-template
+  annotations:
+    description: "Scheduled task to prune SFMS hourly data from the object store."
+    tags: "cronjob,sfms"
+labels:
+  app.kubernetes.io/part-of: "${NAME}"
+  app: ${NAME}-${SUFFIX}
 parameters:
   - name: NAME
     description: Module name


### PR DESCRIPTION
We need the label to be a part of the template resources for the cleanup script to find it
