### PR TITLE
Grant create to crunchydb user

### DIFF
--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -63,10 +63,10 @@ objects:
       init.sql: |-
         \c wps\\
         CREATE EXTENSION postgis;
-        GRANT CREATE ON SCHEMA public TO ${APP_NAME}-16-${SUFFIX};
+        GRANT CREATE ON SCHEMA public TO ${APP_NAME}-${SUFFIX}
     kind: ConfigMap
     metadata:
-      name: wps-init-sql
+      name: wps-init-sql-${SUFFIX}
   - apiVersion: postgres-operator.crunchydata.com/v1beta1
     kind: PostgresCluster
     metadata:
@@ -80,7 +80,7 @@ objects:
           app: ${APP_NAME}-${SUFFIX}
       databaseInitSQL:
         key: init.sql
-        name: wps-init-sql
+        name: wps-init-sql-${SUFFIX}
       users:
         - name: ${APP_NAME}-${SUFFIX}
           databases:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -63,6 +63,7 @@ objects:
       init.sql: |-
         \c wps\\
         CREATE EXTENSION postgis;
+        GRANT CREATE ON SCHEMA public TO ${APP_NAME}-16-${SUFFIX};
     kind: ConfigMap
     metadata:
       name: wps-init-sql


### PR DESCRIPTION
As of pg15 you have explicitly grant privileges to the public schema. This is necessary for alembic to run its migrations.
# Test Links:
[Landing Page](https://wps-pr-4101-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4101-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4101-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4101-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4101-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4101-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4101-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4101-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
