### PR TITLE
Add IF EXISTs clause for partitioned and mat view tables

### DIFF
--- a/api/alembic/versions/4014ddf1f874_partition_weather_station_model_.py
+++ b/api/alembic/versions/4014ddf1f874_partition_weather_station_model_.py
@@ -17,8 +17,8 @@ depends_on = None
 
 def upgrade():
     # ### drop table that's now partitioned ###
-    op.execute("DROP MATERIALIZED VIEW morecast_2_materialized_view")
-    op.drop_table("weather_station_model_predictions_retired")
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS morecast_2_materialized_view")
+    op.drop_table("weather_station_model_predictions_retired", if_exists=True)
 
 
 def downgrade():


### PR DESCRIPTION
So that dev deployments that aren't partitioned can run 
# Test Links:
[Landing Page](https://wps-pr-4133-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4133-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4133-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4133-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4133-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4133-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4133-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4133-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
