### PR TITLE
Fix critical hours when O1A/O1B present

### DIFF
--- a/api/app/db/crud/auto_spatial_advisory.py
+++ b/api/app/db/crud/auto_spatial_advisory.py
@@ -298,6 +298,19 @@ async def get_most_recent_run_parameters(session: AsyncSession, run_type: RunTyp
     return result.first()
 
 
+async def get_run_parameters_by_id(session: AsyncSession, id: int) -> RunParameters:
+    """
+    Retrieve the RunParameters record with the specified id.
+
+    :param session: Async database session.
+    :param id: The id of the RunParameters record.
+    :return: The RunParameters with the specified id.
+    """
+    stmt = select(RunParameters).where(RunParameters.id == id)
+    result = await session.execute(stmt)
+    return result.first()
+
+
 async def get_high_hfi_area(session: AsyncSession, run_type: RunTypeEnum, run_datetime: datetime, for_date: date) -> List[Row]:
     """For each fire zone, get the area of HFI polygons in that zone that fall within the
     4000 - 10000 range and the area of HFI polygons that exceed the 10000 threshold.


### PR DESCRIPTION
The fuel grid raster doesn't differentiate between O1A and O1B fuel types, it combines them as O1A/O1B. This joint fuel type doesn't exist in our FuelTypeEnum. Being unsure of the ramifications with cffdrs, after discussion with the PO we are treating O1A/O1B as O1B for the sake of calculating critical hours.

This PR also adds the ability to re-run critical hours processing by supplying a RunParameters.id.