### PR TITLE
Add no cache header to morecast -> WF1 requests 

### DIFF
--- a/api/app/morecast_v2/forecasts.py
+++ b/api/app/morecast_v2/forecasts.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from app.db.crud.morecast_v2 import get_forecasts_in_range
 from app.schemas.morecast_v2 import MoreCastForecastOutput, MoreCastForecastInput, StationDailyFromWF1, WF1ForecastRecordType, WF1PostForecast, WeatherIndeterminate, WeatherDeterminate
 from app.wildfire_one.schema_parsers import WFWXWeatherStation
-from app.wildfire_one.wfwx_api import get_auth_header, get_forecasts_for_stations_by_date_range, get_wfwx_stations_from_station_codes
+from app.wildfire_one.wfwx_api import get_forecasts_for_stations_by_date_range, get_no_cache_auth_header, get_wfwx_stations_from_station_codes
 from app.fire_behaviour import cffdrs
 
 
@@ -61,7 +61,7 @@ def construct_wf1_forecast(forecast: MoreCastForecastInput, stations: List[WFWXW
 
 async def construct_wf1_forecasts(session: ClientSession, forecast_records: List[MoreCastForecastInput], stations: List[WFWXWeatherStation], username: str) -> List[WF1PostForecast]:
     # Fetch existing forecasts from WF1 for the stations and date range in the forecast records
-    header = await get_auth_header(session)
+    header = await get_no_cache_auth_header(session)
     forecast_dates = [datetime.fromtimestamp(f.for_date / 1000, timezone.utc) for f in forecast_records]
     min_forecast_date = min(forecast_dates)
     max_forecast_date = max(forecast_dates)

--- a/api/app/wildfire_one/wfwx_api.py
+++ b/api/app/wildfire_one/wfwx_api.py
@@ -67,6 +67,15 @@ async def get_auth_header(session: ClientSession) -> dict:
     return header
 
 
+async def get_no_cache_auth_header(session: ClientSession) -> dict:
+    """Get WFWX auth header with explicit no caching"""
+    # Fetch auth header
+    header = await get_auth_header(session)
+    # Add the cache control header
+    header["Cache-Control"] = "no-cache"
+    return header
+
+
 async def get_stations_by_codes(station_codes: List[int]) -> List[WeatherStation]:
     """Get a list of stations by code, from WFWX Fireweather API."""
     logger.info("Using WFWX to retrieve stations by code")


### PR DESCRIPTION
Adds no cache header to morecast -> WF1 requests to eliminate possibility of cached forecasts where we need the most up to date data.
# Test Links:
[Landing Page](https://wps-pr-3971-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3971-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3971-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3971-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3971-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3971-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3971-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3971-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
