### PR TITLE
Add nil check for null or undefined before posting to FireBat API

### DIFF
--- a/web/src/features/fbaCalculator/slices/fbaCalculatorSlice.ts
+++ b/web/src/features/fbaCalculator/slices/fbaCalculatorSlice.ts
@@ -4,7 +4,7 @@ import { FBAStation, FBAWeatherStationsResponse, postFBAStations } from 'api/fba
 import { AppThunk } from 'app/store'
 import { logError } from 'utils/error'
 import { FuelTypes } from '../fuelTypes'
-import { isEmpty, isEqual, isNil, isNull, isUndefined } from 'lodash'
+import { isEmpty, isNil } from 'lodash'
 import { FBATableRow } from 'features/fbaCalculator/RowManager'
 import { DateTime } from 'luxon'
 import { PST_UTC_OFFSET } from 'utils/constants'

--- a/web/src/features/fbaCalculator/slices/fbaCalculatorSlice.ts
+++ b/web/src/features/fbaCalculator/slices/fbaCalculatorSlice.ts
@@ -4,7 +4,7 @@ import { FBAStation, FBAWeatherStationsResponse, postFBAStations } from 'api/fba
 import { AppThunk } from 'app/store'
 import { logError } from 'utils/error'
 import { FuelTypes } from '../fuelTypes'
-import { isEmpty, isEqual, isNull, isUndefined } from 'lodash'
+import { isEmpty, isEqual, isNil, isNull, isUndefined } from 'lodash'
 import { FBATableRow } from 'features/fbaCalculator/RowManager'
 import { DateTime } from 'luxon'
 import { PST_UTC_OFFSET } from 'utils/constants'
@@ -60,12 +60,7 @@ export const fetchFireBehaviourStations =
   async dispatch => {
     const fetchableFireStations = fbcInputRows.flatMap(row => {
       const fuelTypeDetails = FuelTypes.lookup(row.fuelType?.value)
-      if (
-        isNull(fuelTypeDetails) ||
-        isUndefined(fuelTypeDetails) ||
-        isUndefined(row.weatherStation) ||
-        isEqual(row.weatherStation, 'undefined')
-      ) {
+      if (isNil(fuelTypeDetails) || isNil(row.weatherStation)) {
         return []
       }
       return {


### PR DESCRIPTION
We had a null or undefined check for `fuelTypeDetails` but not for `weatherStation`. Replaces all checks with `isNil` to check for null and undefined.
# Test Links:
[Landing Page](https://wps-pr-3961-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3961-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3961-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3961-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3961-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3961-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3961-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3961-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
