### PR TITLE
Critical hours 

### DIFF
--- a/api/app/auto_spatial_advisory/critical_hours.py
+++ b/api/app/auto_spatial_advisory/critical_hours.py
@@ -1,0 +1,426 @@
+import asyncio
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+import math
+import numpy as np
+import os
+import sys
+from time import perf_counter
+import logging
+
+from aiohttp import ClientSession
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app import configure_logging
+from app.auto_spatial_advisory.run_type import RunType
+from app.db.crud.auto_spatial_advisory import (
+    get_all_sfms_fuel_type_records,
+    get_containing_zone,
+    get_fuel_type_stats_in_advisory_area,
+    get_most_recent_run_parameters,
+    get_run_parameters_id,
+    save_all_critical_hours,
+)
+from app.db.database import get_async_write_session_scope
+from app.db.models.auto_spatial_advisory import CriticalHours, HfiClassificationThresholdEnum, RunTypeEnum
+from app.fire_behaviour import cffdrs
+from app.fire_behaviour.fuel_types import FUEL_TYPE_DEFAULTS, FuelTypeEnum
+from app.fire_behaviour.prediction import build_hourly_rh_dict, calculate_cfb, get_critical_hours
+from app.hourlies import get_hourly_readings_in_time_interval
+from app.schemas.fba_calc import WindResult
+from app.stations import get_stations_asynchronously
+from app.utils.geospatial import PointTransformer
+from app.utils.time import get_hour_20_from_date, get_julian_date
+from app.wildfire_one import wfwx_api
+from app.wildfire_one.schema_parsers import WFWXWeatherStation
+
+logger = logging.getLogger(__name__)
+
+
+def determine_start_time(times: list[float]) -> float:
+    """
+    Returns a single start time based on a naive heuristic.
+
+    :param times: A list of potential critical hour start times.
+    :return: A single start time.
+    """
+    if len(times) < 3:
+        return min(times)
+    return math.floor(np.percentile(times, 25))
+
+
+def determine_end_time(times: list[float]) -> float:
+    """
+    Returns a single end time based on a naive heuristic.
+
+    :param times: A list of potential critical hour end times.
+    :return: A single end time.
+    """
+    if len(times) < 3:
+        return max(times)
+    return math.ceil(np.percentile(times, 75))
+
+
+def calculate_representative_hours(critical_hours):
+    """
+    Naively determines start and end times from a list of CriticalHours objects.
+
+    :param critical_hours: A list of CriticalHours objects.
+    :return: Representative start and end time.
+    """
+    start_times = []
+    end_times = []
+    for hours in critical_hours:
+        start_times.append(hours.start)
+        end_times.append(hours.end)
+    start_time = determine_start_time(start_times)
+    end_time = determine_end_time(end_times)
+    return (start_time, end_time)
+
+
+async def get_fuel_types_dict(db_session: AsyncSession):
+    """
+    Gets a dictionary of fuel types keyed by fuel type code.
+
+    :param db_session: An async database session.
+    :return: A dictionary of fuel types keyed by fuel type code.
+    """
+    sfms_fuel_types = await get_all_sfms_fuel_type_records(db_session)
+    fuel_types_dict = defaultdict()
+    for fuel_type in sfms_fuel_types:
+        fuel_types_dict[fuel_type[0].fuel_type_code] = fuel_type[0].id
+    return fuel_types_dict
+
+
+async def save_critical_hours(db_session: AsyncSession, zone_unit_id: int, critical_hours_by_fuel_type: dict, run_parameters_id: int):
+    """
+    Saves CriticalHours records to the API database.
+
+    :param db_session: An async database session.
+    :param zone_id: A zone unit id.
+    :param critical_hours_by_fuel_type: A dictionary of critical hours for the specified zone unit keyed by fuel type code.
+    :param run_parameters_id: The RunParameters id associated with these critical hours (ie an SFMS run).
+    """
+    sfms_fuel_types_dict = await get_fuel_types_dict(db_session)
+    critical_hours_to_save: list[CriticalHours] = []
+    for fuel_type, critical_hours in critical_hours_by_fuel_type.items():
+        start_time, end_time = calculate_representative_hours(critical_hours)
+        critical_hours_record = CriticalHours(
+            advisory_shape_id=zone_unit_id,
+            threshold=HfiClassificationThresholdEnum.ADVISORY.value,
+            run_parameters=run_parameters_id,
+            fuel_type=sfms_fuel_types_dict[fuel_type],
+            start_hour=start_time,
+            end_hour=end_time,
+        )
+        critical_hours_to_save.append(critical_hours_record)
+    await save_all_critical_hours(db_session, critical_hours_to_save)
+
+
+def calculate_wind_speed_result(yesterday: dict, raw_daily: dict) -> WindResult:
+    """
+    Calculates new FWIs based on observed and forecast daily data from WF1.
+
+    :param yesterday: Weather parameter observations and FWIs from yesterday.
+    :param raw_daily: Forecasted weather parameters from WF1.
+    :return: A WindResult object with calculated FWIs.
+    """
+    # extract variables from wf1 that we need to calculate the fire behaviour advisory.
+    bui = cffdrs.bui_calc(raw_daily.get("duffMoistureCode", None), raw_daily.get("droughtCode", None))
+    temperature = raw_daily.get("temperature", None)
+    relative_humidity = raw_daily.get("relativeHumidity", None)
+    precipitation = raw_daily.get("precipitation", None)
+
+    wind_speed = raw_daily.get("windSpeed", None)
+    status = raw_daily.get("recordType").get("id")
+
+    ffmc = cffdrs.fine_fuel_moisture_code(yesterday.get("fineFuelMoistureCode", None), temperature, relative_humidity, precipitation, wind_speed)
+    isi = cffdrs.initial_spread_index(ffmc, wind_speed)
+    fwi = cffdrs.fire_weather_index(isi, bui)
+    return WindResult(ffmc=ffmc, isi=isi, bui=bui, wind_speed=wind_speed, fwi=fwi, status=status)
+
+
+async def calculate_critical_hours_for_station_by_fuel_type(
+    wfwx_station: WFWXWeatherStation,
+    dailies_by_station_id: dict,
+    yesterday_dailies_by_station_id: dict,
+    hourly_observations_by_station_id: dict,
+    fuel_type: FuelTypeEnum,
+    for_date: datetime,
+):
+    """
+    Calculate the critical hours for a fuel type - station pair.
+
+    :param wfwx_station: The WFWXWeatherStation.
+    :param dailies_by_station_id: Today's weather observations (or forecasts) keyed by station guid.
+    :param yesterday_dailies_by_station_id: Yesterday's weather observations and FWIs keyed by station guid.
+    :param hourly_observations_by_station_id: Hourly observations from the past 4 days keyed by station guid.
+    :param fuel_type: The fuel type of interest.
+    :param for_date: The date critical hours are being calculated for.
+    :return: The critical hours for the station and fuel type.
+    """
+    raw_daily = dailies_by_station_id[wfwx_station.wfwx_id]
+    raw_observations = hourly_observations_by_station_id[wfwx_station.code]
+    yesterday = yesterday_dailies_by_station_id[wfwx_station.wfwx_id]
+    last_observed_morning_rh_values = build_hourly_rh_dict(raw_observations.values)
+
+    wind_result = calculate_wind_speed_result(yesterday, raw_daily)
+    bui = wind_result.bui
+    ffmc = wind_result.ffmc
+    isi = wind_result.isi
+    fuel_type_info = FUEL_TYPE_DEFAULTS[fuel_type]
+    percentage_conifer = fuel_type_info.get("PC", None)
+    percentage_dead_balsam_fir = fuel_type_info.get("PDF", None)
+    crown_base_height = fuel_type_info.get("CBH", None)
+    cfl = fuel_type_info.get("CFL", None)
+    grass_cure = yesterday.get("grasslandCuring", None)
+    wind_speed = wind_result.wind_speed
+    yesterday_ffmc = yesterday.get("fineFuelMoistureCode", None)
+    julian_date = get_julian_date(for_date)
+    fmc = cffdrs.foliar_moisture_content(int(wfwx_station.lat), int(wfwx_station.long), wfwx_station.elevation, julian_date)
+    sfc = cffdrs.surface_fuel_consumption(fuel_type, bui, ffmc, percentage_conifer)
+    ros = cffdrs.rate_of_spread(
+        fuel_type,
+        isi=isi,
+        bui=bui,
+        fmc=fmc,
+        sfc=sfc,
+        pc=percentage_conifer,
+        cc=grass_cure,
+        pdf=percentage_dead_balsam_fir,
+        cbh=crown_base_height,
+    )
+    cfb = calculate_cfb(fuel_type, fmc, sfc, ros, crown_base_height)
+
+    critical_hours = get_critical_hours(
+        4000,
+        fuel_type,
+        percentage_conifer,
+        percentage_dead_balsam_fir,
+        bui,
+        grass_cure,
+        crown_base_height,
+        ffmc,
+        fmc,
+        cfb,
+        cfl,
+        wind_speed,
+        yesterday_ffmc,
+        last_observed_morning_rh_values,
+    )
+
+    return critical_hours
+
+
+async def calculate_critical_hours_by_fuel_type(
+    wfwx_stations, dailies_by_station_id, yesterday_dailies_by_station_id, hourly_observations_by_station_code, fuel_types_by_area, for_date
+):
+    """
+    Calculates the critical hours for each fuel type for all stations in a fire zone unit.
+
+    :param wfwx_stations: A list of WFWXWeatherStations in a single fire zone unit.
+    :param dailies_by_station_id: Today's weather observations (or forecasts) keyed by station guid.
+    :param yesterday_dailies_by_station_id: Yesterday's weather observations and FWIs keyed by station guid.
+    :param hourly_observations_by_station_id: Hourly observations from the past 4 days keyed by station guid.
+    :param fuel_types_by_area: The fuel types and their areas exceeding a high HFI threshold.
+    :param for_date: The date critical hours are being calculated for.
+    :return: A dictionary of lists of critical hours keyed by fuel type code.
+    """
+    critical_hours_by_fuel_type = defaultdict(list)
+    for wfwx_station in wfwx_stations:
+        if check_station_valid(wfwx_station, dailies_by_station_id, hourly_observations_by_station_code):
+            for fuel_type_key in fuel_types_by_area.keys():
+                fuel_type_enum = FuelTypeEnum(fuel_type_key.replace("-", ""))
+                try:
+                    # Placing critical hours calculation in a try/except block as failure to calculate critical hours for a single station/fuel type pair
+                    # shouldn't prevent us from continuing with other stations and fuel types.
+                    critical_hours = await calculate_critical_hours_for_station_by_fuel_type(
+                        wfwx_station, dailies_by_station_id, yesterday_dailies_by_station_id, hourly_observations_by_station_code, fuel_type_enum, for_date
+                    )
+                    if critical_hours is not None and critical_hours.start is not None and critical_hours.end is not None:
+                        critical_hours_by_fuel_type[fuel_type_key].append(critical_hours)
+                except Exception as exc:
+                    logger.warning(f"An error occurred when calculating critical hours for station code: {wfwx_station.code} and fuel type: {fuel_type_key}: {exc} ")
+    return critical_hours_by_fuel_type
+
+
+def check_station_valid(wfwx_station: WFWXWeatherStation, dailies, hourlies) -> bool:
+    """
+    Checks if there is sufficient information to calculate critical hours for the specified station.
+
+    :param wfwx_station: The station of interest.
+    :param yesterdays: Yesterday's station data based on observations and FWI calculations.
+    :param hourlies: Hourly observations from yesterday.
+    :return: True if the station can be used for critical hours calculations, otherwise false.
+    """
+    if wfwx_station.wfwx_id not in dailies or wfwx_station.code not in hourlies:
+        return False
+    daily = dailies[wfwx_station.wfwx_id]
+    if daily["duffMoistureCode"] is None or daily["droughtCode"] is None or daily["fineFuelMoistureCode"] is None:
+        return False
+    return True
+
+
+async def get_hourly_observations(station_codes, start_time, end_time):
+    """
+    Gets hourly weather observations from WF1.
+
+    :param station_codes: A list of weather station codes.
+    :param start_time: The start time of interest.
+    :param end_time: The end time of interest.
+    :return: Hourly weather observations from WF1 for all specified station codes.
+    """
+    hourly_observations = await get_hourly_readings_in_time_interval(station_codes, start_time, end_time)
+    # also turn hourly obs data into a dict indexed by station id
+    hourly_observations_by_station_code = {raw_hourly.station.code: raw_hourly for raw_hourly in hourly_observations}
+    return hourly_observations_by_station_code
+
+
+async def get_dailies_by_station_id(client_session, header, wfwx_stations, time_of_interest):
+    """
+    Gets daily observations or forecasts from WF1.
+
+    :param client_session: A client session for making web requests.
+    :param header: An authorization header for making requests to WF1.
+    :param wfwx_stations: A list of WFWXWeatherStations.
+    :param time_of_interest: The time of interest (typically at 20:00 UTC).
+    :return: Daily observations or forecasts from WF1.
+    """
+    dailies = await wfwx_api.get_dailies_generator(client_session, header, wfwx_stations, time_of_interest, time_of_interest)
+    # turn it into a dictionary so we can easily get at data using a station id
+    dailies_by_station_id = {raw_daily.get("stationId"): raw_daily async for raw_daily in dailies}
+    return dailies_by_station_id
+
+
+def get_fuel_types_by_area(advisory_fuel_stats):
+    """
+    Aggregates high HFI area for zone units.
+
+    :param advisory_fuel_stats: A list of fire zone units that includes area exceeding 4K kW/m and 10K kW/m.
+    :return: Fuel types and the total area exceeding an HFI threshold of 4K kW/m.
+    """
+    fuel_types_by_area = {}
+    for row in advisory_fuel_stats:
+        advisory_fuel_stat = row[0]
+        sfms_fuel_type = row[1]
+        key = sfms_fuel_type.fuel_type_code
+        if key == "Non-fuel":
+            continue
+        if key in fuel_types_by_area:
+            fuel_types_by_area[key] += advisory_fuel_stat.area
+        else:
+            fuel_types_by_area[key] = advisory_fuel_stat.area
+    return fuel_types_by_area
+
+
+async def calculate_critical_hours_by_zone(db_session: AsyncSession, header: dict, stations_by_zone, run_parameters_id: int, for_date: date):
+    """
+    Calculates critical hours for fire zone units by determining critical hours for each station in the fire zone unit and heuristically determining a reasonable critical start/end time.
+
+    :param db_session: An async database session.
+    :param header: An authorization header for making requests to WF1.
+    :param stations_by_zone: A dictionary of lists of stations in fire zone units keyed by fire zone unit id.
+    :param run_parameters_id: The RunParameters object (ie. the SFMS run).
+    :param for_date: The date critical hours are being calculated for.
+    :return: A dictionary of critical hours by fuel type per fire zone unit keyed by fire zone unit id.
+    """
+    critical_hours_by_zone_and_fuel_type = defaultdict(str, defaultdict(list))
+    for zone_key in stations_by_zone.keys():
+        advisory_fuel_stats = await get_fuel_type_stats_in_advisory_area(db_session, zone_key, run_parameters_id)
+        fuel_types_by_area = get_fuel_types_by_area(advisory_fuel_stats)
+        wfwx_stations = stations_by_zone[zone_key]
+        unique_station_codes = list(set(station.code for station in wfwx_stations))
+        # get the dailies for all the stations
+        async with ClientSession() as client_session:
+            time_of_interest = get_hour_20_from_date(for_date)
+            dailies_by_station_id = await get_dailies_by_station_id(client_session, header, wfwx_stations, time_of_interest)
+            # must retrieve the previous day's observed/forecasted FFMC value from WFWX
+            prev_day = time_of_interest - timedelta(days=1)
+            # get the "daily" data for the station for the previous day
+            yesterday_dailies_by_station_id = await get_dailies_by_station_id(client_session, header, wfwx_stations, prev_day)
+            # get hourly observation history from our API (used for calculating morning diurnal FFMC)
+            hourly_observations_by_station_code = await get_hourly_observations(unique_station_codes, time_of_interest - timedelta(days=4), time_of_interest)
+
+        critical_hours_by_fuel_type = await calculate_critical_hours_by_fuel_type(
+            wfwx_stations, dailies_by_station_id, yesterday_dailies_by_station_id, hourly_observations_by_station_code, fuel_types_by_area, for_date
+        )
+
+        if len(critical_hours_by_fuel_type) > 0:
+            critical_hours_by_zone_and_fuel_type[zone_key] = critical_hours_by_fuel_type
+
+    for zone_id, critical_hours_by_fuel_type in critical_hours_by_zone_and_fuel_type.items():
+        await save_critical_hours(db_session, zone_id, critical_hours_by_fuel_type, run_parameters_id)
+
+    return critical_hours_by_zone_and_fuel_type
+
+
+async def calculate_critical_hours(run_type: RunType, run_datetime: datetime, for_date: date):
+    """
+    Entry point for calculating critical hours.
+
+    :param run_type: The run type, either forecast or actual.
+    :param run_datetime: The date and time of the sfms run.
+    :param for_date: The date critical hours are being calculated for.
+    """
+
+    logger.info(f"Calculating critical hours for {run_type} run type on run date: {run_datetime}, for date: {for_date}")
+    perf_start = perf_counter()
+
+    async with get_async_write_session_scope() as db_session:
+        run_parameters_id = await get_run_parameters_id(db_session, RunTypeEnum(run_type), run_datetime, for_date)
+        stmt = select(CriticalHours).where(CriticalHours.run_parameters == run_parameters_id)
+        exists = (await db_session.execute(stmt)).scalars().first() is not None
+
+        if exists:
+            logger.info("Critical hours already processed.")
+            return
+
+        async with ClientSession() as client_session:
+            header = await wfwx_api.get_auth_header(client_session)
+            all_stations = await get_stations_asynchronously()
+            station_codes = list(station.code for station in all_stations)
+            stations = await wfwx_api.get_wfwx_stations_from_station_codes(client_session, header, station_codes)
+            stations_by_zone = defaultdict(list)
+            transformer = PointTransformer(4326, 3005)
+            for station in stations:
+                (x, y) = transformer.transform_coordinate(station.lat, station.long)
+                zone_id = await get_containing_zone(db_session, f"POINT({x} {y})", 3005)
+                if zone_id is not None:
+                    stations_by_zone[zone_id[0]].append(station)
+
+            await calculate_critical_hours_by_zone(db_session, header, stations_by_zone, run_parameters_id, for_date)
+
+    perf_end = perf_counter()
+    delta = perf_end - perf_start
+    logger.info(f"delta count before and after calculating critical hours: {delta}")
+
+
+#### - Helper functions for local testing of critical hours calculations.
+
+
+async def start_critical_hours():
+    async with get_async_write_session_scope() as db_session:
+        result = await get_most_recent_run_parameters(db_session, RunTypeEnum.forecast, date(2024, 7, 17))
+        await calculate_critical_hours(result[0].run_type, result[0].run_datetime, result[0].for_date)
+
+
+def main():
+    """Kicks off asynchronous calculation of critical hours."""
+    try:
+        logger.debug("Begin calculating critical hours.")
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(start_critical_hours())
+
+        # Exit with 0 - success.
+        sys.exit(os.EX_OK)
+    except Exception as exception:
+        # Exit non 0 - failure.
+        logger.error("An error occurred while processing critical hours.", exc_info=exception)
+        sys.exit(os.EX_SOFTWARE)
+
+
+if __name__ == "__main__":
+    configure_logging()
+    main()

