### PR TITLE
Morecast: Validation on editable fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,7 @@
         "cffdrs",
         "colour",
         "cutline",
+        "CWFIS",
         "determinates",
         "excinfo",
         "fastapi",

--- a/web/src/features/moreCast2/components/DataGridColumns.tsx
+++ b/web/src/features/moreCast2/components/DataGridColumns.tsx
@@ -83,6 +83,7 @@ export class DataGridColumns {
     tabColumns.push(gcForecastField)
     tabColumns.push(gcCwfisField)
 
+    tabColumns.map(column => column.preProcessEditCellProps)
     return tabColumns
   }
 

--- a/web/src/features/moreCast2/components/EditInputCell.tsx
+++ b/web/src/features/moreCast2/components/EditInputCell.tsx
@@ -1,0 +1,71 @@
+import { GridRenderEditCellParams, useGridApiContext } from '@mui/x-data-grid-pro'
+import { styled } from '@mui/material/styles'
+import Tooltip, { tooltipClasses, TooltipProps } from '@mui/material/Tooltip'
+import React, { useRef, useEffect } from 'react'
+import { TextField } from '@mui/material'
+import { theme } from '@/app/theme'
+
+const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.error.contrastText
+  }
+}))
+
+export const EditInputCell = (props: GridRenderEditCellParams) => {
+  const { id, value, field, hasFocus, error } = props
+  const apiRef = useGridApiContext()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (hasFocus && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [hasFocus])
+
+  const handleValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value // The new value entered by the user
+    apiRef.current.setEditCellValue({ id, field, value: newValue })
+  }
+
+  const handleBlur = () => {
+    // Commit the value when focus is lost
+    apiRef.current.stopCellEditMode({ id, field })
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      // Just exit edit mode without reverting changes
+      apiRef.current.stopCellEditMode({ id, field })
+    }
+  }
+
+  return (
+    <StyledTooltip open={!!error} title={'Wrong value'}>
+      <TextField
+        data-testid="forecast-edit-cell"
+        type="number"
+        inputMode="numeric"
+        inputRef={inputRef}
+        size="small"
+        InputLabelProps={{
+          shrink: true
+        }}
+        sx={{
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: error ? theme.palette.error.main : '#737373',
+              borderWidth: '2px'
+            }
+          }
+        }}
+        value={value}
+        onChange={handleValueChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+      />
+    </StyledTooltip>
+  )
+}


### PR DESCRIPTION
Pulls in the `preProcessEditCellProps` callback for column definitions to set the error prop if validation doesn't pass for forecast fields.

Adds `EditInputCell` as the render component for cell editing that reacts to the error flag being set with a red tooltip and border.

TODO:
- Make the tooltip error less ambiguous
- Add tests

Closes #3571 