### PR TITLE
Cached PMTiles for ASA Go

### DIFF
--- a/mobile/asa-go/capacitor.config.ts
+++ b/mobile/asa-go/capacitor.config.ts
@@ -1,7 +1,7 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
-  appId: 'io.ionic.starter',
+  appId: 'ca.bc.gov.asago',
   appName: 'asa-go',
   webDir: 'dist'
 };

--- a/mobile/asa-go/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/asa-go/ios/App/App.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 		A084ECDBA7D38E1E42DFC39D /* Pods_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */; };
+		4309C9DBE16C4DF38D493C6C /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1E60787A749448FB8E269E5A /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.release.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.release.xcconfig"; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
+		1E60787A749448FB8E269E5A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; name = "PrivacyInfo.xcprivacy"; path = "PrivacyInfo.xcprivacy"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 				504EC3051FED79650016851F /* Products */,
 				7F8756D8B27F46E3366F6CEA /* Pods */,
 				27E2DDA53C4D2A4D1A88CE4A /* Frameworks */,
+				1E60787A749448FB8E269E5A /* Resources */,
 			);
 			sourceTree = "<group>";
 		};
@@ -94,6 +97,15 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		6ACB91DE59924FB1809508A1 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				1E60787A749448FB8E269E5A /* PrivacyInfo.xcprivacy */,
+			);
+			name = Resources;
+			path = undefined;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -122,8 +134,8 @@
 		504EC2FC1FED79650016851F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0920;
