### PR TITLE
Switch to version 2 of snow data

### DIFF
--- a/api/app/jobs/viirs_snow.py
+++ b/api/app/jobs/viirs_snow.py
@@ -23,11 +23,9 @@ logger = logging.getLogger(__name__)
 
 BC_BOUNDING_BOX = "-139.06,48.3,-114.03,60"
 NSIDC_URL = "https://n5eil02u.ecs.nsidc.org/egi/request"
-PRODUCT_VERSION = 1
+PRODUCT_VERSION = 2
 SHORT_NAME = "VNP10A1F"
-# Leaving this here for when we switch to version 2 eventually
-# LAYER_VARIABLE = "/VIIRS_Grid_IMG_2D/CGF_NDSI_Snow_Cover"
-LAYER_VARIABLE = "/NPP_Grid_IMG_2D/CGF_NDSI_Snow_Cover"
+LAYER_VARIABLE = "/VIIRS_Grid_IMG_2D/CGF_NDSI_Snow_Cover"
 RAW_SNOW_COVERAGE_NAME = 'raw_snow_coverage.tif'
 RAW_SNOW_COVERAGE_CLIPPED_NAME = 'raw_snow_coverage_clipped.tif'
 BINARY_SNOW_COVERAGE_CLASSIFICATION_NAME = 'binary_snow_coverage.tif'
@@ -234,8 +232,11 @@ class ViirsSnowJob():
         last_processed_date = await self._get_last_processed_date()
         today = date.today()
         if last_processed_date is None:
-            # Case to cover the initial run of VIIRS snow processing (ie. start processing one week ago)
-            next_date = today - timedelta(days=7)
+            # Case to cover the initial run of VIIRS snow processing (ie. start processing yesterday)
+            next_date = today - timedelta(days=1)
+        elif today - last_processed_date > timedelta(days=14):
+            # Jan 13, 2025 - Start gathering snow data from the start of 2025 give or take a day
+            next_date = today - timedelta(days=14)
         else:
             # Start processing the day after the last record of a successful job.
             next_date = last_processed_date + timedelta(days=1)


### PR DESCRIPTION
- start using version 2 of snow coverage data (v1 is discontinued)
- add a date check which will effectively start snow processing in prod around Jan 1, 2025
# Test Links:
[Landing Page](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[PSU Insights](https://wps-pr-4198-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
