### PR TITLE
Increase s3-backup job timeout

### DIFF
--- a/openshift/templates/backup-s3-postgres-cronjob.yaml
+++ b/openshift/templates/backup-s3-postgres-cronjob.yaml
@@ -166,7 +166,7 @@ objects:
                           key: object-store-bucket
               restartPolicy: "Never"
               terminationGracePeriodSeconds: 30
-              activeDeadlineSeconds: 2700
+              activeDeadlineSeconds: 3000
               dnsPolicy: "ClusterFirst"
               serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
               serviceAccount: "${JOB_SERVICE_ACCOUNT}"


### PR DESCRIPTION
Increase s3-backup cronjob timeout from ~26 min to 60 min.