### PR TITLE
Trivial bug fixes

### DIFF
--- a/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
+++ b/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
@@ -99,14 +99,14 @@ const AdvisoryText = ({
         {issueDate?.isValid ? (
           <Typography data-testid="default-message">Please select a fire center.</Typography>
         ) : (
-          <Typography data-testid="no-data-message">No advisory data available for today.</Typography>
+          <Typography data-testid="no-data-message">No advisory data available for the selected date.</Typography>
         )}{' '}
       </>
     )
   }
 
   const renderAdvisoryText = () => {
-    const forToday = issueDate?.toISODate() === forDate.toISODate()
+    const forToday = forDate.toISODate() === DateTime.now().toISODate()
     const displayForDate = forToday ? 'today' : forDate.toLocaleString({ month: 'short', day: 'numeric' })
 
     const fireCenterSummary = provincialSummary[selectedFireCenter!.name]
@@ -133,7 +133,7 @@ const AdvisoryText = ({
         {!isUndefined(zoneStatus) && zoneStatus === AdvisoryStatus.WARNING && (
           <Typography data-testid="advisory-message-warning">{message}</Typography>
         )}
-        {!hasCriticalHours && (
+        {!hasCriticalHours && !isUndefined(zoneStatus) && (
           <Typography data-testid="advisory-message-no-critical-hours" sx={{ paddingTop: '1rem' }}>
             No critical hours available.
           </Typography>

--- a/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
@@ -1,13 +1,13 @@
 import { selectFireCentreHFIFuelStats, selectFireCentreTPIStats } from '@/app/rootReducer'
 import { calculateStatusColour } from '@/features/fba/calculateZoneStatus'
-import { Box, Grid, Tab, Tabs, Tooltip } from '@mui/material'
+import { Box, Grid, Tab, Tabs, Tooltip, Typography } from '@mui/material'
 import { FireCenter, FireShape } from 'api/fbaAPI'
 import { INFO_PANEL_CONTENT_BACKGROUND, theme } from 'app/theme'
 import FireZoneUnitSummary from 'features/fba/components/infoPanel/FireZoneUnitSummary'
 import InfoAccordion from 'features/fba/components/infoPanel/InfoAccordion'
 import TabPanel from 'features/fba/components/infoPanel/TabPanel'
 import { useFireCentreDetails } from 'features/fba/hooks/useFireCentreDetails'
-import { isNull, isUndefined } from 'lodash'
+import { isEmpty, isNull, isUndefined } from 'lodash'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 
@@ -91,6 +91,11 @@ const FireZoneUnitTabs = ({
         title={selectedFireCenter.name}
         accordionDetailBackgroundColour={INFO_PANEL_CONTENT_BACKGROUND}
       >
+        {isEmpty(sortedGroupedFireZoneUnits) && (
+          <Typography sx={{ paddingLeft: '1rem', paddingTop: '1rem' }}>
+            No advisory data available for the selected date.
+          </Typography>
+        )}
         <Grid container justifyContent="center" minHeight={500}>
           <Grid item sx={{ width: '95%' }}>
             <Box>


### PR DESCRIPTION
- Fix date display logic
- Show message when fire centre selected but no fire zone unit HFI data available (eg. Select date in the future)
- Hide 'No critical hours available' text when no warning or advisory has been issued.
# Test Links:
[Landing Page](https://wps-pr-3921-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3921-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3921-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3921-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3921-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3921-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3921-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3921-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
