### PR TITLE
Store incomplete rows in drafts

### DIFF
--- a/web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -343,23 +343,17 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
   /********** End useEffects for managing visibility of column groups *************/
 
   const updateColumnHelper = (editedRows: MoreCast2Row[]) => {
-    // Create a copy of all Morecast2ForecastRows
-    let newRows = cloneDeep(allRows)
-    newRows = newRows.map(newRow => editedRows.find(row => row.id === newRow.id) || newRow)
-
-    const rowsForSimulation = filterAllVisibleRowsForSimulation(editedRows) ?? []
-
     // Create a copy of editedRows which will be stored as a draft
     let draftRows = cloneDeep(editedRows)
+    const rowsForSimulation = filterAllVisibleRowsForSimulation(editedRows) ?? []
 
     if (rowsForSimulation.length > 0) {
       const filteredRowsWithIndices = simulateFireWeatherIndices(rowsForSimulation)
-      // Merge the copy of allRows with rows that were updated with simulated indices
-      newRows = newRows.map(newRow => filteredRowsWithIndices.find(row => row.id === newRow.id) || newRow)
-      // Merge the draftRows with the rows that were updated with simulated indices
-      draftRows = draftRows.map(draftRow => filteredRowsWithIndices.find(row => row.id === draftRow.id) || draftRow)
+      draftRows = draftRows.map(newRow => filteredRowsWithIndices.find(row => row.id === newRow.id) || newRow)
     }
     storedDraftForecast.updateStoredDraftForecasts(draftRows, getDateTimeNowPST())
+    let newRows = cloneDeep(allRows)
+    newRows = newRows.map(newRow => draftRows.find(row => row.id === newRow.id) || newRow)
     setAllRows(newRows)
   }
 
@@ -508,7 +502,7 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
     storedDraftForecast.updateStoredDraftForecasts(filledRows, getDateTimeNowPST())
     let newRows = cloneDeep(allRows)
     // Merge the copy of existing rows with rows that were updated with simulated indices
-    newRows = newRows.map(newRow => filteredRowsWithIndices.find(row => row.id === newRow.id) || newRow)
+    newRows = newRows.map(newRow => filledRows.find(row => row.id === newRow.id) || newRow)
     setAllRows(newRows)
     return newRow
   }


### PR DESCRIPTION
This PR makes sure that all edited rows get stored, not just edited rows with simulated FWIs.
# Test Links:
[Landing Page](https://wps-pr-3960-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3960-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3960-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3960-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3960-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3960-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3960-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3960-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
