### PR TITLE
Standby cluster update

### DIFF
--- a/openshift/s3-backup/docker/backup_to_s3.sh
+++ b/openshift/s3-backup/docker/backup_to_s3.sh
@@ -76,7 +76,7 @@ _target_folder="${PG_HOSTNAME}_${PG_DATABASE}/${_datestamp}"
 # Using the official aws cli to upload the database back to S3:
 # pg_dump | gzip | aws s3:
 # this is tested and works.
-PGPASSWORD="${PG_PASSWORD}" pg_dump -Fp -h "${PG_HOSTNAME}" -p ${PG_PORT} -U "${PG_USER}" "${PG_DATABASE}" | gzip | AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_KEY}" aws --endpoint="https://${AWS_HOSTNAME}" s3 cp - "s3://${AWS_BUCKET}/backup/${_target_folder}/${_target_filename}"
+PGPASSWORD="${PG_PASSWORD}" pg_dump -Fp -h --no-owner "${PG_HOSTNAME}" -p ${PG_PORT} -U "${PG_USER}" "${PG_DATABASE}" | gzip | AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY}" AWS_SECRET_ACCESS_KEY="${AWS_SECRET_KEY}" aws --endpoint="https://${AWS_HOSTNAME}" s3 cp - "s3://${AWS_BUCKET}/backup/${_target_folder}/${_target_filename}"
 
 # Run python code to prune old backups.
 python3 prune.py

--- a/openshift/templates/crunchy_standby.yaml
+++ b/openshift/templates/crunchy_standby.yaml
@@ -62,8 +62,8 @@ objects:
     metadata:
       name: wps-crunchydb-standby
     spec:
-      postgresVersion: 14
-      postGISVersion: "3.2"
+      postgresVersion: 16
+      postGISVersion: "3.3"
       metadata:
         name: wps-crunchydb-standby
         labels:


### PR DESCRIPTION
 - Change postgres version to 16
 - Change PostGIS version to 3.3
 - Add `--no-owner` flag on pg_dump to S3 storage to prevent errors when restoring a dump to a cluster with a different user. Ownership is set according to the role/user doing the restore.