### PR TITLE
Call item() on np.float64 to properly store floats with sqlalchemy

### DIFF
--- a/api/app/jobs/common_model_fetchers.py
+++ b/api/app/jobs/common_model_fetchers.py
@@ -173,6 +173,10 @@ def accumulate_nam_precipitation(nam_cumulative_precip: float, prediction: Model
     if prediction.prediction_timestamp.hour % nam_accumulation_interval == 0:
         # If we're on an 'accumulation interval', update the cumulative precip
         cumulative_precip = current_precip
+
+    cumulative_precip = cumulative_precip.item() if isinstance(cumulative_precip, np.float64) else cumulative_precip
+    current_precip = current_precip.item() if isinstance(current_precip, np.float64) else current_precip
+
     return (cumulative_precip, current_precip)
 
 
@@ -262,7 +266,8 @@ class ModelValueProcessor:
         if prediction.tmp_tgl_2 is None:
             logger.warning("tmp_tgl_2 is None for ModelRunPrediction.id == %s", prediction.id)
         else:
-            station_prediction.tmp_tgl_2 = prediction.tmp_tgl_2
+            temp = prediction.tmp_tgl_2.item() if isinstance(prediction.tmp_tgl_2, np.float64) else prediction.tmp_tgl_2
+            station_prediction.tmp_tgl_2 = temp
 
         # 2020 Dec 10, Sybrand: Encountered situation where rh_tgl_2 was None, add this workaround for it.
         # NOTE: Not sure why this value would ever be None. This could happen if for whatever reason, the
@@ -272,13 +277,15 @@ class ModelValueProcessor:
             logger.warning("rh_tgl_2 is None for ModelRunPrediction.id == %s", prediction.id)
             station_prediction.rh_tgl_2 = None
         else:
-            station_prediction.rh_tgl_2 = prediction.rh_tgl_2
+            rh = prediction.rh_tgl_2.item() if isinstance(prediction.rh_tgl_2, np.float64) else prediction.rh_tgl_2
+            station_prediction.rh_tgl_2 = rh
         # Check that apcp_sfc_0 is None, since accumulated precipitation
         # does not exist for 00 hour.
         if prediction.apcp_sfc_0 is None:
-            station_prediction.apcp_sfc_0 = 0.0
+            station_prediction.apcp_sfc_0 = float(0.0)
         else:
-            station_prediction.apcp_sfc_0 = prediction.apcp_sfc_0.item() if isinstance(prediction.apcp_sfc_0, np.float64) else prediction.apcp_sfc_0
+            apcp = prediction.apcp_sfc_0.item() if isinstance(prediction.apcp_sfc_0, np.float64) else prediction.apcp_sfc_0
+            station_prediction.apcp_sfc_0 = apcp
         # Calculate the delta_precipitation and 24 hour precip based on station's previous prediction_timestamp
         # for the same model run
         self.session.flush()
@@ -287,10 +294,12 @@ class ModelValueProcessor:
 
         # Get the closest wind speed
         if prediction.wind_tgl_10 is not None:
-            station_prediction.wind_tgl_10 = prediction.wind_tgl_10
+            wind_tgl_10 = prediction.wind_tgl_10.item() if isinstance(prediction.wind_tgl_10, np.float64) else prediction.wind_tgl_10
+            station_prediction.wind_tgl_10 = wind_tgl_10
         # Get the closest wind direcion
         if prediction.wdir_tgl_10 is not None:
-            station_prediction.wdir_tgl_10 = prediction.wdir_tgl_10
+            wdir_tgl_10 = prediction.wdir_tgl_10.item() if isinstance(prediction.wdir_tgl_10, np.float64) else prediction.wdir_tgl_10
+            station_prediction.wdir_tgl_10 = wdir_tgl_10
 
         if prediction_is_interpolated:
             # Dealing with a numerical weather model that only has predictions at 3 hour intervals,

--- a/api/app/jobs/common_model_fetchers.py
+++ b/api/app/jobs/common_model_fetchers.py
@@ -5,6 +5,7 @@ import requests
 import numpy
 from datetime import datetime, timedelta, timezone
 from pyproj import Geod
+import numpy as np
 from sqlalchemy.orm import Session
 from app.db.crud.weather_models import (
     get_processed_file_record,
@@ -277,7 +278,7 @@ class ModelValueProcessor:
         if prediction.apcp_sfc_0 is None:
             station_prediction.apcp_sfc_0 = 0.0
         else:
-            station_prediction.apcp_sfc_0 = prediction.apcp_sfc_0
+            station_prediction.apcp_sfc_0 = prediction.apcp_sfc_0.item() if isinstance(prediction.apcp_sfc_0, np.float64) else prediction.apcp_sfc_0
         # Calculate the delta_precipitation and 24 hour precip based on station's previous prediction_timestamp
         # for the same model run
         self.session.flush()

--- a/api/app/weather_models/process_grib.py
+++ b/api/app/weather_models/process_grib.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 import math
-import struct
 import logging
 import logging.config
 from typing import List, Tuple, Optional
@@ -10,6 +9,7 @@ from sqlalchemy.orm import Session
 from osgeo import gdal
 from pyproj import CRS, Transformer
 from affine import Affine
+import numpy as np
 from app.geospatial import NAD83_CRS
 from app.stations import get_stations_synchronously
 from app.db.models.weather_models import ModelRunPrediction, PredictionModel, PredictionModelRunTimestamp
@@ -192,6 +192,7 @@ class GribFileProcessor:
             prediction.station_code = station_code
 
         variable_name = self.get_variable_name(grib_info)
+        value = value.item() if isinstance(value, np.float64) else value
         setattr(prediction, variable_name, value)
         session.add(prediction)
         session.commit()


### PR DESCRIPTION
Since the numpy 2.0 upgrade, some of our floats for model processing are being passed as `np.float64`. This PR checks if the value we're about to store is a `np.float64` and if so converts it to the standard Python float via `item()`: https://numpy.org/doc/2.1/reference/generated/numpy.ndarray.item.html#numpy.ndarray.item
# Test Links:
[Landing Page](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[PSU Insights](https://wps-pr-4228-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
