### PR TITLE
RDPS precip dif can't be negative

### DIFF
--- a/api/app/tests/weather_models/test_precip_rdps_model.py
+++ b/api/app/tests/weather_models/test_precip_rdps_model.py
@@ -25,6 +25,28 @@ def test_difference_identity():
     assert np.allclose(res, np.zeros(precip_raster.shape))
 
 
+def test_negative_precip_diff_raises_value_error():
+    """
+    Verify ValueError raised if raster subtraction contains a negative value.
+    """
+    later_precip = TemporalPrecip(datetime.fromisoformat("2024-06-10T18:42:49"), np.zeros(1))
+    earlier_precip = TemporalPrecip(datetime.fromisoformat("2024-06-09T18:42:49"), np.ones(1))
+    with pytest.raises(ValueError):
+        compute_precip_difference(later_precip, earlier_precip)
+
+
+def test_trivial_negative_precip_diff_returns_zero():
+    """
+    Verify that a negative precip dif between -0.01 and 0 returns 0.
+    """
+    early_array = np.empty(1)
+    early_array[0] = 0.005
+    later_precip = TemporalPrecip(datetime.fromisoformat("2024-06-10T18:42:49"), np.zeros(1))
+    earlier_precip = TemporalPrecip(datetime.fromisoformat("2024-06-09T18:42:49"), early_array)
+    result = compute_precip_difference(later_precip, earlier_precip)
+    assert result[0] == 0
+
+
 @pytest.mark.parametrize(
     "later_datetime,earlier_datetime",
     [

--- a/api/app/weather_models/precip_rdps_model.py
+++ b/api/app/weather_models/precip_rdps_model.py
@@ -137,7 +137,18 @@ def compute_precip_difference(later_precip: TemporalPrecip, earlier_precip: Temp
 
 
 def _diff(value_a: float, value_b: float):
-    return value_a - value_b
+    """
+    Subtract value_a from value_b.
+    :param value_a: _description_
+    :param value_b: _description_
+    :raises ValueError: If difference is less than -0.01 (ie. negative precip not allowed)
+    :return: Return value_a minus value_b if the value is >= 0. If the difference is slightly negative (-0.01 <= value < 0), due to floating
+    point math for example, return 0. If the value is truly negative, raise an error.
+    """
+    result = value_a - value_b
+    if result < -0.01:
+        raise ValueError("Precip difference cannot be negative")
+    return result if result > 0 else 0
 
 
 vectorized_diff = vectorize(_diff)

--- a/api/app/weather_models/precip_rdps_model.py
+++ b/api/app/weather_models/precip_rdps_model.py
@@ -143,7 +143,7 @@ def compute_precip_difference(later_precip: TemporalPrecip, earlier_precip: Temp
 def _diff(value_a: float, value_b: float):
     """
     Subtract value_a from value_b.
-    :param value_a: _description_
+    :param value_a: The first value
     :param value_b: _description_
     :raises ValueError: If difference is less than -0.01 (ie. negative precip not allowed)
     :return: Return value_a minus value_b if the value is >= 0. If the difference is slightly negative (-0.01 <= value < 0), due to floating

--- a/api/app/weather_models/precip_rdps_model.py
+++ b/api/app/weather_models/precip_rdps_model.py
@@ -144,7 +144,7 @@ def _diff(value_a: float, value_b: float):
     """
     Subtract value_a from value_b.
     :param value_a: The first value
-    :param value_b: _description_
+    :param value_b: The second value
     :raises ValueError: If difference is less than -0.01 (ie. negative precip not allowed)
     :return: Return value_a minus value_b if the value is >= 0. If the difference is slightly negative (-0.01 <= value < 0), due to floating
     point math for example, return 0. If the value is truly negative, raise an error.


### PR DESCRIPTION
Adding a check to determine if precip is negative. There are three possibilities:
1. Precip is >= 0 -- return the calculated value
2. Precip is -0.01 < value < 0 -- return 0, the negative is due to floating point math
3. Precip is < -0.01 -- something has gone wrong, throw an error

Closes #3753

# Test Links:
[Landing Page](https://wps-pr-4001-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4001-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4001-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4001-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4001-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4001-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4001-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4001-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
