### PR TITLE
Use shape id, not source identifier for storing TPI stats

### DIFF
--- a/api/app/auto_spatial_advisory/elevation.py
+++ b/api/app/auto_spatial_advisory/elevation.py
@@ -243,7 +243,6 @@ async def process_tpi_by_firezone(run_type: RunType, run_date: date, for_date: d
     gdal.SetConfigOption("AWS_VIRTUAL_HOSTING", "FALSE")
     bucket = config.get("OBJECT_STORE_BUCKET")
     dem_file = config.get("CLASSIFIED_TPI_DEM_NAME")
-
     key = f"/vsis3/{bucket}/dem/tpi/{dem_file}"
     tpi_source: gdal.Dataset = gdal.Open(key, gdal.GA_ReadOnly)
     pixel_size_metres = int(tpi_source.GetGeoTransform()[1])
@@ -278,7 +277,7 @@ async def process_tpi_by_firezone(run_type: RunType, run_date: date, for_date: d
 
             # Drop TPI class 4, this is the no data value from the TPI raster
             tpi_class_freq_dist.pop(4, None)
-            fire_zone_stats[row[1]] = tpi_class_freq_dist
+            fire_zone_stats[row[0]] = tpi_class_freq_dist
 
         hfi_masked_tpi = None
         return FireZoneTPIStats(fire_zone_stats=fire_zone_stats, pixel_size_metres=pixel_size_metres)


### PR DESCRIPTION
Using the wrong id -- we should store/lookup by shape id, not the source identifier.
# Test Links:
[Landing Page](https://wps-pr-3831-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3831-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3831-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3831-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3831-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3831-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3831-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3831-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
