### PR TITLE
Nats deployment - trigger rollout

### DIFF
--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -252,8 +252,20 @@ objects:
       name: ${APP_NAME}-${SUFFIX}-nats-consumer
       labels:
         app: ${APP_NAME}-${SUFFIX}
+        annotations:
+              image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": ${IMAGE_NAME}:${IMAGE_TAG},
+            "namespace": ${PROJ_TOOLS}
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
     spec:
-      replicas: 2
+      replicas: 3
       selector:
         matchLabels:
           app: ${APP_NAME}-${SUFFIX}

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -252,18 +252,18 @@ objects:
       name: ${APP_NAME}-${SUFFIX}-nats-consumer
       labels:
         app: ${APP_NAME}-${SUFFIX}
-        annotations:
-              image.openshift.io/triggers: |-
-      [
-        {
-          "from": {
-            "kind": "ImageStreamTag",
-            "name": ${IMAGE_NAME}:${IMAGE_TAG},
-            "namespace": ${PROJ_TOOLS}
-          },
-          "fieldPath": "spec.template.spec.containers[0].image"
-        }
-      ]
+      annotations:
+        image.openshift.io/triggers: |-
+          [
+            {
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "${IMAGE_NAME}:${IMAGE_TAG}",
+                "namespace": "${PROJ_TOOLS}"
+              },
+              "fieldPath": "spec.template.spec.containers[0].image"
+            }
+          ]
     spec:
       replicas: 3
       selector:

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -253,7 +253,7 @@ objects:
       labels:
         app: ${APP_NAME}-${SUFFIX}
     spec:
-      replicas: 3
+      replicas: 2
       selector:
         matchLabels:
           app: ${APP_NAME}-${SUFFIX}


### PR DESCRIPTION
- Triggers nats-consumer deployment pods to start a new rollout whenever their image is updated
- [Info](https://docs.openshift.com/container-platform/4.14/openshift_images/triggering-updates-on-imagestream-changes.html)
- Closes #2606 
# Test Links:
[Landing Page](https://wps-pr-3923-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3923-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3923-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3923-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3923-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3923-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3923-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3923-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
