### PR TITLE
Handle missing RDPS data

### DIFF
--- a/api/app/tests/weather_models/test_precip_rdps_model.py
+++ b/api/app/tests/weather_models/test_precip_rdps_model.py
@@ -75,13 +75,15 @@ async def test_generate_24_hour_accumulating_precip_raster_model_hour_ok(mocker:
     ],
 )
 @pytest.mark.anyio
-async def test_generate_24_hour_accumulating_precip_raster_fail(current_time: datetime, today_raster: np.ndarray, yesterday_raster: np.ndarray, mocker: MockerFixture):
+async def test_generate_24_hour_accumulating_precip_raster_no_today_raster(current_time: datetime, today_raster: np.ndarray, yesterday_raster: np.ndarray, mocker: MockerFixture):
     """
     Verify that the appropriate rasters are diffed correctly.
     """
     mocker.patch("app.weather_models.precip_rdps_model.read_into_memory", side_effect=[today_raster, yesterday_raster])
-    with pytest.raises(ValueError):
-        await generate_24_hour_accumulating_precip_raster(current_time)
+    (day_data, day_geotransform, day_projection) = await generate_24_hour_accumulating_precip_raster(current_time)
+    assert day_data is None
+    assert day_geotransform is None
+    assert day_projection is None
 
 
 @pytest.mark.parametrize(

--- a/api/app/tests/weather_models/test_precip_rdps_model.py
+++ b/api/app/tests/weather_models/test_precip_rdps_model.py
@@ -161,7 +161,6 @@ async def return_none_tuple(timestamp: datetime):
 
 @patch("app.weather_models.precip_rdps_model.generate_24_hour_accumulating_precip_raster", return_none_tuple)
 @pytest.mark.anyio
-async def test_compute_and_store_precip_rasters_no_today_data(caplog):
+async def test_compute_and_store_precip_rasters_no_today_data_does_not_throw():
     timestamp = datetime.fromisoformat("2024-06-10T18:42:49+00:00")
     await compute_and_store_precip_rasters(timestamp)
-    assert "No precip raster data for hour:" in caplog.text


### PR DESCRIPTION
We run an hourly cron job and often run into a situation where our cron job kicks off and starts downloading RDPS precip gribs before the ECCC has finished uploading them. When this happens we don't have the data we need to subtract precip rasters. This is expected behaviour and we now simply exit and pick things up during the next cron job when ECCC has finished uploading the precip gribs.
# Test Links:
[Landing Page](https://wps-pr-3996-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-3996-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-3996-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-3996-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-3996-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-3996-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-3996-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-3996-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
