### PR TITLE
Don't show TPI stats if they're all zero

### DIFF
--- a/web/src/features/fba/components/infoPanel/FireZoneUnitSummary.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitSummary.tsx
@@ -37,7 +37,7 @@ const FireZoneUnitSummary = ({
             <FuelSummary selectedFireZoneUnit={selectedFireZoneUnit} fuelTypeInfo={fuelTypeInfo} />
           </Grid>
           <Grid item sx={{ width: '95%' }}>
-            { isNull(fireZoneTPIStats) ? (
+            { isNull(fireZoneTPIStats) || fireZoneTPIStats.valley_bottom + fireZoneTPIStats.mid_slope + fireZoneTPIStats.upper_slope === 0 ? (
               <Typography>
                 No elevation information available.
               </Typography>

--- a/web/src/features/fba/components/infoPanel/fireZoneUnitSummary.test.tsx
+++ b/web/src/features/fba/components/infoPanel/fireZoneUnitSummary.test.tsx
@@ -85,4 +85,27 @@ describe('FireZoneUnitSummary', () => {
     const fireZoneUnitInfo = getByTestId('elevation-status')
     expect(fireZoneUnitInfo).toBeInTheDocument()
   })
+
+  it('should not render TPI stats all zero', () => {
+    const fireShape: FireShape = {
+      fire_shape_id: 1,
+      mof_fire_zone_name: 'foo',
+      mof_fire_centre_name: 'fizz',
+      area_sqm: 10
+    }
+    const { queryByTestId } = render(
+      <FireZoneUnitSummary
+        fuelTypeInfo={[]}
+        fireZoneTPIStats={{
+          fire_zone_id: 0, 
+          valley_bottom: 0,
+          mid_slope: 0,
+          upper_slope: 0
+        }}
+        selectedFireZoneUnit={fireShape}
+      />
+    )
+    const fireZoneUnitInfo = queryByTestId('elevation-status')
+    expect(fireZoneUnitInfo).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
To behave similarly to the fuel stats table above.
# Test Links:
[Landing Page](https://wps-pr-3869-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3869-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3869-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3869-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3869-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3869-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3869-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3869-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
