### PR TITLE
 Fix datetime comparison check to be tz aware

### DIFF
--- a/api/app/auto_spatial_advisory/process_hfi.py
+++ b/api/app/auto_spatial_advisory/process_hfi.py
@@ -22,6 +22,7 @@ from app.auto_spatial_advisory.hfi_filepath import get_pmtiles_filename, get_pmt
 from app.utils.polygonize import polygonize_in_memory
 from app.utils.pmtiles import tippecanoe_wrapper, write_geojson
 from app.utils.s3 import get_client
+import app.utils.time as time_utils
 
 
 logger = logging.getLogger(__name__)
@@ -104,7 +105,7 @@ async def process_hfi(run_type: RunType, run_date: date, run_datetime: datetime,
             classify_hfi(hfi_key, temp_filename)
             # If something has gone wrong with the collection of snow coverage data and it has not been collected
             # within the past 7 days, don't apply an old snow mask, work with the classified hfi data as is
-            if last_processed_snow is None or last_processed_snow[0].for_date + timedelta(days=7) < datetime.now():
+            if last_processed_snow is None or last_processed_snow[0].for_date + timedelta(days=7) < time_utils.get_utc_now():
                 logger.info("No recently processed snow data found. Proceeding with non-masked hfi data.")
                 working_hfi_path = temp_filename
             else:


### PR DESCRIPTION
Consumers were logging errors: `TypeError: can't compare offset-naive and offset-aware datetimes`. This PR uses `get_utc_now()` to make sure we're using `now` in utc, which is how the processed snow timestamps are stored.

# Test Links:
[Landing Page](https://wps-pr-3812-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3812-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3812-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3812-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3812-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3812-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3812-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3812-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
