### PR TITLE
Fix search for modelKey

### DIFF
--- a/web/src/app/theme.ts
+++ b/web/src/app/theme.ts
@@ -134,16 +134,16 @@ export const MORECAST_MODEL_COLORS: ModelDetails = {
 }
 export type MoreCastModelColors = typeof MORECAST_MODEL_COLORS
 
-export const modelColorClass = (params: Pick<GridCellParams | GridColumnHeaderParams, 'field'>) => {
+export const modelColorClass = (params: Pick<GridCellParams | GridColumnHeaderParams, 'colDef' | 'field'>) => {
   if (params.field.includes('Actual')) {
     return ''
   }
   const stringKeys = Object.keys(MORECAST_MODEL_COLORS)
-  const modelKey = stringKeys.find(key => params.field.includes(key.toUpperCase()))
+  const modelKey = stringKeys.find(key => params.colDef.headerName?.startsWith(key.toUpperCase()))
   return modelKey ? modelKey : ''
 }
 
-export const modelHeaderColorClass = (params: Pick<GridCellParams | GridColumnHeaderParams, 'field'>) => {
+export const modelHeaderColorClass = (params: Pick<GridCellParams | GridColumnHeaderParams, 'colDef' | 'field'>) => {
   const modelClass = modelColorClass(params)
   return modelClass === '' ? modelClass : `${modelClass}-header`
 }

--- a/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
+++ b/web/src/features/moreCast2/components/ColumnDefBuilder.tsx
@@ -129,10 +129,10 @@ export class ColumnDefBuilder implements ColDefGenerator, ForecastColDefGenerato
       sortable: false,
       type: 'number',
       width: width ?? DEFAULT_COLUMN_WIDTH,
-      cellClassName: (params: Pick<GridCellParams, 'field'>) => {
+      cellClassName: (params: Pick<GridCellParams, 'colDef' | 'field'>) => {
         return modelColorClass(params)
       },
-      headerClassName: (params: Pick<GridColumnHeaderParams, 'field'>) => {
+      headerClassName: (params: Pick<GridColumnHeaderParams, 'colDef' | 'field'>) => {
         return modelHeaderColorClass(params)
       },
       renderCell: (params: Pick<GridRenderCellParams, 'formattedValue'>) => {


### PR DESCRIPTION
Adjust logic for determining background colour of weather model columns in Morecast. HRDPS and RDPS currently have the same colour in prod but they should be different.
# Test Links:
[Landing Page](https://wps-pr-3922-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3922-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3922-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3922-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3922-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3922-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3922-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3922-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
