### PR TITLE
Bump pgbackrest to 2.53.1

### DIFF
--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -113,7 +113,7 @@ objects:
             storageClassName: netapp-block-standard
       backups:
         pgbackrest:
-          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:ubi8-2.41-4
+          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest/ubi8-2.53.1-1
           manual:
             repoName: repo1
             options:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -113,7 +113,7 @@ objects:
             storageClassName: netapp-block-standard
       backups:
         pgbackrest:
-          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest/ubi8-2.53.1-1
+          image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:ubi8-2.53.1-1
           manual:
             repoName: repo1
             options:


### PR DESCRIPTION
2.53.1 is the latest version available in artifactory and notes up to pg17 support here: https://pgbackrest.org/release.html

# Test Links:
[Landing Page](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[PSU Insights](https://wps-pr-4212-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