+				LastSwiftUpdateCheck = 920;
+				LastUpgradeCheck = 920;
 				TargetAttributes = {
 					504EC3031FED79650016851F = {
 						CreatedOnToolsVersion = 9.2;
@@ -163,6 +175,7 @@
 				50379B232058CBB4000EE86E /* capacitor.config.json in Resources */,
 				504EC30D1FED79650016851F /* Main.storyboard in Resources */,
 				2FAD9763203C412B000D30F8 /* config.xml in Resources */,
+				4309C9DBE16C4DF38D493C6C /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -354,7 +367,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
-				PRODUCT_BUNDLE_IDENTIFIER = io.ionic.starter;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.asago;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
@@ -373,7 +386,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = io.ionic.starter;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.bc.gov.asago;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;

--- a/mobile/asa-go/ios/App/App/Info.plist
+++ b/mobile/asa-go/ios/App/App/Info.plist
@@ -30,6 +30,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>Your app requires access to the Documents folder for file management.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/mobile/asa-go/ios/App/Podfile
+++ b/mobile/asa-go/ios/App/Podfile
@@ -12,6 +12,7 @@ def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
+  pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'

--- a/mobile/asa-go/ios/App/Podfile.lock
+++ b/mobile/asa-go/ios/App/Podfile.lock
@@ -4,6 +4,8 @@ PODS:
   - CapacitorApp (7.0.0):
     - Capacitor
   - CapacitorCordova (7.0.0)
+  - CapacitorFilesystem (7.0.0):
+    - Capacitor
   - CapacitorHaptics (7.0.0):
     - Capacitor
   - CapacitorKeyboard (7.0.0):
@@ -15,6 +17,7 @@ DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
+  - "CapacitorFilesystem (from `../../node_modules/@capacitor/filesystem`)"
   - "CapacitorHaptics (from `../../node_modules/@capacitor/haptics`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
@@ -26,6 +29,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/app"
   CapacitorCordova:
     :path: "../../node_modules/@capacitor/ios"
+  CapacitorFilesystem:
+    :path: "../../node_modules/@capacitor/filesystem"
   CapacitorHaptics:
     :path: "../../node_modules/@capacitor/haptics"
   CapacitorKeyboard:
@@ -37,10 +42,11 @@ SPEC CHECKSUMS:
   Capacitor: fcbee427ff437f414bbb3bc2d39364ad9bd2b8a5
   CapacitorApp: 45cb7cbef4aa380b9236fd6980033eb5cde6fcd2
   CapacitorCordova: 345f93b7edd121db98e4ec20ac94d6d7bcaf7e48
+  CapacitorFilesystem: 2881ad012b5c8d0ffbfed1216aadfc2cca16d5b5
   CapacitorHaptics: 1fba3e460e7614349c6d5f868b1fccdc5c87b66d
   CapacitorKeyboard: 2c26c6fccde35023c579fc37d4cae6326d5e6343
   CapacitorStatusBar: 438e90beeeefa8276b24e6c5991cb02dd13e51bf
 
-PODFILE CHECKSUM: f8c95c38f42283ff8d7c6bf6fa1435ecdce85ae9
+PODFILE CHECKSUM: 57f6d064c0cf78e8c1949d60532f6d3d30cc6578
 
 COCOAPODS: 1.16.2

--- a/mobile/asa-go/ios/App/PrivacyInfo.xcprivacy
+++ b/mobile/asa-go/ios/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>C617.1</string>
+        </array>
+      </dict>
+    </array>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+  </dict>
+</plist>

--- a/mobile/asa-go/package.json
+++ b/mobile/asa-go/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test": "vitest",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -30,20 +31,25 @@
     "ol-pmtiles": "^2.0.0",
     "pmtiles": "^4.2.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "vitest": "^3.0.5"
   },
   "devDependencies": {
     "@capacitor/cli": "7.0.0",
     "@eslint/js": "^9.17.0",
+    "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.14",
     "@types/luxon": "^3.4.2",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
+    "@types/sinon": "^17.0.3",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "eslint": "^9.17.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
+    "jsdom": "^26.0.0",
+    "sinon": "^19.0.2",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5"

--- a/mobile/asa-go/package.json
+++ b/mobile/asa-go/package.json
@@ -10,9 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@capacitor/android": "^7.0.0",
+    "@capacitor/android": "7.0.0",
     "@capacitor/app": "7.0.0",
     "@capacitor/core": "7.0.0",
+    "@capacitor/filesystem": "^7.0.0",
     "@capacitor/haptics": "7.0.0",
     "@capacitor/ios": "7.0.0",
     "@capacitor/keyboard": "7.0.0",
@@ -27,6 +28,7 @@
     "luxon": "^3.5.0",
     "ol": "^10.3.1",
     "ol-pmtiles": "^2.0.0",
+    "pmtiles": "^4.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -1,28 +1,18 @@
 import { useState } from "react";
 import { Box } from "@mui/material";
 
-import { DateTime } from "luxon";
 import FBAMap from "@/FBAMap";
-import { FireCenter, FireShape, RunType } from "@/api/fbaAPI";
-import { PST_UTC_OFFSET } from "@/utils/constants";
+import { FireCenter, FireShape } from "@/api/fbaAPI";
 import { AppHeader } from "@/AppHeader";
 import { ASATabs } from "@/ASATabs";
 
 const App = () => {
   const [fireCenter] = useState<FireCenter | undefined>(undefined);
 
-  const [selectedFireShape, setSelectedFireShape] = useState<
-    FireShape | undefined
-  >(undefined);
-  const [zoomSource, setZoomSource] = useState<
-    "fireCenter" | "fireShape" | undefined
-  >("fireCenter");
-  const [dateOfInterest] = useState(
-    DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`).hour < 13
-      ? DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`)
-      : DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`).plus({ days: 1 })
+  const [selectedFireShape] = useState<FireShape | undefined>(undefined);
+  const [zoomSource] = useState<"fireCenter" | "fireShape" | undefined>(
+    "fireCenter"
   );
-  const [runType] = useState(RunType.FORECAST);
 
   return (
     <Box
@@ -40,13 +30,9 @@ const App = () => {
       <FBAMap
         selectedFireCenter={fireCenter}
         selectedFireShape={selectedFireShape}
-        forDate={dateOfInterest}
-        setSelectedFireShape={setSelectedFireShape}
         fireShapeAreas={[]}
-        runType={runType}
         zoomSource={zoomSource}
         advisoryThreshold={0}
-        setZoomSource={setZoomSource}
       />
       <ASATabs />
     </Box>

--- a/mobile/asa-go/src/FBAMap.tsx
+++ b/mobile/asa-go/src/FBAMap.tsx
@@ -26,7 +26,7 @@ import { fireZoneExtentsMap } from "@/fireZoneUnitExtents";
 import { CENTER_OF_BC } from "@/utils/constants";
 import { extentsMap } from "@/fireCentreExtents";
 import { PMTilesFileVectorSource } from "@/utils/pmtilesVectorSource";
-import { PMTilesCache } from "@/utils/PMTilesCache";
+import { PMTilesCache } from "@/utils/pmtilesCache";
 import { Filesystem } from "@capacitor/filesystem";
 export const MapContext = React.createContext<Map | null>(null);
 

--- a/mobile/asa-go/src/FBAMap.tsx
+++ b/mobile/asa-go/src/FBAMap.tsx
@@ -20,7 +20,6 @@ import {
 import { DateTime } from "luxon";
 import { isUndefined, cloneDeep } from "lodash";
 import { Box } from "@mui/material";
-// import Legend from "@/Legend";
 import ScalebarContainer from "@/ScaleBarContainer";
 import { fireZoneExtentsMap } from "@/fireZoneUnitExtents";
 import { CENTER_OF_BC } from "@/utils/constants";
@@ -36,17 +35,9 @@ export interface FBAMapProps {
   testId?: string;
   selectedFireCenter: FireCenter | undefined;
   selectedFireShape: FireShape | undefined;
-  forDate: DateTime;
-  setSelectedFireShape: React.Dispatch<
-    React.SetStateAction<FireShape | undefined>
-  >;
   fireShapeAreas: FireShapeArea[];
-  runType: RunType;
   advisoryThreshold: number;
   zoomSource?: "fireCenter" | "fireShape";
-  setZoomSource: React.Dispatch<
-    React.SetStateAction<"fireCenter" | "fireShape" | undefined>
-  >;
 }
 
 const FBAMap = (props: FBAMapProps) => {
@@ -74,6 +65,7 @@ const FBAMap = (props: FBAMapProps) => {
       // reset map view to full province
       map.getView().fit(bcExtent, { duration: 600, padding: [50, 50, 50, 50] });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.selectedFireCenter]);
 
   useEffect(() => {
@@ -92,6 +84,7 @@ const FBAMap = (props: FBAMapProps) => {
         });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.selectedFireShape]);
 
   useEffect(() => {

--- a/mobile/asa-go/src/FBAMap.tsx
+++ b/mobile/asa-go/src/FBAMap.tsx
@@ -29,7 +29,7 @@ import ScalebarContainer from "@/ScaleBarContainer";
 import { fireZoneExtentsMap } from "@/fireZoneUnitExtents";
 import { CENTER_OF_BC } from "@/utils/constants";
 import { extentsMap } from "@/fireCentreExtents";
-import { PMTilesFileVectorSource } from "@/utils/pmtiles";
+import { PMTilesFileVectorSource } from "@/utils/pmtilesVectorSource";
 import { PMTilesCache } from "@/utils/PMTilesCache";
 import { Filesystem } from "@capacitor/filesystem";
 export const MapContext = React.createContext<Map | null>(null);
@@ -275,15 +275,16 @@ const FBAMap = (props: FBAMapProps) => {
     setMap(mapObject);
 
     const load = async () => {
-      const fireCentreFileVectorSource = await PMTilesFileVectorSource.create(
-        new PMTilesCache(Filesystem),
-        {
-          filename: "hfi.pmtiles",
-          for_date: DateTime.fromFormat("2024/08/08", "yyyy/MM/dd"),
-          run_type: RunType.FORECAST,
-          run_date: DateTime.fromFormat("2024/08/08", "yyyy/MM/dd"),
-        }
-      );
+      const fireCentreFileVectorSource =
+        await PMTilesFileVectorSource.createHFILayer(
+          new PMTilesCache(Filesystem),
+          {
+            filename: "hfi.pmtiles",
+            for_date: DateTime.fromFormat("2024/08/08", "yyyy/MM/dd"),
+            run_type: RunType.FORECAST,
+            run_date: DateTime.fromFormat("2024/08/08", "yyyy/MM/dd"),
+          }
+        );
       if (mapObject) {
         const fileLayer = new VectorTileLayer({
           source: fireCentreFileVectorSource,

--- a/mobile/asa-go/src/api/pmtilesAPI.ts
+++ b/mobile/asa-go/src/api/pmtilesAPI.ts
@@ -9,7 +9,7 @@ import { DateTime } from "luxon";
  * @param run_date The date of the run to process. (when was the hfi file created?)
  * @returns pmtiles blob
  */
-export const fetchPMTiles = async (
+export const fetchHFIPMTiles = async (
   for_date: DateTime,
   run_type: RunType,
   run_date: DateTime
@@ -19,6 +19,15 @@ export const fetchPMTiles = async (
       format: "basic",
     }
   )}.pmtiles`;
+
+  const response = await fetch(PMTilesURL);
+  const blob = await response.blob();
+
+  return blob;
+};
+
+export const fetchStaticPMTiles = async (filename: string): Promise<Blob> => {
+  const PMTilesURL = `${PMTILES_BUCKET}${filename}`;
 
   const response = await fetch(PMTilesURL);
   const blob = await response.blob();

--- a/mobile/asa-go/src/api/pmtilesAPI.ts
+++ b/mobile/asa-go/src/api/pmtilesAPI.ts
@@ -1,0 +1,27 @@
+import { RunType } from "@/api/fbaAPI";
+import { PMTILES_BUCKET } from "@/utils/env";
+import { DateTime } from "luxon";
+
+/**
+ *
+ * @param for_date The date of the hfi to process. (when is the hfi for?)
+ * @param run_type forecast or actual
+ * @param run_date The date of the run to process. (when was the hfi file created?)
+ * @returns pmtiles blob
+ */
+export const fetchPMTiles = async (
+  for_date: DateTime,
+  run_type: RunType,
+  run_date: DateTime
+): Promise<Blob> => {
+  const PMTilesURL = `${PMTILES_BUCKET}hfi/${run_type.toLowerCase()}/${run_date.toISODate()}/hfi${for_date.toISODate(
+    {
+      format: "basic",
+    }
+  )}.pmtiles`;
+
+  const response = await fetch(PMTilesURL);
+  const blob = await response.blob();
+
+  return blob;
+};

--- a/mobile/asa-go/src/utils/PMTilesCache.ts
+++ b/mobile/asa-go/src/utils/PMTilesCache.ts
@@ -113,60 +113,6 @@ const fetchAndStoreHFIPMTiles = (
 
 export class PMTilesCache {
   constructor(private readonly fileSystem: FilesystemPlugin) {}
-  // private readonly downloadAndStorePMTiles = async (
-  //   for_date: DateTime,
-  //   run_type: RunType,
-  //   run_date: DateTime,
-  //   filename: string
-  // ) => {
-  //   try {
-  //     const blob = await fetchHFIPMTiles(for_date, run_type, run_date);
-  //     const serialized = await this.serialize(blob);
-
-  //     await this.fileSystem.writeFile({
-  //       path: filename,
-  //       data: serialized,
-  //       directory: Directory.Data,
-  //       encoding: Encoding.UTF8,
-  //     });
-
-  //     console.log(`PMTiles stored: ${filename}`);
-  //   } catch (error) {
-  //     console.error("Error storing PMTiles:", error);
-  //   }
-  // };
-
-  // private readonly blobToBase64 = async (blob: Blob): Promise<string> => {
-  //   return new Promise((resolve, reject) => {
-  //     const reader = new FileReader();
-  //     reader.readAsDataURL(blob);
-  //     reader.onload = () => resolve(reader.result as string);
-  //     reader.onerror = reject;
-  //   });
-  // };
-
-  // private readonly base64ToBlob = (
-  //   base64: string,
-  //   contentType = "application/octet-stream"
-  // ) => {
-  //   const byteCharacters = atob(base64.split(",")[1]); // Remove Base64 prefix
-  //   const byteNumbers = new Array(byteCharacters.length)
-  //     .fill(0)
-  //     .map((_, i) => byteCharacters.charCodeAt(i));
-  //   const byteArray = new Uint8Array(byteNumbers);
-  //   return new Blob([byteArray], { type: contentType });
-  // };
-
-  // private readonly serialize = async (blob: Blob) => {
-  //   // Mobile devices require string data
-  //   const base64Data = await this.blobToBase64(blob);
-  //   return base64Data;
-  // };
-
-  // private readonly deserialize = (text: string): Blob => {
-  //   return this.base64ToBlob(text);
-  // };
-
   public readonly loadPMTiles = async (
     filename: string,
     fetchAndStoreCallback?: () => Promise<PMTiles | undefined>

--- a/mobile/asa-go/src/utils/PMTilesCache.ts
+++ b/mobile/asa-go/src/utils/PMTilesCache.ts
@@ -134,11 +134,6 @@ export class PMTilesCache implements IPMTilesCache {
       fetchAndStoreCallback ??
       fetchAndStoreStaticPMTiles(filename, this.fileSystem);
     try {
-      const res = await this.fileSystem.stat({
-        directory: Directory.Data,
-        path: filename,
-      });
-      console.log(res);
       const file = await this.fileSystem.readFile({
         path: filename,
         directory: Directory.Data,

--- a/mobile/asa-go/src/utils/PMTilesCache.ts
+++ b/mobile/asa-go/src/utils/PMTilesCache.ts
@@ -111,7 +111,20 @@ const fetchAndStoreHFIPMTiles = (
   };
 };
 
-export class PMTilesCache {
+export interface IPMTilesCache {
+  loadPMTiles: (
+    filename: string,
+    fetchAndStoreCallback?: () => Promise<PMTiles | undefined>
+  ) => Promise<PMTiles | undefined>;
+  loadHFIPMTiles: (
+    for_date: DateTime,
+    run_type: RunType,
+    run_date: DateTime,
+    filename: string
+  ) => Promise<PMTiles | undefined>;
+}
+
+export class PMTilesCache implements IPMTilesCache {
   constructor(private readonly fileSystem: FilesystemPlugin) {}
   public readonly loadPMTiles = async (
     filename: string,

--- a/mobile/asa-go/src/utils/PMTilesCache.ts
+++ b/mobile/asa-go/src/utils/PMTilesCache.ts
@@ -1,5 +1,5 @@
 import { RunType } from "@/api/fbaAPI";
-import { fetchPMTiles } from "@/api/pmtilesAPI";
+import { fetchHFIPMTiles, fetchStaticPMTiles } from "@/api/pmtilesAPI";
 import {
   Directory,
   Encoding,
@@ -9,107 +9,207 @@ import {
 import { DateTime } from "luxon";
 import { FileSource, PMTiles } from "pmtiles";
 
-export class PMTilesCache {
-  constructor(private readonly fileSystem: FilesystemPlugin) {}
-  private readonly downloadAndStorePMTiles = async (
-    for_date: DateTime,
-    run_type: RunType,
-    run_date: DateTime,
-    filename: string
-  ) => {
-    try {
-      const blob = await fetchPMTiles(for_date, run_type, run_date);
-      const serialized = await this.serialize(blob);
+const base64ToBlob = (
+  base64: string,
+  contentType = "application/octet-stream"
+) => {
+  const byteCharacters = atob(base64.split(",")[1]); // Remove Base64 prefix
+  const byteNumbers = new Array(byteCharacters.length)
+    .fill(0)
+    .map((_, i) => byteCharacters.charCodeAt(i));
+  const byteArray = new Uint8Array(byteNumbers);
+  return new Blob([byteArray], { type: contentType });
+};
 
-      await this.fileSystem.writeFile({
+const blobToBase64 = async (blob: Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(blob);
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+  });
+};
+
+const serialize = async (blob: Blob) => {
+  // Mobile devices require string data
+  const base64Data = await blobToBase64(blob);
+  return base64Data;
+};
+
+const deserialize = (text: string): Blob => {
+  return base64ToBlob(text);
+};
+
+const toPMTiles = (file: ReadFileResult, filename: string) => {
+  const deserialized = deserialize(file.data as string);
+
+  // Initialize PMTiles with local blob
+  const pmtiles = new PMTiles(
+    new FileSource(new File([deserialized], filename))
+  );
+  return pmtiles;
+};
+
+const fetchAndStoreStaticPMTiles = (
+  filename: string,
+  fileSystem: FilesystemPlugin
+) => {
+  return async () => {
+    try {
+      const blob = await fetchStaticPMTiles(filename);
+      const serialized = await serialize(blob);
+
+      await fileSystem.writeFile({
         path: filename,
         data: serialized,
         directory: Directory.Data,
         encoding: Encoding.UTF8,
       });
 
-      console.log(`PMTiles stored: ${filename}`);
-    } catch (error) {
-      console.error("Error storing PMTiles:", error);
-    }
-  };
-
-  private readonly blobToBase64 = async (blob: Blob): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.readAsDataURL(blob);
-      reader.onload = () => resolve(reader.result as string);
-      reader.onerror = reject;
-    });
-  };
-
-  private readonly base64ToBlob = (
-    base64: string,
-    contentType = "application/octet-stream"
-  ) => {
-    const byteCharacters = atob(base64.split(",")[1]); // Remove Base64 prefix
-    const byteNumbers = new Array(byteCharacters.length)
-      .fill(0)
-      .map((_, i) => byteCharacters.charCodeAt(i));
-    const byteArray = new Uint8Array(byteNumbers);
-    return new Blob([byteArray], { type: contentType });
-  };
-
-  private readonly serialize = async (blob: Blob) => {
-    // Mobile devices require string data
-    const base64Data = await this.blobToBase64(blob);
-    return base64Data;
-  };
-
-  private readonly deserialize = (text: string): Blob => {
-    return this.base64ToBlob(text);
-  };
-
-  public readonly load = async (
-    for_date: DateTime,
-    run_type: RunType,
-    run_date: DateTime,
-    filename: string
-  ) => {
-    try {
-      const cachedFilename = `${for_date.toISODate()}_${run_type}_${run_date.toISODate()}_${filename}`;
-      const res = await this.fileSystem.stat({
-        directory: Directory.Data,
-        path: cachedFilename,
-      });
-      console.log(res);
-      const file = await this.fileSystem.readFile({
-        path: cachedFilename,
+      const file = await fileSystem.readFile({
+        path: filename,
         directory: Directory.Data,
         encoding: Encoding.UTF8,
       });
 
-      return this.toPMTiles(file, filename);
-    } catch (e) {
-      console.log("Error reading file, attempting to re-fetch", e);
-      await this.downloadAndStorePMTiles(
-        for_date,
-        run_type,
-        run_date,
-        filename
-      );
+      return toPMTiles(file, filename);
+    } catch (error) {
+      console.error("Error storing PMTiles:", error);
+    }
+  };
+};
+
+const fetchAndStoreHFIPMTiles = (
+  for_date: DateTime,
+  run_type: RunType,
+  run_date: DateTime,
+  filename: string,
+  fileSystem: FilesystemPlugin
+) => {
+  return async () => {
+    try {
+      const blob = await fetchHFIPMTiles(for_date, run_type, run_date);
+      const serialized = await serialize(blob);
+
+      await fileSystem.writeFile({
+        path: filename,
+        data: serialized,
+        directory: Directory.Data,
+        encoding: Encoding.UTF8,
+      });
+
+      const file = await fileSystem.readFile({
+        path: filename,
+        directory: Directory.Data,
+        encoding: Encoding.UTF8,
+      });
+
+      return toPMTiles(file, filename);
+    } catch (error) {
+      console.error("Error storing PMTiles:", error);
+    }
+  };
+};
+
+export class PMTilesCache {
+  constructor(private readonly fileSystem: FilesystemPlugin) {}
+  // private readonly downloadAndStorePMTiles = async (
+  //   for_date: DateTime,
+  //   run_type: RunType,
+  //   run_date: DateTime,
+  //   filename: string
+  // ) => {
+  //   try {
+  //     const blob = await fetchHFIPMTiles(for_date, run_type, run_date);
+  //     const serialized = await this.serialize(blob);
+
+  //     await this.fileSystem.writeFile({
+  //       path: filename,
+  //       data: serialized,
+  //       directory: Directory.Data,
+  //       encoding: Encoding.UTF8,
+  //     });
+
+  //     console.log(`PMTiles stored: ${filename}`);
+  //   } catch (error) {
+  //     console.error("Error storing PMTiles:", error);
+  //   }
+  // };
+
+  // private readonly blobToBase64 = async (blob: Blob): Promise<string> => {
+  //   return new Promise((resolve, reject) => {
+  //     const reader = new FileReader();
+  //     reader.readAsDataURL(blob);
+  //     reader.onload = () => resolve(reader.result as string);
+  //     reader.onerror = reject;
+  //   });
+  // };
+
+  // private readonly base64ToBlob = (
+  //   base64: string,
+  //   contentType = "application/octet-stream"
+  // ) => {
+  //   const byteCharacters = atob(base64.split(",")[1]); // Remove Base64 prefix
+  //   const byteNumbers = new Array(byteCharacters.length)
+  //     .fill(0)
+  //     .map((_, i) => byteCharacters.charCodeAt(i));
+  //   const byteArray = new Uint8Array(byteNumbers);
+  //   return new Blob([byteArray], { type: contentType });
+  // };
+
+  // private readonly serialize = async (blob: Blob) => {
+  //   // Mobile devices require string data
+  //   const base64Data = await this.blobToBase64(blob);
+  //   return base64Data;
+  // };
+
+  // private readonly deserialize = (text: string): Blob => {
+  //   return this.base64ToBlob(text);
+  // };
+
+  public readonly loadPMTiles = async (
+    filename: string,
+    fetchAndStoreCallback?: () => Promise<PMTiles | undefined>
+  ) => {
+    const fetchAndStore =
+      fetchAndStoreCallback ??
+      fetchAndStoreStaticPMTiles(filename, this.fileSystem);
+    try {
+      const res = await this.fileSystem.stat({
+        directory: Directory.Data,
+        path: filename,
+      });
+      console.log(res);
       const file = await this.fileSystem.readFile({
         path: filename,
         directory: Directory.Data,
         encoding: Encoding.UTF8,
       });
 
-      return this.toPMTiles(file, filename);
+      return toPMTiles(file, filename);
+    } catch (e) {
+      console.log("Error reading file, attempting to re-fetch", e);
+      const pmTiles = await fetchAndStore();
+      return pmTiles;
     }
   };
 
-  private toPMTiles(file: ReadFileResult, filename: string) {
-    const deserialized = this.deserialize(file.data as string);
-
-    // Initialize PMTiles with local blob
-    const pmtiles = new PMTiles(
-      new FileSource(new File([deserialized], filename))
+  public readonly loadHFIPMTiles = async (
+    for_date: DateTime,
+    run_type: RunType,
+    run_date: DateTime,
+    filename: string
+  ) => {
+    const cachedFilename = `${for_date.toISODate()}_${run_type}_${run_date.toISODate()}_${filename}`;
+    return this.loadPMTiles(
+      cachedFilename,
+      fetchAndStoreHFIPMTiles(
+        for_date,
+        run_type,
+        run_date,
+        cachedFilename,
+        this.fileSystem
+      )
     );
-    return pmtiles;
-  }
+  };
 }

--- a/mobile/asa-go/src/utils/PMTilesCache.ts
+++ b/mobile/asa-go/src/utils/PMTilesCache.ts
@@ -1,0 +1,83 @@
+import { RunType } from "@/api/fbaAPI";
+import { fetchPMTiles } from "@/api/pmtilesAPI";
+import { Directory, Encoding, FilesystemPlugin } from "@capacitor/filesystem";
+import { DateTime } from "luxon";
+import { FileSource, PMTiles } from "pmtiles";
+
+export class PMTilesCache {
+  constructor(private readonly fileSystem: FilesystemPlugin) {}
+  private readonly downloadAndStorePMTiles = async (
+    for_date: DateTime,
+    run_type: RunType,
+    run_date: DateTime,
+    filename: string
+  ) => {
+    try {
+      const blob = await fetchPMTiles(for_date, run_type, run_date);
+      const serialized = await this.serialize(blob);
+
+      await this.fileSystem.writeFile({
+        path: filename,
+        data: serialized,
+        directory: Directory.Data,
+        encoding: Encoding.UTF8,
+      });
+
+      console.log(`PMTiles stored: ${filename}`);
+    } catch (error) {
+      console.error("Error storing PMTiles:", error);
+    }
+  };
+
+  private readonly blobToBase64 = async (blob: Blob): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(blob);
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+    });
+  };
+
+  private readonly base64ToBlob = (
+    base64: string,
+    contentType = "application/octet-stream"
+  ) => {
+    const byteCharacters = atob(base64.split(",")[1]); // Remove Base64 prefix
+    const byteNumbers = new Array(byteCharacters.length)
+      .fill(0)
+      .map((_, i) => byteCharacters.charCodeAt(i));
+    const byteArray = new Uint8Array(byteNumbers);
+    return new Blob([byteArray], { type: contentType });
+  };
+
+  private readonly serialize = async (blob: Blob) => {
+    const base64Data = await this.blobToBase64(blob);
+    return base64Data;
+  };
+
+  private readonly deserialize = (text: string): Blob => {
+    return this.base64ToBlob(text);
+  };
+
+  public readonly load = async (
+    for_date: DateTime,
+    run_type: RunType,
+    run_date: DateTime,
+    filename: string
+  ) => {
+    await this.downloadAndStorePMTiles(for_date, run_type, run_date, filename);
+    const file = await this.fileSystem.readFile({
+      path: filename,
+      directory: Directory.Data,
+      encoding: Encoding.UTF8,
+    });
+
+    const deserialized = this.deserialize(file.data as string);
+
+    // Initialize PMTiles with local blob
+    const pmtiles = new PMTiles(
+      new FileSource(new File([deserialized], filename))
+    );
+    return pmtiles;
+  };
+}

--- a/mobile/asa-go/src/utils/PMTilesCache.ts
+++ b/mobile/asa-go/src/utils/PMTilesCache.ts
@@ -125,7 +125,10 @@ export interface IPMTilesCache {
 }
 
 export class PMTilesCache implements IPMTilesCache {
-  constructor(private readonly fileSystem: FilesystemPlugin) {}
+  constructor(
+    private readonly fileSystem: FilesystemPlugin,
+    private retries: number = 3
+  ) {}
   public readonly loadPMTiles = async (
     filename: string,
     fetchAndStoreCallback?: () => Promise<PMTiles | undefined>
@@ -142,6 +145,10 @@ export class PMTilesCache implements IPMTilesCache {
 
       return toPMTiles(file, filename);
     } catch (e) {
+      if (this.retries === 0) {
+        return;
+      }
+      this.retries--;
       console.log("Error reading file, attempting to re-fetch", e);
       const pmTiles = await fetchAndStore();
       return pmTiles;

--- a/mobile/asa-go/src/utils/pmtiles.ts
+++ b/mobile/asa-go/src/utils/pmtiles.ts
@@ -1,0 +1,131 @@
+import { Tile } from "ol";
+import RenderFeature from "ol/render/Feature";
+import VectorTile, {
+  type Options as VectorTileSourceOptions,
+  default as VectorTileSource,
+} from "ol/source/VectorTile";
+import { createXYZ } from "ol/tilegrid";
+import TileState from "ol/TileState";
+import { PMTiles } from "pmtiles";
+import { MVT } from "ol/format";
+import { PMTilesCache } from "@/utils/PMTilesCache";
+import { DateTime } from "luxon";
+import { RunType } from "@/api/fbaAPI";
+
+export type PMTilesFileVectorOptions = VectorTileSourceOptions & {
+  filename: string;
+  for_date: DateTime;
+  run_type: RunType;
+  run_date: DateTime;
+};
+
+export class PMTilesFileVectorSource extends VectorTileSource {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  pmtiles_: PMTiles;
+
+  tileLoadFunction = (tile: Tile, url: string) => {
+    const vtile = tile as unknown as VectorTile;
+    const re = new RegExp(/pmtiles:\/\/(\d+)\/(\d+)\/(\d+)/);
+    const result = url.match(re);
+
+    if (!(result && result.length >= 4)) {
+      throw new Error("Could not parse tile URL");
+    }
+    const z = +result[1];
+    const x = +result[2];
+    const y = +result[3];
+
+    tile.setState(TileState.LOADING); // Set state to LOADING
+
+    // Use the PMTiles getZxy method to fetch the tile data
+    this.pmtiles_
+      .getZxy(z, x, y)
+      .then((tile_result) => {
+        if (tile_result) {
+          const format = new MVT(); // Create the MVT format (or use the one from the tile)
+          const features = format.readFeatures(tile_result.data, {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            extent: vtile.extent,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            featureProjection: vtile.projection,
+          });
+
+          // Set features and state to LOADED on the existing tile object
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          vtile.setFeatures(features); // Set the features on the tile (which can now handle vector data)
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          vtile.setState(TileState.LOADED); // Mark the tile as loaded
+        } else {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          vtile.setFeatures([]);
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          vtile.setState(TileState.EMPTY); // Mark the tile as empty if no data is found
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        vtile.setFeatures([]);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        vtile.setState(TileState.ERROR); // Mark the tile as error if the loading fails
+      });
+  };
+
+  constructor(options: VectorTileSourceOptions<RenderFeature>) {
+    super({
+      ...options,
+      state: "loading",
+      url: "pmtiles://{z}/{x}/{y}",
+      format: options.format || new MVT(),
+    });
+  }
+
+  // Static async factory method
+  static async create(
+    pmtilesCache: PMTilesCache,
+    options: PMTilesFileVectorOptions
+  ) {
+    const instance = new PMTilesFileVectorSource(options);
+
+    // Perform asynchronous initialization (e.g., loading PMTiles)
+    await instance.init(pmtilesCache, options);
+
+    return instance;
+  }
+
+  async init(pmtilesCache: PMTilesCache, options: PMTilesFileVectorOptions) {
+    try {
+      console.log(`Attempting to read ${options.filename}`);
+
+      // Initialize PMTiles with the Object URL
+      this.pmtiles_ = await pmtilesCache.load(
+        options.for_date,
+        options.run_type,
+        options.run_date,
+        options.filename
+      );
+      const header = await this.pmtiles_.getHeader();
+
+      this.tileGrid = createXYZ({
+        maxZoom: header.maxZoom,
+        minZoom: header.minZoom,
+        tileSize: 512,
+      });
+
+      this.setTileLoadFunction(this.tileLoadFunction);
+      this.setState("ready");
+    } catch (error) {
+      console.error("Error loading PMTiles file:", error);
+      this.setState("error");
+    }
+  }
+}

--- a/mobile/asa-go/src/utils/pmtiles.ts
+++ b/mobile/asa-go/src/utils/pmtiles.ts
@@ -22,7 +22,7 @@ export type PMTilesFileVectorOptions = VectorTileSourceOptions & {
 export class PMTilesFileVectorSource extends VectorTileSource {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  pmtiles_: PMTiles;
+  private pmtiles_: PMTiles;
 
   tileLoadFunction = (tile: Tile, url: string) => {
     const vtile = tile as unknown as VectorTile;
@@ -43,7 +43,7 @@ export class PMTilesFileVectorSource extends VectorTileSource {
       .getZxy(z, x, y)
       .then((tile_result) => {
         if (tile_result) {
-          const format = new MVT(); // Create the MVT format (or use the one from the tile)
+          const format = new MVT(); // Create the MVT format
           const features = format.readFeatures(tile_result.data, {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
@@ -53,7 +53,6 @@ export class PMTilesFileVectorSource extends VectorTileSource {
             featureProjection: vtile.projection,
           });
 
-          // Set features and state to LOADED on the existing tile object
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           vtile.setFeatures(features); // Set the features on the tile (which can now handle vector data)
@@ -84,7 +83,7 @@ export class PMTilesFileVectorSource extends VectorTileSource {
     super({
       ...options,
       state: "loading",
-      url: "pmtiles://{z}/{x}/{y}",
+      url: "pmtiles://{z}/{x}/{y}", // only used for parsing out the z, x, y parameters when tile loading
       format: options.format || new MVT(),
     });
   }
@@ -106,7 +105,6 @@ export class PMTilesFileVectorSource extends VectorTileSource {
     try {
       console.log(`Attempting to read ${options.filename}`);
 
-      // Initialize PMTiles with the Object URL
       this.pmtiles_ = await pmtilesCache.load(
         options.for_date,
         options.run_type,

--- a/mobile/asa-go/src/utils/pmtilesCache.test.ts
+++ b/mobile/asa-go/src/utils/pmtilesCache.test.ts
@@ -110,7 +110,7 @@ describe("pmtilesCache", () => {
     sandbox.restore();
   });
 
-  it("should attempt to load stored static pmtiles first then fallback to requesting them", async () => {
+  it("should attempt to load stored static pmtiles", async () => {
     const mockFs = new MockFilesystem();
 
     const stubRead = sandbox.stub(mockFs, "readFile");
@@ -120,7 +120,16 @@ describe("pmtilesCache", () => {
     sinon.assert.calledOnce(stubRead);
   });
 
-  it("should attempt to load stored hfi pmtiles first then fallback to requesting them", async () => {
+  it("should attempt to load stored static pmtiles first then fallback to requesting them", async () => {
+    const mockFs = new MockFilesystem();
+
+    const stubFetch = sandbox.stub().rejects(new Error("Fetch failed"));
+    const testCache = new PMTilesCache(mockFs);
+    await testCache.loadPMTiles("test.pmtiles", stubFetch);
+    sinon.assert.calledThrice(stubFetch);
+  });
+
+  it("should attempt to load stored hfi pmtiles", async () => {
     const mockFs = new MockFilesystem();
 
     const stubRead = sandbox.stub(mockFs, "readFile");
@@ -133,5 +142,20 @@ describe("pmtilesCache", () => {
       "test.pmtiles"
     );
     sinon.assert.calledOnce(stubRead);
+  });
+
+  it("should attempt to load stored hfi pmtiles first then fallback to requesting them", async () => {
+    const mockFs = new MockFilesystem();
+
+    const stubFetch = sandbox.stub().rejects(new Error("Fetch failed"));
+    const testCache = new PMTilesCache(mockFs);
+    await testCache.loadHFIPMTiles(
+      DateTime.fromISO("2016-05-25T09:08:34.123"),
+      RunType.FORECAST,
+      DateTime.fromISO("2016-05-25T09:08:34.123"),
+      "test.pmtiles",
+      stubFetch
+    );
+    sinon.assert.calledThrice(stubFetch);
   });
 });

--- a/mobile/asa-go/src/utils/pmtilesCache.test.ts
+++ b/mobile/asa-go/src/utils/pmtilesCache.test.ts
@@ -1,0 +1,120 @@
+import { PMTilesCache } from "@/utils/pmtilesCache";
+import { PluginListenerHandle } from "@capacitor/core";
+import {
+  AppendFileOptions,
+  CopyOptions,
+  CopyResult,
+  DeleteFileOptions,
+  DownloadFileOptions,
+  DownloadFileResult,
+  FilesystemPlugin,
+  GetUriOptions,
+  GetUriResult,
+  MkdirOptions,
+  PermissionStatus,
+  ProgressListener,
+  ReaddirOptions,
+  ReaddirResult,
+  ReadFileOptions,
+  ReadFileResult,
+  RenameOptions,
+  RmdirOptions,
+  StatOptions,
+  StatResult,
+  WriteFileOptions,
+  WriteFileResult,
+} from "@capacitor/filesystem";
+
+import sinon from "sinon";
+
+export class MockFilesystem implements FilesystemPlugin {
+  readFile(options: ReadFileOptions): Promise<ReadFileResult> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve({ data: "" });
+  }
+  writeFile(options: WriteFileOptions): Promise<WriteFileResult> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve({ uri: "" });
+  }
+  appendFile(options: AppendFileOptions): Promise<void> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve();
+  }
+  deleteFile(options: DeleteFileOptions): Promise<void> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve();
+  }
+  mkdir(options: MkdirOptions): Promise<void> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve();
+  }
+  rmdir(options: RmdirOptions): Promise<void> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve();
+  }
+  readdir(options: ReaddirOptions): Promise<ReaddirResult> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve({ files: [] });
+  }
+  getUri(options: GetUriOptions): Promise<GetUriResult> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve({ uri: "" });
+  }
+  stat(options: StatOptions): Promise<StatResult> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve({ type: "file", size: 0, mtime: 0, uri: "" });
+  }
+  rename(options: RenameOptions): Promise<void> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve();
+  }
+  copy(options: CopyOptions): Promise<CopyResult> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve({ uri: "" });
+  }
+  checkPermissions(): Promise<PermissionStatus> {
+    console.log("Method not implemented.");
+    return Promise.resolve({ publicStorage: "granted" });
+  }
+  requestPermissions(): Promise<PermissionStatus> {
+    console.log("Method not implemented.");
+    return Promise.resolve({ publicStorage: "granted" });
+  }
+  downloadFile(options: DownloadFileOptions): Promise<DownloadFileResult> {
+    console.log("Method not implemented.", options);
+    return Promise.resolve({});
+  }
+  addListener(
+    eventName: "progress",
+    listenerFunc: ProgressListener
+  ): Promise<PluginListenerHandle> {
+    console.log("Method not implemented.", eventName, listenerFunc);
+    return Promise.resolve({
+      remove: () => Promise.resolve(),
+    });
+  }
+  removeAllListeners(): Promise<void> {
+    console.log("Method not implemented.");
+    return Promise.resolve();
+  }
+}
+
+describe("pmtilesCache", () => {
+  let sandbox: sinon.SinonSandbox;
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should attempt to load stored static pmtiles first then fallback to requesting them", async () => {
+    const mockFs = new MockFilesystem();
+
+    const stubRead = sandbox.stub(mockFs, "readFile");
+    stubRead.resolves({ data: btoa("mocked file content") });
+    const testCache = new PMTilesCache(mockFs);
+    testCache.loadPMTiles("test.pmtiles");
+    sinon.assert.calledOnce(stubRead);
+  });
+});

--- a/mobile/asa-go/src/utils/pmtilesCache.test.ts
+++ b/mobile/asa-go/src/utils/pmtilesCache.test.ts
@@ -1,3 +1,4 @@
+import { RunType } from "@/api/fbaAPI";
 import { PMTilesCache } from "@/utils/pmtilesCache";
 import { PluginListenerHandle } from "@capacitor/core";
 import {
@@ -24,6 +25,7 @@ import {
   WriteFileOptions,
   WriteFileResult,
 } from "@capacitor/filesystem";
+import { DateTime } from "luxon";
 
 import sinon from "sinon";
 
@@ -115,6 +117,21 @@ describe("pmtilesCache", () => {
     stubRead.resolves({ data: btoa("mocked file content") });
     const testCache = new PMTilesCache(mockFs);
     testCache.loadPMTiles("test.pmtiles");
+    sinon.assert.calledOnce(stubRead);
+  });
+
+  it("should attempt to load stored hfi pmtiles first then fallback to requesting them", async () => {
+    const mockFs = new MockFilesystem();
+
+    const stubRead = sandbox.stub(mockFs, "readFile");
+    stubRead.resolves({ data: btoa("mocked file content") });
+    const testCache = new PMTilesCache(mockFs);
+    testCache.loadHFIPMTiles(
+      DateTime.fromISO("2016-05-25T09:08:34.123"),
+      RunType.FORECAST,
+      DateTime.fromISO("2016-05-25T09:08:34.123"),
+      "test.pmtiles"
+    );
     sinon.assert.calledOnce(stubRead);
   });
 });

--- a/mobile/asa-go/src/utils/pmtilesCache.test.ts
+++ b/mobile/asa-go/src/utils/pmtilesCache.test.ts
@@ -116,17 +116,21 @@ describe("pmtilesCache", () => {
     const stubRead = sandbox.stub(mockFs, "readFile");
     stubRead.resolves({ data: btoa("mocked file content") });
     const testCache = new PMTilesCache(mockFs);
-    testCache.loadPMTiles("test.pmtiles");
+    await testCache.loadPMTiles("test.pmtiles");
     sinon.assert.calledOnce(stubRead);
   });
 
   it("should attempt to load stored static pmtiles first then fallback to requesting them", async () => {
     const mockFs = new MockFilesystem();
+    const stubRead = sandbox
+      .stub(mockFs, "readFile")
+      .rejects(new Error("Read failed"));
 
     const stubFetch = sandbox.stub().rejects(new Error("Fetch failed"));
     const testCache = new PMTilesCache(mockFs);
     await testCache.loadPMTiles("test.pmtiles", stubFetch);
     sinon.assert.calledThrice(stubFetch);
+    sinon.assert.callOrder(stubRead, stubFetch, stubFetch, stubFetch);
   });
 
   it("should attempt to load stored hfi pmtiles", async () => {
@@ -135,7 +139,7 @@ describe("pmtilesCache", () => {
     const stubRead = sandbox.stub(mockFs, "readFile");
     stubRead.resolves({ data: btoa("mocked file content") });
     const testCache = new PMTilesCache(mockFs);
-    testCache.loadHFIPMTiles(
+    await testCache.loadHFIPMTiles(
       DateTime.fromISO("2016-05-25T09:08:34.123"),
       RunType.FORECAST,
       DateTime.fromISO("2016-05-25T09:08:34.123"),
@@ -146,6 +150,9 @@ describe("pmtilesCache", () => {
 
   it("should attempt to load stored hfi pmtiles first then fallback to requesting them", async () => {
     const mockFs = new MockFilesystem();
+    const stubRead = sandbox
+      .stub(mockFs, "readFile")
+      .rejects(new Error("Read failed"));
 
     const stubFetch = sandbox.stub().rejects(new Error("Fetch failed"));
     const testCache = new PMTilesCache(mockFs);
@@ -157,5 +164,6 @@ describe("pmtilesCache", () => {
       stubFetch
     );
     sinon.assert.calledThrice(stubFetch);
+    sinon.assert.callOrder(stubRead, stubFetch, stubFetch, stubFetch);
   });
 });

--- a/mobile/asa-go/src/utils/pmtilesVectorSource.test.ts
+++ b/mobile/asa-go/src/utils/pmtilesVectorSource.test.ts
@@ -1,0 +1,66 @@
+import { RunType } from "@/api/fbaAPI";
+import { IPMTilesCache } from "@/utils/pmtilesCache";
+import { PMTilesFileVectorSource } from "@/utils/pmtilesVectorSource";
+import { DateTime } from "luxon";
+import { PMTiles } from "pmtiles";
+import sinon from "sinon";
+
+describe("pmTilesVectorSource", () => {
+  let sandbox: sinon.SinonSandbox;
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  const buildPMTilesTestCache = () => {
+    return {
+      loadPMTiles: function (
+        filename: string,
+        fetchAndStoreCallback?: () => Promise<PMTiles | undefined>
+      ): Promise<PMTiles | undefined> {
+        console.log("loadPMTiles called", filename, fetchAndStoreCallback);
+        return Promise.resolve(undefined);
+      },
+      loadHFIPMTiles: function (
+        for_date: DateTime,
+        run_type: RunType,
+        run_date: DateTime,
+        filename: string
+      ): Promise<PMTiles | undefined> {
+        console.log(
+          "loadPMTiles called",
+          for_date,
+          run_type,
+          run_date,
+          filename
+        );
+        return Promise.resolve(undefined);
+      },
+    };
+  };
+  it("should attempt to load static pmtiles upon creation", async () => {
+    const testCache: IPMTilesCache = buildPMTilesTestCache();
+    const pmTilesCacheSpy = sandbox.spy(testCache);
+
+    await PMTilesFileVectorSource.createStaticLayer(testCache, {
+      filename: "test.pmtiles",
+    });
+    sinon.assert.calledOnce(pmTilesCacheSpy.loadPMTiles);
+    sinon.assert.notCalled(pmTilesCacheSpy.loadHFIPMTiles);
+  });
+
+  it("should attempt to load hfi pmtiles upon creation", async () => {
+    const testCache: IPMTilesCache = buildPMTilesTestCache();
+    const pmTilesCacheSpy = sandbox.spy(testCache);
+
+    await PMTilesFileVectorSource.createHFILayer(testCache, {
+      filename: "test.pmtiles",
+      for_date: DateTime.fromISO("2016-05-25T09:08:34.123"),
+      run_type: RunType.FORECAST,
+      run_date: DateTime.fromISO("2016-05-25T09:08:34.123"),
+    });
+    sinon.assert.calledOnce(pmTilesCacheSpy.loadHFIPMTiles);
+    sinon.assert.notCalled(pmTilesCacheSpy.loadPMTiles);
+  });
+});

--- a/mobile/asa-go/src/utils/pmtilesVectorSource.test.ts
+++ b/mobile/asa-go/src/utils/pmtilesVectorSource.test.ts
@@ -2,8 +2,84 @@ import { RunType } from "@/api/fbaAPI";
 import { IPMTilesCache } from "@/utils/pmtilesCache";
 import { PMTilesFileVectorSource } from "@/utils/pmtilesVectorSource";
 import { DateTime } from "luxon";
-import { PMTiles } from "pmtiles";
+import {
+  Cache,
+  Compression,
+  DecompressFunc,
+  Header,
+  PMTiles,
+  RangeResponse,
+  Source,
+  TileType,
+} from "pmtiles";
 import sinon from "sinon";
+import { assert } from "vitest";
+
+const testPMTilesHeader: Header = {
+  specVersion: 0,
+  rootDirectoryOffset: 0,
+  rootDirectoryLength: 0,
+  jsonMetadataOffset: 0,
+  jsonMetadataLength: 0,
+  leafDirectoryOffset: 0,
+  tileDataOffset: 0,
+  numAddressedTiles: 0,
+  numTileEntries: 0,
+  numTileContents: 0,
+  clustered: false,
+  internalCompression: Compression.Unknown,
+  tileCompression: Compression.Unknown,
+  tileType: TileType.Unknown,
+  minZoom: 0,
+  maxZoom: 0,
+  minLon: 0,
+  minLat: 0,
+  maxLon: 0,
+  maxLat: 0,
+  centerZoom: 0,
+  centerLon: 0,
+  centerLat: 0,
+};
+
+class TestPMTiles implements PMTiles {
+  source!: Source;
+  cache!: Cache;
+  decompress!: DecompressFunc;
+  getHeader(): Promise<Header> {
+    console.log("getHeader called");
+    return Promise.resolve(testPMTilesHeader);
+  }
+  getZxyAttempt(
+    z: number,
+    x: number,
+    y: number,
+    signal?: AbortSignal
+  ): Promise<RangeResponse | undefined> {
+    console.log("getZxyAttempt called", z, x, y, signal);
+    return Promise.resolve(undefined);
+  }
+  getZxy(
+    z: number,
+    x: number,
+    y: number,
+    signal?: AbortSignal
+  ): Promise<RangeResponse | undefined> {
+    console.log("getZxy called", z, x, y, signal);
+    return Promise.resolve(undefined);
+  }
+  getMetadataAttempt(): Promise<unknown> {
+    console.log("getMetadataAttempt called");
+    return Promise.resolve();
+  }
+  getMetadata(): Promise<unknown> {
+    console.log("getMetadata called");
+    return Promise.resolve();
+  }
+  getTileJson(baseTilesUrl: string): Promise<unknown> {
+    console.log("getTileJSON called", baseTilesUrl);
+    return Promise.resolve();
+  }
+}
 
 describe("pmTilesVectorSource", () => {
   let sandbox: sinon.SinonSandbox;
@@ -13,14 +89,15 @@ describe("pmTilesVectorSource", () => {
   afterEach(() => {
     sandbox.restore();
   });
-  const buildPMTilesTestCache = () => {
+
+  const buildPMTilesTestCache = (pmtiles?: PMTiles) => {
     return {
       loadPMTiles: function (
         filename: string,
         fetchAndStoreCallback?: () => Promise<PMTiles | undefined>
       ): Promise<PMTiles | undefined> {
         console.log("loadPMTiles called", filename, fetchAndStoreCallback);
-        return Promise.resolve(undefined);
+        return Promise.resolve(pmtiles);
       },
       loadHFIPMTiles: function (
         for_date: DateTime,
@@ -35,12 +112,12 @@ describe("pmTilesVectorSource", () => {
           run_date,
           filename
         );
-        return Promise.resolve(undefined);
+        return Promise.resolve(pmtiles);
       },
     };
   };
   it("should attempt to load static pmtiles upon creation", async () => {
-    const testCache: IPMTilesCache = buildPMTilesTestCache();
+    const testCache: IPMTilesCache = buildPMTilesTestCache(new TestPMTiles());
     const pmTilesCacheSpy = sandbox.spy(testCache);
 
     await PMTilesFileVectorSource.createStaticLayer(testCache, {
@@ -51,7 +128,7 @@ describe("pmTilesVectorSource", () => {
   });
 
   it("should attempt to load hfi pmtiles upon creation", async () => {
-    const testCache: IPMTilesCache = buildPMTilesTestCache();
+    const testCache: IPMTilesCache = buildPMTilesTestCache(new TestPMTiles());
     const pmTilesCacheSpy = sandbox.spy(testCache);
 
     await PMTilesFileVectorSource.createHFILayer(testCache, {
@@ -62,5 +139,20 @@ describe("pmTilesVectorSource", () => {
     });
     sinon.assert.calledOnce(pmTilesCacheSpy.loadHFIPMTiles);
     sinon.assert.notCalled(pmTilesCacheSpy.loadPMTiles);
+  });
+
+  it("should set tile status ready once initialized", async () => {
+    const testCache: IPMTilesCache = buildPMTilesTestCache(new TestPMTiles());
+    const instance = await PMTilesFileVectorSource.createHFILayer(testCache, {
+      filename: "test.pmtiles",
+      for_date: DateTime.fromISO("2016-05-25T09:08:34.123"),
+      run_type: RunType.FORECAST,
+      run_date: DateTime.fromISO("2016-05-25T09:08:34.123"),
+    });
+    const tileGrid = instance.getTileGrid();
+    assert(tileGrid !== null);
+    assert(tileGrid.getMaxZoom() === testPMTilesHeader.maxZoom);
+    assert(tileGrid.getMinZoom() === testPMTilesHeader.minZoom);
+    assert(instance.getState() === "ready");
   });
 });

--- a/mobile/asa-go/src/utils/pmtilesVectorSource.ts
+++ b/mobile/asa-go/src/utils/pmtilesVectorSource.ts
@@ -8,7 +8,7 @@ import { createXYZ } from "ol/tilegrid";
 import TileState from "ol/TileState";
 import { PMTiles } from "pmtiles";
 import { MVT } from "ol/format";
-import { PMTilesCache } from "@/utils/pmtilesCache";
+import { IPMTilesCache } from "@/utils/pmtilesCache";
 import { DateTime } from "luxon";
 import { RunType } from "@/api/fbaAPI";
 import { isUndefined } from "lodash";
@@ -95,7 +95,7 @@ export class PMTilesFileVectorSource extends VectorTileSource {
 
   // Static async factory method
   static async createStaticLayer(
-    pmtilesCache: PMTilesCache,
+    pmtilesCache: IPMTilesCache,
     options: PMTilesFileVectorOptions
   ) {
     const instance = new PMTilesFileVectorSource(options);
@@ -107,7 +107,7 @@ export class PMTilesFileVectorSource extends VectorTileSource {
   }
 
   async initStaticLayer(
-    pmtilesCache: PMTilesCache,
+    pmtilesCache: IPMTilesCache,
     options: PMTilesFileVectorOptions
   ) {
     try {
@@ -141,7 +141,7 @@ export class PMTilesFileVectorSource extends VectorTileSource {
   }
 
   static async createHFILayer(
-    pmtilesCache: PMTilesCache,
+    pmtilesCache: IPMTilesCache,
     options: HFIPMTilesFileVectorOptions
   ) {
     const instance = new PMTilesFileVectorSource(options);
@@ -152,7 +152,7 @@ export class PMTilesFileVectorSource extends VectorTileSource {
   }
 
   async initHFILayer(
-    pmtilesCache: PMTilesCache,
+    pmtilesCache: IPMTilesCache,
     options: HFIPMTilesFileVectorOptions
   ) {
     try {

--- a/mobile/asa-go/tsconfig.app.json
+++ b/mobile/asa-go/tsconfig.app.json
@@ -40,6 +40,7 @@
     }
   },
   "include": [
-    "src"
+    "src",
+    "vitest.config.ts"
   ]
 }

--- a/mobile/asa-go/vitest.config.ts
+++ b/mobile/asa-go/vitest.config.ts
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      coverage: {
+        provider: "istanbul",
+        reportsDirectory: "./coverage",
+        include: ["src/**/*.{ts,tsx}", "!src/**/*.d.ts", "!src/index.tsx"],
+      },
+      include: ["src/**/*.{spec,test}.{js,jsx,ts,tsx}"],
+      globals: true,
+      environment: "jsdom",
+    },
+  })
+);

--- a/mobile/asa-go/yarn.lock
+++ b/mobile/asa-go/yarn.lock
@@ -2,7 +2,18 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2":
+"@asamuzakjp/css-color@^2.8.2":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-2.8.3.tgz#665f0f5e8edb95d8f543847529e30fe5cc437ef7"
+  integrity sha512-GIc76d9UI1hCvOATjZPyHFmE5qhRccp3/zGfMPapK3jBi+yocEzp6BBB0UnfRYP9NP4FANqUZYb0hnfs3TM3hw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.1"
+    "@csstools/css-color-parser" "^3.0.7"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2":
   version "7.26.2"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz"
   integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
@@ -148,6 +159,34 @@
   version "7.0.0"
   resolved "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.0.tgz"
   integrity sha512-wsvPkWkoSOXMIgVHu4c6P1sOuDSZ1ClUo5OpLRwj7u8DYzlV4jlmNzztQn2Lvsiqx1z4kfukSaqe40k1Lo4c9g==
+
+"@csstools/color-helpers@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.0.1.tgz#829f1c76f5800b79c51c709e2f36821b728e0e10"
+  integrity sha512-MKtmkA0BX87PKaO1NFRTFH+UnkgnmySQOvNxJubsadusqPEC2aJ9MOQiMceZJJ6oitUl/i0L6u0M1IrmAOmgBA==
+
+"@csstools/css-calc@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-2.1.1.tgz#a7dbc66627f5cf458d42aed14bda0d3860562383"
+  integrity sha512-rL7kaUnTkL9K+Cvo2pnCieqNpTKgQzy5f+N+5Iuko9HAoasP+xgprVh7KN/MaJVvVL1l0EzQq2MoqBHKSrDrag==
+
+"@csstools/css-color-parser@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-3.0.7.tgz#442d61d58e54ad258d52c309a787fceb33906484"
+  integrity sha512-nkMp2mTICw32uE5NN+EsJ4f5N+IGFeCFu4bGpiKgb2Pq/7J/MpyLBeQ5ry4KKtRFZaYs6sTmcMYrSRIyj5DFKA==
+  dependencies:
+    "@csstools/color-helpers" "^5.0.1"
+    "@csstools/css-calc" "^2.1.1"
+
+"@csstools/css-parser-algorithms@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz#74426e93bd1c4dcab3e441f5cc7ba4fb35d94356"
+  integrity sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==
+
+"@csstools/css-tokenizer@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz#a5502c8539265fecbd873c1e395a890339f119c2"
+  integrity sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==
 
 "@emotion/babel-plugin@^11.13.5":
   version "11.13.5"
@@ -566,6 +605,32 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@jest/expect-utils@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
+  integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
+  dependencies:
+    jest-get-type "^29.6.3"
+
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.8"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz"
@@ -585,7 +650,7 @@
   resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
@@ -806,6 +871,39 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz#7a2d89a82cf0388d60304964217dd7beac6de645"
   integrity sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==
 
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
+"@sinonjs/commons@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^13.0.1", "@sinonjs/fake-timers@^13.0.2":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz#36b9dbc21ad5546486ea9173d6bea063eb1717d5"
+  integrity sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+
+"@sinonjs/samsam@^8.0.1":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.2.tgz#e4386bf668ff36c95949e55a38dc5f5892fc2689"
+  integrity sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+    lodash.get "^4.4.2"
+    type-detect "^4.1.0"
+
+"@sinonjs/text-encoding@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz#282046f03e886e352b2d5f5da5eb755e01457f3f"
+  integrity sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==
+
 "@swc/core-darwin-arm64@1.10.8":
   version "1.10.8"
   resolved "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.8.tgz"
@@ -887,7 +985,7 @@
   dependencies:
     "@swc/counter" "^0.1.3"
 
-"@types/estree@1.0.6", "@types/estree@^1.0.6":
+"@types/estree@1.0.6", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.6"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
@@ -898,6 +996,33 @@
   integrity sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==
   dependencies:
     "@types/node" "*"
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz#53047614ae72e19fc0401d872de3ae2b4ce350bf"
+  integrity sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
+  integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
+"@types/jest@^29.5.14":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
 
 "@types/json-schema@^7.0.15":
   version "7.0.15"
@@ -954,10 +1079,39 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/sinon@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-17.0.3.tgz#9aa7e62f0a323b9ead177ed23a36ea757141a5fa"
+  integrity sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "8.1.5"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz#5fd3592ff10c1e9695d377020c033116cc2889f2"
+  integrity sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==
+
 "@types/slice-ansi@^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz"
   integrity sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==
+
+"@types/stack-utils@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
+  integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/yargs-parser@*":
+  version "21.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
+  integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
+
+"@types/yargs@^17.0.8":
+  version "17.0.33"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.33.tgz#8c32303da83eec050a84b3c7ae7b9f922d13e32d"
+  integrity sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@8.20.0":
   version "8.20.0"
@@ -1047,6 +1201,65 @@
   dependencies:
     "@swc/core" "^1.7.26"
 
+"@vitest/expect@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.0.5.tgz#aa0acd0976cf56842806e5dcaebd446543966b14"
+  integrity sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==
+  dependencies:
+    "@vitest/spy" "3.0.5"
+    "@vitest/utils" "3.0.5"
+    chai "^5.1.2"
+    tinyrainbow "^2.0.0"
+
+"@vitest/mocker@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.0.5.tgz#8dce3dc4cb0adfd9d554531cea836244f8c36bcd"
+  integrity sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==
+  dependencies:
+    "@vitest/spy" "3.0.5"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.17"
+
+"@vitest/pretty-format@3.0.5", "@vitest/pretty-format@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.0.5.tgz#10ae6a83ccc1a866e31b2d0c1a7a977ade02eff9"
+  integrity sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/runner@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.0.5.tgz#c5960a1169465a2b9ac21f1d24a4cf1fe67c7501"
+  integrity sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==
+  dependencies:
+    "@vitest/utils" "3.0.5"
+    pathe "^2.0.2"
+
+"@vitest/snapshot@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.0.5.tgz#afd0ae472dc5893b0bb10e3e673ef649958663f4"
+  integrity sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==
+  dependencies:
+    "@vitest/pretty-format" "3.0.5"
+    magic-string "^0.30.17"
+    pathe "^2.0.2"
+
+"@vitest/spy@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.0.5.tgz#7bb5d84ec21cc0d62170fda4e31cd0b46c1aeb8b"
+  integrity sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.0.5.tgz#dc3eaefd3534598917e939af59d9a9b6a5be5082"
+  integrity sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==
+  dependencies:
+    "@vitest/pretty-format" "3.0.5"
+    loupe "^3.1.2"
+    tinyrainbow "^2.0.0"
+
 "@xmldom/xmldom@^0.8.8":
   version "0.8.10"
   resolved "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz"
@@ -1061,6 +1274,11 @@ acorn@^8.14.0:
   version "8.14.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
+
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
+  integrity sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -1089,6 +1307,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-styles@^6.1.0:
   version "6.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
@@ -1098,6 +1321,11 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -1181,10 +1409,26 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
   integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+chai@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.2.tgz#3afbc340b994ae3610ca519a6c70ace77ad4378d"
+  integrity sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -1194,10 +1438,20 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+check-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
+  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
+
 chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
+ci-info@^3.2.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 clsx@^2.1.1:
   version "2.1.1"
@@ -1283,17 +1537,43 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cssstyle@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.2.1.tgz#5142782410fea95db66fb68147714a652a7c2381"
+  integrity sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==
+  dependencies:
+    "@asamuzakjp/css-color" "^2.8.2"
+    rrweb-cssom "^0.8.0"
+
 csstype@^3.0.2, csstype@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-debug@^4.0.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+
+debug@4, debug@^4.0.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
     ms "^2.1.3"
+
+decimal.js@^10.4.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.5.0.tgz#0f371c7cf6c4898ce0afb09836db73cd82010f22"
+  integrity sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -1309,6 +1589,16 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
+diff@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
+  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -1345,6 +1635,11 @@ emoji-regex@^9.2.2:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
+entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
 env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz"
@@ -1356,6 +1651,11 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-module-lexer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.6.0.tgz#da49f587fd9e68ee2404fe4e256c0c7d3a81be21"
+  integrity sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==
 
 esbuild@^0.24.2:
   version "0.24.2"
@@ -1387,6 +1687,11 @@ esbuild@^0.24.2:
     "@esbuild/win32-arm64" "0.24.2"
     "@esbuild/win32-ia32" "0.24.2"
     "@esbuild/win32-x64" "0.24.2"
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -1489,10 +1794,33 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+expect-type@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.1.0.tgz#a146e414250d13dfc49eafcfd1344a4060fa4c75"
+  integrity sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==
+
+expect@^29.0.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
+  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
+  dependencies:
+    "@jest/expect-utils" "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -1592,7 +1920,7 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
-form-data@^4.0.0:
+form-data@^4.0.0, form-data@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz"
   integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
@@ -1692,7 +2020,7 @@ globals@^15.14.0:
   resolved "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz"
   integrity sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1720,6 +2048,36 @@ hoist-non-react-statics@^3.3.1:
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
+
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
+https-proxy-agent@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
@@ -1788,6 +2146,11 @@ is-number@^7.0.0:
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz"
@@ -1807,6 +2170,58 @@ jackspeak@^4.0.1:
   dependencies:
     "@isaacs/cliui" "^8.0.2"
 
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
+
+jest-matcher-utils@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
+  integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -1818,6 +2233,33 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsdom@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-26.0.0.tgz#446dd1ad8cfc50df7e714e58f1f972c1763b354c"
+  integrity sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==
+  dependencies:
+    cssstyle "^4.2.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.4.3"
+    form-data "^4.0.1"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.6"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.16"
+    parse5 "^7.2.1"
+    rrweb-cssom "^0.8.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^5.0.0"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.1.0"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
 
 jsesc@^3.0.2:
   version "3.1.0"
@@ -1852,6 +2294,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+just-extend@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-6.2.0.tgz#b816abfb3d67ee860482e7401564672558163947"
+  integrity sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==
 
 keyv@^4.5.4:
   version "4.5.4"
@@ -1895,6 +2342,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
@@ -1912,6 +2364,16 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^3.1.0, loupe@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
+  integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
+
+lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^11.0.0:
   version "11.0.2"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz"
@@ -1922,12 +2384,19 @@ luxon@^3.5.0:
   resolved "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz"
   integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
 
+magic-string@^0.30.17:
+  version "0.30.17"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
+  integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.8:
+micromatch@^4.0.4, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -2030,6 +2499,22 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+nise@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-6.1.1.tgz#78ea93cc49be122e44cb7c8fdf597b0e8778b64a"
+  integrity sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+    "@sinonjs/fake-timers" "^13.0.1"
+    "@sinonjs/text-encoding" "^0.7.3"
+    just-extend "^6.2.0"
+    path-to-regexp "^8.1.0"
+
+nwsapi@^2.2.16:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.16.tgz#177760bba02c351df1d2644e220c31dfec8cdb43"
+  integrity sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==
+
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
@@ -2122,6 +2607,13 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse5@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.2.1.tgz#8928f55915e6125f430cc44309765bf17556a33a"
+  integrity sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==
+  dependencies:
+    entities "^4.5.0"
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
@@ -2145,10 +2637,25 @@ path-scurry@^2.0.0:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
 
+path-to-regexp@^8.1.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.2.0.tgz#73990cc29e57a3ff2a0d914095156df5db79e8b4"
+  integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathe@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.2.tgz#5ed86644376915b3c7ee4d00ac8c348d671da3a5"
+  integrity sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==
+
+pathval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
+  integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
 
 pbf@4.0.1:
   version "4.0.1"
@@ -2167,7 +2674,7 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.3.1:
+picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -2202,6 +2709,15 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+pretty-format@^29.0.0, pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 prompts@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz"
@@ -2229,7 +2745,7 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -2268,6 +2784,11 @@ react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-is@^19.0.0:
   version "19.0.0"
@@ -2367,6 +2888,11 @@ rollup@^4.23.0:
     "@rollup/rollup-win32-x64-msvc" "4.31.0"
     fsevents "~2.3.2"
 
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
@@ -2379,10 +2905,22 @@ safe-buffer@~5.2.0:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 sax@1.1.4, sax@>=0.6.0:
   version "1.1.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
   integrity sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.23.2:
   version "0.23.2"
@@ -2408,6 +2946,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
@@ -2418,10 +2961,27 @@ signal-exit@^4.0.1:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+sinon@^19.0.2:
+  version "19.0.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-19.0.2.tgz#944cf771d22236aa84fc1ab70ce5bffc3a215dad"
+  integrity sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+    "@sinonjs/fake-timers" "^13.0.2"
+    "@sinonjs/samsam" "^8.0.1"
+    diff "^7.0.0"
+    nise "^6.1.1"
+    supports-color "^7.2.0"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -2446,6 +3006,23 @@ split2@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz"
   integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
+stack-utils@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
+  integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.8.0.tgz#b56ffc1baf1a29dcc80a3bdf11d7fca7c315e7d5"
+  integrity sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
@@ -2512,7 +3089,7 @@ stylis@4.2.0:
   resolved "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
-supports-color@^7.1.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -2523,6 +3100,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 tar@^6.1.11:
   version "6.2.1"
@@ -2543,12 +3125,63 @@ through2@^4.0.2:
   dependencies:
     readable-stream "3"
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinypool@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
+  integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
+
+tldts-core@^6.1.76:
+  version "6.1.76"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.76.tgz#1ea632bbf11b288645dd7e2f3fb9cb6fa41e6bd7"
+  integrity sha512-uzhJ02RaMzgQR3yPoeE65DrcHI6LoM4saUqXOt/b5hmb3+mc4YWpdSeAQqVqRUlQ14q8ZuLRWyBR1ictK1dzzg==
+
+tldts@^6.1.32:
+  version "6.1.76"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.76.tgz#c8b60fba55ca78e1c228bead4f69d18731526079"
+  integrity sha512-6U2ti64/nppsDxQs9hw8ephA3nO6nSQvVVfxwRw8wLQPFtLI1cFI1a1eP22g+LUP+1TA2pKKjUTwWB+K2coqmQ==
+  dependencies:
+    tldts-core "^6.1.76"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+tough-cookie@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.0.tgz#0667b0f2fbb5901fe6f226c3e0b710a9a4292f87"
+  integrity sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==
+  dependencies:
+    tldts "^6.1.32"
+
+tr46@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.0.0.tgz#3b46d583613ec7283020d79019f1335723801cec"
+  integrity sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==
+  dependencies:
+    punycode "^2.3.1"
 
 tree-kill@^1.2.2:
   version "1.2.2"
@@ -2571,6 +3204,16 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-detect@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
+  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
 
 typescript-eslint@^8.18.2:
   version "8.20.0"
@@ -2613,7 +3256,18 @@ util-deprecate@^1.0.1:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-vite@^6.0.5:
+vite-node@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.0.5.tgz#6a0d06f7a4bdaae6ddcdedc12d910d886cf7d62f"
+  integrity sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.0"
+    es-module-lexer "^1.6.0"
+    pathe "^2.0.2"
+    vite "^5.0.0 || ^6.0.0"
+
+"vite@^5.0.0 || ^6.0.0", vite@^6.0.5:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/vite/-/vite-6.0.11.tgz#224497e93e940b34c3357c9ebf2ec20803091ed8"
   integrity sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==
@@ -2624,10 +3278,68 @@ vite@^6.0.5:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vitest@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.0.5.tgz#a9a3fa1203d85869c9ba66f3ea990b72d00ddeb0"
+  integrity sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==
+  dependencies:
+    "@vitest/expect" "3.0.5"
+    "@vitest/mocker" "3.0.5"
+    "@vitest/pretty-format" "^3.0.5"
+    "@vitest/runner" "3.0.5"
+    "@vitest/snapshot" "3.0.5"
+    "@vitest/spy" "3.0.5"
+    "@vitest/utils" "3.0.5"
+    chai "^5.1.2"
+    debug "^4.4.0"
+    expect-type "^1.1.0"
+    magic-string "^0.30.17"
+    pathe "^2.0.2"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinypool "^1.0.2"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0"
+    vite-node "3.0.5"
+    why-is-node-running "^2.3.0"
+
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
+
 web-worker@^1.2.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz"
   integrity sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0, whatwg-url@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.1.0.tgz#fffebec86cc8e6c2a657e50dc606207b870f0ab3"
+  integrity sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==
+  dependencies:
+    tr46 "^5.0.0"
+    webidl-conversions "^7.0.0"
 
 which@^2.0.1:
   version "2.0.2"
@@ -2635,6 +3347,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.5:
   version "1.2.5"
@@ -2668,6 +3388,16 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
+ws@^8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
 xml-utils@^1.0.2:
   version "1.10.1"
   resolved "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.1.tgz"
@@ -2690,6 +3420,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/mobile/asa-go/yarn.lock
+++ b/mobile/asa-go/yarn.lock
@@ -84,9 +84,9 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@capacitor/android@^7.0.0":
+"@capacitor/android@7.0.0":
   version "7.0.0"
-  resolved "https://registry.npmjs.org/@capacitor/android/-/android-7.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/@capacitor/android/-/android-7.0.0.tgz#232439e19c037301fa0a49a20675325d4929469a"
   integrity sha512-T7WMJPGlzEzNFI3s3lA8F2H6XyYzQM8OwgIfPKOAbawc6Fq669ABKIpfNPzsQHR1kVxH3cMHYSkDaPMgJyDdXQ==
 
 "@capacitor/app@7.0.0":
@@ -123,6 +123,11 @@
   integrity sha512-JMJxPi/tHeOR/I87/P0kc1DUKrj+XfXlYTnNZ8sCp4LA/MPLkTOzpZm3cga7fTY0nWaSqLll2xalrC0psQBfuA==
   dependencies:
     tslib "^2.1.0"
+
+"@capacitor/filesystem@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@capacitor/filesystem/-/filesystem-7.0.0.tgz#3823c5a63dfa2992db401832db1dbe6063f1b1a7"
+  integrity sha512-xMzLq+ZaqYBAincYOKF1eNy/3UWwx1XM6TuvWBTVQTHeRsURzqwwbqBKtfkhbRzk5wnXEprWZz5k5iFo2s2BXw==
 
 "@capacitor/haptics@7.0.0":
   version "7.0.0"
@@ -2178,7 +2183,7 @@ plist@^3.1.0:
 
 pmtiles@^4.2.1:
   version "4.2.1"
-  resolved "https://registry.npmjs.org/pmtiles/-/pmtiles-4.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/pmtiles/-/pmtiles-4.2.1.tgz#e403e018cafd91ed573c7aa3defd800a236f2012"
   integrity sha512-Z73aph49f7KpU7JPb+zDWr+62wPv9jF3p+tvvL26/XeECnzUHnQ0nGopXGPYnq+OQXqyaXZPrsNdKxSD+2HlLA==
   dependencies:
     fflate "^0.8.2"
@@ -2608,7 +2613,7 @@ util-deprecate@^1.0.1:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-vite@^6.0.9:
+vite@^6.0.5:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/vite/-/vite-6.0.11.tgz#224497e93e940b34c3357c9ebf2ec20803091ed8"
   integrity sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==


### PR DESCRIPTION
- Only tested on iOS simulator so far -- added filesystem permissions on iOS to app manifest
- Adds the capacitor filesystem package for reading and writing files to device disk
- Implements a custom openlayers `VectorTileSource` called `PMTilesFileVectorSource` that heavily borrows from the official `PMTilesVectorSource` that adds file specific tile loading.
- Implements a file cache that attempts to load stored copies of hfi, fire centre, fire zone and labels pmtiles falling back on an attempt to loading from object storage

Closes #4220 

# Test Links:
[Landing Page](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[PSU Insights](https://wps-pr-4238-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
