### PR TITLE
24 hour precip diff issue

### DIFF
--- a/api/app/weather_models/precip_rdps_model.py
+++ b/api/app/weather_models/precip_rdps_model.py
@@ -91,9 +91,9 @@ async def generate_24_hour_accumulating_precip_raster(timestamp: datetime):
     """
     (yesterday_key, today_key) = get_raster_keys_to_diff(timestamp)
     (day_data, day_geotransform, day_projection) = await read_into_memory(today_key)
+    if day_data is None:
+        raise ValueError("No precip raster data for today_key: %s" % today_key)
     if yesterday_key is None:
-        if day_data is None:
-            raise ValueError("No precip raster data for %s" % today_key)
         return (day_data, day_geotransform, day_projection)
 
     yesterday_time = timestamp - timedelta(days=1)

--- a/api/app/weather_models/precip_rdps_model.py
+++ b/api/app/weather_models/precip_rdps_model.py
@@ -99,7 +99,7 @@ async def generate_24_hour_accumulating_precip_raster(timestamp: datetime):
     yesterday_time = timestamp - timedelta(days=1)
     (yesterday_data, _, _) = await read_into_memory(yesterday_key)
     if yesterday_data is None:
-        raise ValueError("No precip raster data for %s" % yesterday_key)
+        raise ValueError("No precip raster data for yesterday_key: %s" % yesterday_key)
 
     later_precip = TemporalPrecip(timestamp=timestamp, precip_amount=day_data)
     earlier_precip = TemporalPrecip(timestamp=yesterday_time, precip_amount=yesterday_data)


### PR DESCRIPTION
After a review of logs I believe we are in a race with the ECCC as they upload RDPS data for the most recent model run and we try to download it. We try to download 36 hours worth of gribs when only a subset of those files may be available.

I'm moving a `None` check to confirm this is the case.

If this is the case, I think it is an expected behaviour and we will have to add some logic to handle the partial download of a set of precip grib files.
# Test Links:
[Landing Page](https://wps-pr-3989-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3989-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3989-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3989-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3989-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3989-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3989-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3989-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
