### PR TITLE
Fix critical hours when O1A/O1B present

### DIFF
--- a/api/app/db/crud/auto_spatial_advisory.py
+++ b/api/app/db/crud/auto_spatial_advisory.py
@@ -298,6 +298,19 @@ async def get_most_recent_run_parameters(session: AsyncSession, run_type: RunTyp
     return result.first()
 
 
+async def get_run_parameters_by_id(session: AsyncSession, id: int) -> RunParameters:
+    """
+    Retrieve the RunParameters record with the specified id.
+
+    :param session: Async database session.
+    :param id: The id of the RunParameters record.
+    :return: The RunParameters with the specified id.
+    """
+    stmt = select(RunParameters).where(RunParameters.id == id)
+    result = await session.execute(stmt)
+    return result.first()
+
+
 async def get_high_hfi_area(session: AsyncSession, run_type: RunTypeEnum, run_datetime: datetime, for_date: date) -> List[Row]:
     """For each fire zone, get the area of HFI polygons in that zone that fall within the
     4000 - 10000 range and the area of HFI polygons that exceed the 10000 threshold.


### PR DESCRIPTION
The fuel grid raster doesn't differentiate between O1A and O1B fuel types, it combines them as O1A/O1B. This joint fuel type doesn't exist in our FuelTypeEnum. Being unsure of the ramifications with cffdrs, after discussion with the PO we are treating O1A/O1B as O1B for the sake of calculating critical hours.

This PR also adds the ability to re-run critical hours processing by supplying a RunParameters.id.
# Test Links:
[Landing Page](https://wps-pr-3946-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3946-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3946-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3946-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3946-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3946-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3946-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3946-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