--- a/api/app/auto_spatial_advisory/nats_consumer.py
+++ b/api/app/auto_spatial_advisory/nats_consumer.py
@@ -11,6 +11,7 @@ from starlette.background import BackgroundTasks
 import nats
 from nats.js.api import StreamConfig, RetentionPolicy
 from nats.aio.msg import Msg
+from app.auto_spatial_advisory.critical_hours import calculate_critical_hours
 from app.auto_spatial_advisory.nats_config import server, stream_name, sfms_file_subject, subjects, hfi_classify_durable_group
 from app.auto_spatial_advisory.process_elevation_hfi import process_hfi_elevation
 from app.auto_spatial_advisory.process_hfi import RunType, process_hfi
@@ -77,6 +78,7 @@ async def run():
                 await process_hfi_elevation(run_type, run_date, run_datetime, for_date)
                 await process_high_hfi_area(run_type, run_datetime, for_date)
                 await process_fuel_type_hfi_by_shape(run_type, run_datetime, for_date)
+                await calculate_critical_hours(run_type, run_datetime, for_date)
             except Exception as e:
                 logger.error("Error processing HFI message: %s, adding back to queue", msg.data, exc_info=e)
                 background_tasks = BackgroundTasks()

--- a/api/app/db/crud/auto_spatial_advisory.py
+++ b/api/app/db/crud/auto_spatial_advisory.py
@@ -10,6 +10,8 @@ from sqlalchemy.engine.row import Row
 from app.auto_spatial_advisory.run_type import RunType
 from app.db.models.auto_spatial_advisory import (
     AdvisoryFuelStats,
+    CriticalHours,
+    HfiClassificationThresholdEnum,
     Shape,
     ClassifiedHfi,
     HfiClassificationThreshold,
@@ -115,19 +117,30 @@ async def get_all_hfi_thresholds(session: AsyncSession) -> List[HfiClassificatio
 
 async def get_all_sfms_fuel_types(session: AsyncSession) -> List[SFMSFuelType]:
     """
-    Retrieve all records from sfms_fuel_types table
+    Retrieve all records from sfms_fuel_types table excluding record IDs.
     """
     logger.info("retrieving SFMS fuel types info...")
-    stmt = select(SFMSFuelType)
-    result = await session.execute(stmt)
+    result = await get_all_sfms_fuel_type_records(session)
 
     fuel_types = []
 
-    for row in result.all():
+    for row in result:
         fuel_type_object = row[0]
         fuel_types.append(SFMSFuelType(fuel_type_id=fuel_type_object.fuel_type_id, fuel_type_code=fuel_type_object.fuel_type_code, description=fuel_type_object.description))
 
     return fuel_types
+
+
+async def get_all_sfms_fuel_type_records(session: AsyncSession) -> List[SFMSFuelType]:
+    """
+    Retrieve all records from the sfms_fuel_types table.
+
+    :param session: An async database session.
+    :return: A list of all SFMSFuelType records.
+    """
+    stmt = select(SFMSFuelType)
+    result = await session.execute(stmt)
+    return result.all()
 
 
 async def get_precomputed_high_hfi_fuel_type_areas_for_shape(session: AsyncSession, run_type: RunTypeEnum, run_datetime: datetime, for_date: date, advisory_shape_id: int) -> List[Row]:
@@ -152,6 +165,14 @@ async def get_precomputed_high_hfi_fuel_type_areas_for_shape(session: AsyncSessi
     logger.info("%f delta count before and after fuel types/high hfi/zone query", delta)
     return all_results
 
+async def get_fuel_type_stats_in_advisory_area(session: AsyncSession, advisory_shape_id: int, run_parameters_id: int):
+    stmt = (
+        select(AdvisoryFuelStats, SFMSFuelType)
+        .join_from(AdvisoryFuelStats, SFMSFuelType, AdvisoryFuelStats.fuel_type == SFMSFuelType.id)
+        .filter(AdvisoryFuelStats.advisory_shape_id == advisory_shape_id, AdvisoryFuelStats.run_parameters == run_parameters_id)
+    )
+    result = await session.execute(stmt)
+    return result.all()
 
 async def get_high_hfi_fuel_types_for_shape(session: AsyncSession, run_type: RunTypeEnum, run_datetime: datetime, for_date: date, shape_id: int) -> List[Row]:
     """
@@ -243,8 +264,25 @@ async def get_run_datetimes(session: AsyncSession, run_type: RunTypeEnum, for_da
     return result.all()
 
 
-async def get_high_hfi_area(session: AsyncSession, run_type: RunTypeEnum, run_datetime: datetime, for_date: date) -> List[Row]:
-    """For each fire zone, get the area of HFI polygons in that zone that fall within the
+async def get_most_recent_run_parameters(session: AsyncSession, run_type: RunTypeEnum, for_date: date) -> List[Row]:
+    """
+    Retrieve the most recent sfms run parameters record for the specified run type and for date.
+
+    :param session: Async database read session.
+    :param run_type: Type of run (forecast or actual).
+    :param for_date: The date of interest.
+    :return: The most recent sfms run parameters record for the specified run type and for date, otherwise return None.
+    """
+    stmt = select(RunParameters).where(RunParameters.run_type == run_type.value, RunParameters.for_date == for_date).distinct().order_by(RunParameters.run_datetime.desc()).limit(1)
+    result = await session.execute(stmt)
+    return result.first()
+
+
+async def get_high_hfi_area(session: AsyncSession,
+                            run_type: RunTypeEnum,
+                            run_datetime: datetime,
+                            for_date: date) -> List[Row]:
+    """ For each fire zone, get the area of HFI polygons in that zone that fall within the 
     4000 - 10000 range and the area of HFI polygons that exceed the 10000 threshold.
     """
     stmt = (
@@ -267,7 +305,7 @@ async def store_advisory_fuel_stats(session: AsyncSession, fuel_type_areas: dict
     :param : A dictionary keyed by fuel type code with value representing an area in square meters.
     :param threshold: The current threshold being processed, 1 = 4k-10k, 2 = > 10k.
     :param run_parameters_id: The RunParameter object id associated with the run_type, for_date and run_datetime of interest.
-    :param advisory_shape_id: The id of advisory shape (eg. fire zone unit) the fuel type area has been calcualted for.
+    :param advisory_shape_id: The id of advisory shape (eg. fire zone unit) the fuel type area has been calculated for.
     """
     advisory_fuel_stats = []
     for key in fuel_type_areas:
@@ -313,7 +351,6 @@ async def get_run_parameters_id(session: AsyncSession, run_type: RunType, run_da
     stmt = select(RunParameters.id).where(cast(RunParameters.run_type, String) == run_type.value, RunParameters.run_datetime == run_datetime, RunParameters.for_date == for_date)
     result = await session.execute(stmt)
     return result.scalar()
-
 
 async def save_run_parameters(session: AsyncSession, run_type: RunType, run_datetime: datetime, for_date: date):
     logger.info(f"Writing run parameters. RunType: {run_type.value}; run_datetime: {run_datetime.isoformat()}; for_date: {for_date.isoformat()}")
@@ -389,3 +426,29 @@ async def get_provincial_rollup(session: AsyncSession, run_type: RunTypeEnum, ru
     )
     result = await session.execute(stmt)
     return result.all()
+
+
+async def get_containing_zone(session: AsyncSession, geometry: str, srid: int):
+    geom = func.ST_GeomFromText(geometry, srid)
+    stmt = select(Shape.id).filter(func.ST_Contains(Shape.geom, geom))
+    result = await session.execute(stmt)
+    return result.first()
+
+
+async def save_critical_hours(session: AsyncSession, critical_hours: CriticalHours):
+    session.add(critical_hours)
+
+
+async def get_critical_hours_for_run_parameters(session: AsyncSession, run_type: RunTypeEnum, run_datetime: datetime, for_date: date):
+    stmt = (
+        select(CriticalHours)
+        .join_from(CriticalHours, RunParameters, CriticalHours.run_parameters == RunParameters.id)
+        .where(
+            RunParameters.run_type == run_type.value,
+            RunParameters.run_datetime == run_datetime,
+            RunParameters.for_date == for_date,
+        )
+        .group_by(CriticalHours.advisory_shape_id)
+    )
+    result = await session.execute(stmt)
+    return result

--- a/api/app/db/models/__init__.py
+++ b/api/app/db/models/__init__.py
@@ -20,8 +20,18 @@ from app.db.models.weather_models import (
     ModelRunForSFMS,
 )
 from app.db.models.hfi_calc import (FireCentre, FuelType, PlanningArea, PlanningWeatherStation)
-from app.db.models.auto_spatial_advisory import (Shape, ShapeType, HfiClassificationThreshold,
-                                                 ClassifiedHfi, RunTypeEnum, ShapeTypeEnum, FuelType, HighHfiArea, RunParameters)
+from app.db.models.auto_spatial_advisory import (
+    Shape,
+    ShapeType,
+    HfiClassificationThreshold,
+    ClassifiedHfi,
+    RunTypeEnum,
+    ShapeTypeEnum,
+    FuelType,
+    HighHfiArea,
+    RunParameters,
+    CriticalHours,
+)
 from app.db.models.morecast_v2 import MorecastForecastRecord
 from app.db.models.snow import ProcessedSnow, SnowSourceEnum
 from app.db.models.grass_curing import PercentGrassCuring

--- a/api/app/db/models/auto_spatial_advisory.py
+++ b/api/app/db/models/auto_spatial_advisory.py
@@ -8,6 +8,13 @@ from app.geospatial import NAD83_BC_ALBERS
 from sqlalchemy.dialects import postgresql
 
 
+class HfiClassificationThresholdEnum(enum.Enum):
+    """Enum for the different HFI classification thresholds."""
+
+    ADVISORY = "advisory"
+    WARNING = "warning"
+
+
 class ShapeTypeEnum(enum.Enum):
     """Define different shape types. e.g. "Zone", "Fire Centre" - later we may add
     "Incident"/"Fire", "Custom" etc. etc."""
@@ -203,3 +210,19 @@ class AdvisoryTPIStats(Base):
     mid_slope = Column(Integer, nullable=False, index=False)
     upper_slope = Column(Integer, nullable=False, index=False)
     pixel_size_metres = Column(Integer, nullable=False, index=False)
+
+class CriticalHours(Base):
+    """
+    Critical hours for a fuel type in a firezone unit.
+    """
+
+    __tablename__ = "critical_hours"
+    __table_args__ = {"comment": "Critical hours by firezone unit, fuel type and sfms run parameters."}
+    id = Column(Integer, primary_key=True, index=True)
+    advisory_shape_id = Column(Integer, ForeignKey(Shape.id), nullable=False, index=True)
+    threshold = Column(postgresql.ENUM("advisory", "warning", name="hficlassificationthresholdenum", create_type=False), nullable=False)
+    run_parameters = Column(Integer, ForeignKey(RunParameters.id), nullable=False, index=True)
+    fuel_type = Column(Integer, ForeignKey(SFMSFuelType.id), nullable=False, index=True)
+    start_hour = Column(Integer, nullable=False)
+    end_hour = Column(Integer, nullable=False)
+

--- a/api/app/jobs/critical_hours.py
+++ b/api/app/jobs/critical_hours.py
@@ -1,0 +1,399 @@
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from typing import Tuple
+from osgeo import gdal, ogr, osr
+import asyncio
+import logging
+import math
+import numpy as np
+import os
+import requests
+from sqlalchemy.ext.asyncio import AsyncSession
+import statistics
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from app import configure_logging
+from app.db.crud.grass_curing import get_last_percent_grass_curing_for_date, save_percent_grass_curing
+from app.db.database import get_async_read_session_scope, get_async_write_session_scope
+from app.fire_behaviour import cffdrs
+from app.fire_behaviour.fuel_types import FUEL_TYPE_DEFAULTS, FuelTypeEnum
+from app.fire_behaviour.prediction import build_hourly_rh_dict, calculate_cfb, get_critical_hours
+from app.fire_behaviour.wind_speed import calculate_wind_speed_result
+from app.geospatial import WGS84
+from app.db.models.grass_curing import PercentGrassCuring
+from app.hourlies import get_hourly_readings_in_time_interval
+from app.rocketchat_notifications import send_rocketchat_notification
+from app.schemas.fba_calc import WindResult
+from app.stations import get_stations_asynchronously
+
+
+from aiohttp.client import ClientSession
+from app.db.crud.auto_spatial_advisory import (
+    get_all_sfms_fuel_type_records,
+    get_fire_zone_unit_shape_type_id,
+    get_most_recent_run_parameters,
+    get_containing_zone,
+    get_fuel_type_stats_in_advisory_area,
+    save_critical_hours,
+)
+from app.db.models.auto_spatial_advisory import (
+    AdvisoryFuelStats,
+    CriticalHours,
+    HfiClassificationThresholdEnum,
+    Shape,
+    ClassifiedHfi,
+    HfiClassificationThreshold,
+    SFMSFuelType,
+    RunTypeEnum,
+    FuelType,
+    HighHfiArea,
+    RunParameters,
+    AdvisoryElevationStats,
+    ShapeType,
+)
+from app.utils.time import get_hour_20_from_date, get_julian_date, get_utc_now
+from app.wildfire_one import wfwx_api
+from app.wildfire_one.schema_parsers import WFWXWeatherStation
+
+logger = logging.getLogger(__name__)
+
+
+class PointTransformer:
+    def __init__(self, source_srs, target_srs):
+        source = osr.SpatialReference()
+        source.ImportFromEPSG(source_srs)
+        target = osr.SpatialReference()
+        target.ImportFromEPSG(target_srs)
+        self.transform = osr.CoordinateTransformation(source, target)
+
+    def transform_coordinate(self, x: float, y: float) -> Tuple[float, float]:
+        point = ogr.CreateGeometryFromWkt(f"POINT ({x} {y})")
+        point.Transform(self.transform)
+        return (point.GetX(), point.GetY())
+
+
+class CriticalHoursJob:
+    def __init__(self):
+        self.db_session = None
+        self.client_session = None
+
+    def _set_db_session(self, db_session: AsyncSession):
+        self.db_session = db_session
+
+    def _set_client_session(self, client_session: ClientSession):
+        self.client_session = client_session
+
+    def _calculate_wind_speed_result(self, yesterday: dict, raw_daily: dict) -> WindResult:
+        # extract variable from wf1 that we need to calculate the fire behaviour advisory.
+        bui = cffdrs.bui_calc(raw_daily.get("duffMoistureCode", None), raw_daily.get("droughtCode", None))
+        temperature = raw_daily.get("temperature", None)
+        relative_humidity = raw_daily.get("relativeHumidity", None)
+        precipitation = raw_daily.get("precipitation", None)
+
+        wind_speed = raw_daily.get("windSpeed", None)
+        status = raw_daily.get("recordType").get("id")
+
+        ffmc = cffdrs.fine_fuel_moisture_code(yesterday.get("fineFuelMoistureCode", None), temperature, relative_humidity, precipitation, wind_speed)
+        isi = cffdrs.initial_spread_index(ffmc, wind_speed)
+        fwi = cffdrs.fire_weather_index(isi, bui)
+        return WindResult(ffmc=ffmc, isi=isi, bui=bui, wind_speed=wind_speed, fwi=fwi, status=status)
+
+    async def _calculate_critical_hours():
+        # Fetch all stations from WF1 API
+        stations = get_stations_asynchronously()
+        zone_unit_shape_type_id = await get_fire_zone_unit_shape_type_id()
+        zone_units = 1
+        stations_by_zone_unit = {}
+
+    def _sort_station_by_zone(self, stations: list[WFWXWeatherStation]):
+        stations_by_zone = defaultdict(list)
+        for station in stations:
+            stations_by_zone[station.zone_code].append(station)
+        return stations_by_zone
+
+    async def _get_most_recent_sfms_run_parameters(self, run_type: RunTypeEnum, for_date: datetime):
+        result = await get_most_recent_run_parameters(self.db_session, RunTypeEnum.forecast, date(2024, 7, 16))
+        if len(result) > 0:
+            return result[0]
+        return None
+
+    # def _get_high_hfi_fuel_types(self, session: ClientSession, station_code: int, for_date: datetime):
+
+    async def _calculate_critical_hours_for_station_by_fuel_type(
+        self,
+        wfwx_station: WFWXWeatherStation,
+        dailies_by_station_id: dict,
+        yesterday_dailies_by_station_id: dict,
+        hourly_observations_by_station_id: dict,
+        fuel_type: FuelTypeEnum,
+        for_date: datetime,
+    ):
+        raw_daily = dailies_by_station_id[wfwx_station.wfwx_id]
+        raw_observations = hourly_observations_by_station_id[wfwx_station.code]
+        yesterday = yesterday_dailies_by_station_id[wfwx_station.wfwx_id]
+        last_observed_morning_rh_values = build_hourly_rh_dict(raw_observations.values)
+
+        wind_result = self._calculate_wind_speed_result(yesterday, raw_daily)
+        bui = wind_result.bui
+        ffmc = wind_result.ffmc
+        isi = wind_result.isi
+        fuel_type_info = FUEL_TYPE_DEFAULTS[fuel_type]
+        percentage_conifer = fuel_type_info.get("PC", None)
+        percentage_dead_balsam_fir = fuel_type_info.get("PDF", None)
+        crown_base_height = fuel_type_info.get("CBH", None)
+        cfl = fuel_type_info.get("CFL", None)
+        grass_cure = yesterday.get("grasslandCuring", None)
+        wind_speed = wind_result.wind_speed
+        yesterday_ffmc = yesterday.get("fineFuelMoistureCode", None)
+        julian_date = get_julian_date(for_date)
+        fmc = cffdrs.foliar_moisture_content(int(wfwx_station.lat), int(wfwx_station.long), wfwx_station.elevation, julian_date)
+        sfc = cffdrs.surface_fuel_consumption(fuel_type, bui, ffmc, percentage_conifer)
+        ros = cffdrs.rate_of_spread(
+            fuel_type,
+            isi=isi,
+            bui=bui,
+            fmc=fmc,
+            sfc=sfc,
+            pc=percentage_conifer,
+            cc=grass_cure,
+            pdf=percentage_dead_balsam_fir,
+            cbh=crown_base_height,
+        )
+        cfb = calculate_cfb(fuel_type, fmc, sfc, ros, crown_base_height)
+
+        critical_hours = get_critical_hours(
+            4000,
+            fuel_type,
+            percentage_conifer,
+            percentage_dead_balsam_fir,
+            bui,
+            grass_cure,
+            crown_base_height,
+            ffmc,
+            fmc,
+            cfb,
+            cfl,
+            wind_speed,
+            yesterday_ffmc,
+            last_observed_morning_rh_values,
+        )
+
+        return critical_hours
+
+    # async def _calculate_critical_hours_for_stations(self, header, stations):
+    #     for_date = get_hour_20_from_date(get_utc_now())
+    #     time_of_interest = get_hour_20_from_date(for_date)
+    #     unique_station_codes = list(set(station.code for station in stations))
+    #     # get the dailies for all the stations
+    #     dailies = await wfwx_api.get_dailies_generator(self.session, header, stations, time_of_interest, time_of_interest)
+    #     # turn it into a dictionary so we can easily get at data using a station id
+    #     dailies_by_station_id = {raw_daily.get("stationId"): raw_daily async for raw_daily in dailies}
+    #     # must retrieve the previous day's observed/forecasted FFMC value from WFWX
+    #     prev_day = time_of_interest - timedelta(days=1)
+    #     # get the "daily" data for the station for the previous day
+    #     yesterday_response = await wfwx_api.get_dailies_generator(self.session, header, stations, prev_day, prev_day)
+    #     # turn it into a dictionary so we can easily get at data
+    #     yesterday_dailies_by_station_id = {raw_daily.get("stationId"): raw_daily async for raw_daily in yesterday_response}
+    #     # get hourly observation history from our API (used for calculating morning diurnal FFMC)
+    #     hourly_observations = await get_hourly_readings_in_time_interval(unique_station_codes, time_of_interest - timedelta(days=4), time_of_interest)
+    #     # also turn hourly obs data into a dict indexed by station id
+    #     hourly_obs_by_station_code = {raw_hourly.station.code: raw_hourly for raw_hourly in hourly_observations}
+
+    #     # we need a lookup from station code to station id
+    #     # TODO: this is a bit silly, the call to get_wfwx_stations_from_station_codes repeats a lot of this!
+    #     wfwx_station_lookup = {wfwx_station.code: wfwx_station for wfwx_station in stations}
+    #     stations_critical_hours = {}
+    #     for station in stations:
+    #         critical_hours = await self._calculate_critical_hours_for_station(station, dailies_by_station_id, yesterday_dailies_by_station_id, hourly_obs_by_station_code, for_date)
+    #         return
+
+    def _get_fuel_types_by_area(self, advisory_fuel_stats):
+        fuel_types_by_area = {}
+        for row in advisory_fuel_stats:
+            advisory_fuel_stat = row[0]
+            sfms_fuel_type = row[1]
+            key = sfms_fuel_type.fuel_type_code
+            if key == "Non-fuel":
+                continue
+            if key in fuel_types_by_area:
+                fuel_types_by_area[key] += advisory_fuel_stat.area
+            else:
+                fuel_types_by_area[key] = advisory_fuel_stat.area
+        return fuel_types_by_area
+
+    def _calculate_representative_hours(self, critical_hours):
+        print(critical_hours)
+
+    def _check_station_valid(self, wfwx_station: WFWXWeatherStation, dailies, hourlies) -> bool:
+        """
+        Checks if there is sufficient information to calculate critical hours for the specified station.
+
+        :param wfwx_station: The station of interest.
+        :param yesterdays: Yesterday's station data based on observations and FWI calculations.
+        :param hourlies: Hourly observations from yesterday.
+        :return: True if the station can be used for critical hours calculations, otherwise false.
+        """
+        if wfwx_station.wfwx_id not in dailies or wfwx_station.code not in hourlies:
+            return False
+        daily = dailies[wfwx_station.wfwx_id]
+        if daily["duffMoistureCode"] is None or daily["droughtCode"] is None or daily["fineFuelMoistureCode"] is None:
+            return False
+        return True
+
+    def _determine_start_time(self, times: list[float]) -> float:
+        if len(times) < 3:
+            return min(times)
+        return math.floor(np.percentile(times, 25))
+
+    def _determine_end_time(self, times: list[float]) -> float:
+        if len(times) < 3:
+            return max(times)
+        return math.ceil(np.percentile(times, 75))
+
+    def _calculate_representative_hours(self, critical_hours):
+        start_times = []
+        end_times = []
+        for hours in critical_hours:
+            start_times.append(hours.start)
+            end_times.append(hours.end)
+        start_time = self._determine_start_time(start_times)
+        end_time = self._determine_end_time(end_times)
+        return (start_time, end_time)
+
+    async def _get_sfms_fuel_types_dict(self):
+        sfms_fuel_types = await get_all_sfms_fuel_type_records(self.db_session)
+        fuel_types_dict = defaultdict()
+        for fuel_type in sfms_fuel_types:
+            fuel_types_dict[fuel_type[0].fuel_type_code] = fuel_type[0].id
+        return fuel_types_dict
+
+    async def _save_critical_hours(self, zone_id: int, critical_hours_by_fuel_type: dict, run_parameters_id: int):
+        sfms_fuel_types_dict = await self._get_sfms_fuel_types_dict()
+        critical_hours_to_save: list[CriticalHours] = []
+        for fuel_type, critical_hours in critical_hours_by_fuel_type.items():
+            start_time, end_time = self._calculate_representative_hours(critical_hours)
+            critical_hours_record = CriticalHours(
+                advisory_shape_id=zone_id,
+                threshold=HfiClassificationThresholdEnum.ADVISORY.value,
+                run_parameters=run_parameters_id,
+                fuel_type=sfms_fuel_types_dict[fuel_type],
+                start_hour=start_time,
+                end_hour=end_time,
+            )
+            critical_hours_to_save.append(critical_hours_record)
+        await save_critical_hours(self.db_session, critical_hours_to_save)
+        print(fuel_type)
+
+    async def _calculate_critical_hours_by_zone(self, header, stations_by_zone):
+        for_date = get_hour_20_from_date(get_utc_now())
+        time_of_interest = get_hour_20_from_date(for_date)
+        run_parameters = await self._get_most_recent_sfms_run_parameters(RunTypeEnum.forecast, date(2024, 8, 7))
+        run_parameters_id = run_parameters.id
+        critical_hours_by_zone_and_fuel_type = defaultdict(str, defaultdict(list))
+        for zone_key in stations_by_zone.keys():
+            critical_hours_by_station = defaultdict(list)
+            advisory_fuel_stats = await get_fuel_type_stats_in_advisory_area(self.db_session, zone_key, run_parameters_id)
+            fuel_types_by_area = self._get_fuel_types_by_area(advisory_fuel_stats)
+            wfwx_stations = stations_by_zone[zone_key]
+            unique_station_codes = list(set(station.code for station in wfwx_stations))
+            # get the dailies for all the stations
+            async with ClientSession() as client_session:
+                dailies = await wfwx_api.get_dailies_generator(client_session, header, wfwx_stations, time_of_interest, time_of_interest)
+                # turn it into a dictionary so we can easily get at data using a station id
+                dailies_by_station_id = {raw_daily.get("stationId"): raw_daily async for raw_daily in dailies}
+                # must retrieve the previous day's observed/forecasted FFMC value from WFWX
+                prev_day = time_of_interest - timedelta(days=1)
+                # get the "daily" data for the station for the previous day
+                yesterday_response = await wfwx_api.get_dailies_generator(client_session, header, wfwx_stations, prev_day, prev_day)
+                # turn it into a dictionary so we can easily get at data
+                yesterday_dailies_by_station_id = {raw_daily.get("stationId"): raw_daily async for raw_daily in yesterday_response}
+                # get hourly observation history from our API (used for calculating morning diurnal FFMC)
+                hourly_observations = await get_hourly_readings_in_time_interval(unique_station_codes, time_of_interest - timedelta(days=4), time_of_interest)
+                # also turn hourly obs data into a dict indexed by station id
+                hourly_obs_by_station_code = {raw_hourly.station.code: raw_hourly for raw_hourly in hourly_observations}
+
+                # we need a lookup from station code to station id
+                # TODO: this is a bit silly, the call to get_wfwx_stations_from_station_codes repeats a lot of this!
+                wfwx_station_lookup = {wfwx_station.code: wfwx_station for wfwx_station in wfwx_stations}
+
+            for wfwx_station in wfwx_stations:
+                if self._check_station_valid(wfwx_station, dailies_by_station_id, hourly_obs_by_station_code):
+                    for fuel_type_key in fuel_types_by_area.keys():
+                        fuel_type_enum = FuelTypeEnum(fuel_type_key.replace("-", ""))
+                        try:
+                            # Placing critical hours calculation in a try/except block as failure to calculate critical hours for a single station/fuel type pair
+                            # shouldn't prevent us from continuing with other stations and fuel types.
+                            critical_hours = await self._calculate_critical_hours_for_station_by_fuel_type(
+                                wfwx_station, dailies_by_station_id, yesterday_dailies_by_station_id, hourly_obs_by_station_code, fuel_type_enum, for_date
+                            )
+                            if critical_hours is not None and critical_hours.start is not None and critical_hours.end is not None:
+                                critical_hours_by_station[fuel_type_key].append(critical_hours)
+                        except Exception as exc:
+                            logger.warning(f"An error occurred when calculating critical hours for station code: {wfwx_station.code} and fuel type: {fuel_type_key}: {exc} ")
+            if len(critical_hours_by_station) > 0:
+                critical_hours_by_zone_and_fuel_type[zone_key] = critical_hours_by_station
+
+        for zone_id, critical_hours_by_fuel_type in critical_hours_by_zone_and_fuel_type.items():
+            await self._save_critical_hours(zone_id, critical_hours_by_fuel_type, run_parameters_id)
+            print(zone_id)
+
+        return critical_hours_by_zone_and_fuel_type
+
+    async def _sort_stations_by_zone_unit(self, stations):
+        stations_by_zone = defaultdict(list)
+        transformer = PointTransformer(4326, 3005)
+        for station in stations:
+            (x, y) = transformer.transform_coordinate(station.lat, station.long)
+            zone_id = await get_containing_zone(self.db_session, f"POINT({x} {y})", 3005)
+            if zone_id is not None:
+                stations_by_zone[zone_id[0]].append(station)
+        return stations_by_zone
+
+    async def _run_critical_hours(self):
+        """Entry point for running the job."""
+        # Somehow check the last time critical hours were calculated
+        async with ClientSession() as client_session:
+            header = await wfwx_api.get_auth_header(client_session)
+            all_stations = await get_stations_asynchronously()
+            station_codes = list(station.code for station in all_stations)
+            stations = await wfwx_api.get_wfwx_stations_from_station_codes(client_session, header, station_codes)
+            stations_by_zone = await self._sort_stations_by_zone_unit(stations)
+
+        critical_hours_by_zone = await self._calculate_critical_hours_by_zone(header, stations_by_zone)
+
+        print("test")
+        # await self._calculate_critical_hours()
+
+    async def run_job(self):
+        # Create a db session and client session for use throughout the job.
+        async with get_async_write_session_scope() as db_session:
+            self._set_db_session(db_session)
+            async with ClientSession() as client_session:
+                self._set_client_session(client_session)
+                await self._run_critical_hours()
+
+
+def main():
+    """Kicks off asynchronous calculation of critical hours."""
+    try:
+        logger.debug("Begin calculating critical hours.")
+
+        job = CriticalHoursJob()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(job.run_job())
+
+        # Exit with 0 - success.
+        sys.exit(os.EX_OK)
+    except Exception as exception:
+        # Exit non 0 - failure.
+        logger.error("An error occurred while processing critical hours.", exc_info=exception)
+        rc_message = ":scream: Encountered an error while processing critical hours."
+        send_rocketchat_notification(rc_message, exception)
+        sys.exit(os.EX_SOFTWARE)
+
+
+if __name__ == "__main__":
+    configure_logging()
+    main()

--- a/api/app/utils/geospatial.py
+++ b/api/app/utils/geospatial.py
@@ -1,5 +1,10 @@
 import logging
+<<<<<<< HEAD
 from osgeo import gdal
+=======
+from typing import Tuple
+from osgeo import gdal, ogr, osr
+>>>>>>> ec740239 (Critical hours job)
 
 
 logger = logging.getLogger(__name__)
@@ -83,3 +88,21 @@ def raster_mul(tpi_ds: gdal.Dataset, hfi_ds: gdal.Dataset, chunk_size=256) -> gd
             hfi_chunk = None
 
     return out_ds
+
+
+class PointTransformer:
+    """
+    Transforms the coordinates of a point from one spatial reference to another.
+    """
+
+    def __init__(self, source_srs, target_srs):
+        source = osr.SpatialReference()
+        source.ImportFromEPSG(source_srs)
+        target = osr.SpatialReference()
+        target.ImportFromEPSG(target_srs)
+        self.transform = osr.CoordinateTransformation(source, target)
+
+    def transform_coordinate(self, x: float, y: float) -> Tuple[float, float]:
+        point = ogr.CreateGeometryFromWkt(f"POINT ({x} {y})")
+        point.Transform(self.transform)
+        return (point.GetX(), point.GetY())


### PR DESCRIPTION
- Critical hours are calculated for each station within a fire zone unit. A representative start and end time is then selected for the fire zone unit.
- Critical hours are saved in a new critical_hours table.
- This is a temporary implementation that will be replaced once we are able to perform critical hours calculations spatially. As this is temporary there are no unit tests.
- A lot of functionality is borrowed/copied from FireBat.
# Test Links:
[Landing Page](https://wps-pr-3846-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3846-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3846-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3846-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3846-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3846-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3846-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3846-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
