### PR TITLE
TPI Proportions 2

### DIFF
--- a/api/alembic/versions/1e6932096921_fuel_area_per_tpi_class.py
+++ b/api/alembic/versions/1e6932096921_fuel_area_per_tpi_class.py
@@ -1,0 +1,41 @@
+"""Fuel area per TPI class
+
+Revision ID: 1e6932096921
+Revises: 4014ddf1f874
+Create Date: 2025-01-21 09:48:41.621501
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "1e6932096921"
+down_revision = "4014ddf1f874"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "tpi_fuel_area",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("advisory_shape_id", sa.Integer(), nullable=False),
+        sa.Column("tpi_class", sa.Enum("valley_bottom", "mid_slope", "upper_slope", name="tpiclassenum"), nullable=False),
+        sa.Column("fuel_area", sa.Float(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["advisory_shape_id"],
+            ["advisory_shapes.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        comment="Combustible area in each TPI class per fire zone unit.",
+    )
+    op.create_index(op.f("ix_tpi_fuel_area_advisory_shape_id"), "tpi_fuel_area", ["advisory_shape_id"], unique=False)
+    op.create_index(op.f("ix_tpi_fuel_area_id"), "tpi_fuel_area", ["id"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_tpi_fuel_area_id"), table_name="tpi_fuel_area")
+    op.drop_index(op.f("ix_tpi_fuel_area_advisory_shape_id"), table_name="tpi_fuel_area")
+    op.drop_table("tpi_fuel_area")

--- a/api/alembic/versions/fa4b3ecb57fe_populate_tpi_fuel_area_table.py
+++ b/api/alembic/versions/fa4b3ecb57fe_populate_tpi_fuel_area_table.py
@@ -5,8 +5,12 @@ Revises: 1e6932096921
 Create Date: 2025-01-21 10:04:48.838953
 
 """
+from alembic import op
+import geoalchemy2
+import sqlalchemy as sa
 
-from app.auto_spatial_advisory.process_tpi_fuel_area import process_tpi_fuel_area
+from sqlalchemy.orm.session import Session
+from app.auto_spatial_advisory.process_tpi_fuel_area import calculate_masked_tpi_areas
 
 
 # revision identifiers, used by Alembic.
@@ -15,11 +19,49 @@ down_revision = "1e6932096921"
 branch_labels = None
 depends_on = None
 
+shape_type_table = sa.Table("advisory_shape_types", sa.MetaData(), sa.Column("id", sa.Integer), sa.Column("name", sa.String))
+
+shape_table = sa.Table(
+    "advisory_shapes",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer),
+    sa.Column("source_identifier", sa.String),
+    sa.Column("shape_type", sa.Integer),
+    sa.Column("geom", geoalchemy2.Geometry),
+)
+
+tpi_area_table = sa.Table(
+    "tpi_fuel_area",
+    sa.MetaData(),
+    sa.Column("advisory_shape_id", sa.Integer),
+    sa.Column("tpi_class", sa.Enum("valley_bottom", "mid_slope", "upper_slope", name="tpiclassenum")),
+    sa.Column("fuel_area", sa.Float),
+)
+
+
+def get_fire_zone_unit_shape_type_id(session: Session):
+    statement = shape_type_table.select().where(shape_type_table.c.name == "fire_zone_unit")
+    result = session.execute(statement).fetchone()
+    return result.id
+
+
+def get_fire_zone_units(session: Session, fire_zone_type_id: int):
+    statement = shape_table.select().where(shape_table.c.shape_type == fire_zone_type_id)
+    result = session.execute(statement).fetchall()
+    return result
+
 
 def upgrade():
-    process_tpi_fuel_area()
-    pass
+    session = Session(bind=op.get_bind())
+    fire_zone_shape_type_id = get_fire_zone_unit_shape_type_id(session)
+    zone_units = get_fire_zone_units(session, fire_zone_shape_type_id)
+    tpi_area = calculate_masked_tpi_areas(zone_units)
+    for tuple in tpi_area:
+        stmt = sa.insert(tpi_area_table).values(advisory_shape_id=tuple[0], tpi_class=tuple[1].name, fuel_area=tuple[2])
+        session.execute(stmt)
 
 
 def downgrade():
-    pass
+    session = Session(bind=op.get_bind())
+    stmt = sa.delete(tpi_area_table)
+    session.execute(stmt)

--- a/api/alembic/versions/fa4b3ecb57fe_populate_tpi_fuel_area_table.py
+++ b/api/alembic/versions/fa4b3ecb57fe_populate_tpi_fuel_area_table.py
@@ -57,7 +57,7 @@ def upgrade():
     zone_units = get_fire_zone_units(session, fire_zone_shape_type_id)
     tpi_area = calculate_masked_tpi_areas(zone_units)
     for tuple in tpi_area:
-        stmt = sa.insert(tpi_area_table).values(advisory_shape_id=tuple[0], tpi_class=tuple[1].name, fuel_area=tuple[2])
+        stmt = sa.insert(tpi_area_table).values(advisory_shape_id=tuple[0], tpi_class=tuple[1].name, fuel_area=tuple[2].item())
         session.execute(stmt)
 
 

--- a/api/alembic/versions/fa4b3ecb57fe_populate_tpi_fuel_area_table.py
+++ b/api/alembic/versions/fa4b3ecb57fe_populate_tpi_fuel_area_table.py
@@ -1,0 +1,25 @@
+"""Populate tpi_fuel_area table
+
+Revision ID: fa4b3ecb57fe
+Revises: 1e6932096921
+Create Date: 2025-01-21 10:04:48.838953
+
+"""
+
+from app.auto_spatial_advisory.process_tpi_fuel_area import process_tpi_fuel_area
+
+
+# revision identifiers, used by Alembic.
+revision = "fa4b3ecb57fe"
+down_revision = "1e6932096921"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    process_tpi_fuel_area()
+    pass
+
+
+def downgrade():
+    pass

--- a/api/app/.env.example
+++ b/api/app/.env.example
@@ -57,4 +57,5 @@ OBJECT_STORE_BUCKET=object_store_bucket
 DEM_NAME=dem_mosaic_250_max.tif
 TPI_DEM_NAME=bc_dem_50m_tpi.tif
 CLASSIFIED_TPI_DEM_NAME=bc_dem_50m_tpi_win100_classified.tif
+CLASSIFIED_TPI_DEM_FUEL_MASKED_NAME=bc_dem_50m_tpi_win100_classified_fuel_masked.tif
 SENTRY_DSN=some_dsn

--- a/api/app/auto_spatial_advisory/elevation.py
+++ b/api/app/auto_spatial_advisory/elevation.py
@@ -32,7 +32,6 @@ async def process_elevation_tpi(run_type: RunType, run_datetime: datetime, for_d
     """
     Create new elevation statistics records for the given parameters.
 
-    :param hfi_s3_key: the object store key pointing to the hfi tif to intersect with tpi layer
     :param run_type: The type of run to process. (is it a forecast or actual run?)
     :param run_datetime: The date and time of the run to process. (when was the hfi file created?)
     :param for_date: The date of the hfi to process. (when is the hfi for?)

--- a/api/app/auto_spatial_advisory/local/generate_fuel_masked_tpi.py
+++ b/api/app/auto_spatial_advisory/local/generate_fuel_masked_tpi.py
@@ -1,0 +1,70 @@
+import asyncio
+import os
+import numpy as np
+import tempfile
+from osgeo import gdal
+
+from app import config
+from app.auto_spatial_advisory.process_fuel_type_area import get_fuel_type_s3_key
+from app.utils.geospatial import GDALResamplingMethod, warp_to_match_raster
+from app.utils.s3 import set_s3_gdal_config
+from app.utils.s3_client import S3Client
+
+
+def prepare_masked_tif(temp_dir: str) -> str:
+    """
+    Creates a masked TPI raster using a classified TPI raster from S3 storage and masking it using the fuel layer
+    also from S3 storage
+    """
+    # Open up our rasters with gdal
+    set_s3_gdal_config()
+    bucket = config.get("OBJECT_STORE_BUCKET")
+    tpi_raster_name = config.get("CLASSIFIED_TPI_DEM_NAME")
+    fuel_raster_key = get_fuel_type_s3_key(bucket)
+    tpi_raster_key = f"/vsis3/{bucket}/dem/tpi/{tpi_raster_name}"
+    fuel_ds: gdal.Dataset = gdal.Open(fuel_raster_key, gdal.GA_ReadOnly)  # LCC projection
+    tpi_ds: gdal.Dataset = gdal.Open(tpi_raster_key, gdal.GA_ReadOnly)  # BC Albers 3005 projection
+
+    # Warp the fuel raster to match extent, spatial reference and cell size of the TPI raster
+    warped_fuel_path = "/vsimem/warped_fuel.tif"
+    warped_fuel_ds: gdal.Dataset = warp_to_match_raster(fuel_ds, tpi_ds, warped_fuel_path, GDALResamplingMethod.NEAREST_NEIGHBOUR)
+
+    # Convert the warped fuel dataset into a binary mask by classifying fuel cells as 1 and non-fuel cells as 0.
+    warped_fuel_band: gdal.Band = warped_fuel_ds.GetRasterBand(1)
+    warped_fuel_data: np.ndarray = warped_fuel_band.ReadAsArray()
+    mask = np.where((warped_fuel_data > 0) & (warped_fuel_data < 99), 1, 0)
+
+    # Some helpful things for creating the final masked TPI raster
+    geo_transform = tpi_ds.GetGeoTransform()
+    tpi_ds_srs = tpi_ds.GetProjection()
+    tpi_band: gdal.Band = tpi_ds.GetRasterBand(1)
+    tpi_data = tpi_band.ReadAsArray()
+
+    # Apply the fuel layer mask to the classified TPI raster and store the result in an in-memory gdal dataset
+    masked_tpi_data = np.multiply(mask, tpi_data)
+    output_driver: gdal.Driver = gdal.GetDriverByName("GTiff")
+    output_path = os.path.join(temp_dir, config.get("CLASSIFIED_TPI_DEM_FUEL_MASKED_NAME"))
+    masked_tpi_dataset: gdal.Dataset = output_driver.Create(output_path, xsize=tpi_band.XSize, ysize=tpi_band.YSize, bands=1, eType=gdal.GDT_Byte)
+    masked_tpi_dataset.SetGeoTransform(geo_transform)
+    masked_tpi_dataset.SetProjection(tpi_ds_srs)
+    masked_fuel_type_band: gdal.Band = masked_tpi_dataset.GetRasterBand(1)
+    masked_fuel_type_band.SetNoDataValue(0)
+    masked_fuel_type_band.WriteArray(masked_tpi_data)
+    fuel_ds = None
+    tpi_ds = None
+    masked_tpi_dataset
+    return output_path
+
+
+async def create_fuel_masked_tpi_raster():
+    async with S3Client() as s3_client:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            masked_tpi_path = prepare_masked_tif(temp_dir)
+            masked_tpi_key = f"dem/tpi/{config.get("CLASSIFIED_TPI_DEM_FUEL_MASKED_NAME")}"
+            await s3_client.put_object(key=masked_tpi_key, body=open(masked_tpi_path, "rb"))
+
+
+if __name__ == "__main__":
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(create_fuel_masked_tpi_raster())

--- a/api/app/auto_spatial_advisory/local/generate_fuel_masked_tpi.py
+++ b/api/app/auto_spatial_advisory/local/generate_fuel_masked_tpi.py
@@ -52,7 +52,7 @@ def prepare_masked_tif(temp_dir: str) -> str:
     masked_fuel_type_band.WriteArray(masked_tpi_data)
     fuel_ds = None
     tpi_ds = None
-    masked_tpi_dataset
+    masked_tpi_dataset = None
     return output_path
 
 

--- a/api/app/auto_spatial_advisory/process_tpi_fuel_area.py
+++ b/api/app/auto_spatial_advisory/process_tpi_fuel_area.py
@@ -4,15 +4,9 @@ from osgeo import gdal, ogr, osr
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 from app import config
-from app.auto_spatial_advisory.process_fuel_type_area import get_fuel_type_s3_key
 from app.db.database import get_write_session_scope
 from app.db.models.auto_spatial_advisory import Shape, TPIClassEnum, TPIFuelArea
-from app.utils.geospatial import GDALResamplingMethod, warp_to_match_raster
 from app.utils.s3 import set_s3_gdal_config
-
-
-REPROJECTED_FUEL_LAYER_NAME = "warped_fuel.tif"
-MASKED_TPI_NAME = "masked_tpi.tif"
 
 
 def store_tpi_area_data(session: Session, advisory_shape_id: int, data: np.ndarray, pixel_size: int):
@@ -31,49 +25,6 @@ def store_tpi_area_data(session: Session, advisory_shape_id: int, data: np.ndarr
             fuel_area = count * pixel_size * pixel_size
             tpi_fuel_area = TPIFuelArea(advisory_shape_id=advisory_shape_id, tpi_class=tpi_enum, fuel_area=fuel_area)
             session.add(tpi_fuel_area)
-
-
-def prepare_masked_tif():
-    """
-    Creates a masked TPI raster using a classified TPI raster from S3 storage and masking it using the fuel layer
-    also from S3 storage
-    """
-    # Open up our rasters with gdal
-    set_s3_gdal_config()
-    bucket = config.get("OBJECT_STORE_BUCKET")
-    tpi_raster_name = config.get("CLASSIFIED_TPI_DEM_NAME")
-    fuel_raster_key = get_fuel_type_s3_key(bucket)
-    tpi_raster_key = f"/vsis3/{bucket}/dem/tpi/{tpi_raster_name}"
-    fuel_ds: gdal.Dataset = gdal.Open(fuel_raster_key, gdal.GA_ReadOnly)  # LCC projection
-    tpi_ds: gdal.Dataset = gdal.Open(tpi_raster_key, gdal.GA_ReadOnly)  # BC Albers 3005 projection
-
-    # Warp the fuel raster to match extent, spatial reference and cell size of the TPI raster
-    warped_fuel_path = f"/vsimem/{REPROJECTED_FUEL_LAYER_NAME}"
-    warped_fuel_ds: gdal.Dataset = warp_to_match_raster(fuel_ds, tpi_ds, warped_fuel_path, GDALResamplingMethod.NEAREST_NEIGHBOUR)
-
-    # Convert the warped fuel dataset into a binary mask by classifying fuel cells as 1 and non-fuel cells as 0.
-    warped_fuel_band: gdal.Band = warped_fuel_ds.GetRasterBand(1)
-    warped_fuel_data: np.ndarray = warped_fuel_band.ReadAsArray()
-    mask = np.where((warped_fuel_data > 0) & (warped_fuel_data < 99), 1, 0)
-
-    # Some helpful things for creating the final masked TPI raster
-    geo_transform = tpi_ds.GetGeoTransform()
-    tpi_ds_srs = tpi_ds.GetProjection()
-    tpi_band: gdal.Band = tpi_ds.GetRasterBand(1)
-    tpi_data = tpi_band.ReadAsArray()
-
-    # Apply the fuel layer mask to the classified TPI raster and store the result in an in-memory gdal dataset
-    masked_tpi_data = np.multiply(mask, tpi_data)
-    output_driver: gdal.Driver = gdal.GetDriverByName("MEM")
-    masked_tpi_dataset: gdal.Dataset = output_driver.Create(f"/vsimem/{MASKED_TPI_NAME}", xsize=tpi_band.XSize, ysize=tpi_band.YSize, bands=1, eType=gdal.GDT_Byte)
-    masked_tpi_dataset.SetGeoTransform(geo_transform)
-    masked_tpi_dataset.SetProjection(tpi_ds_srs)
-    masked_fuel_type_band: gdal.Band = masked_tpi_dataset.GetRasterBand(1)
-    masked_fuel_type_band.SetNoDataValue(0)
-    masked_fuel_type_band.WriteArray(masked_tpi_data)
-    fuel_ds = None
-    tpi_ds = None
-    return masked_tpi_dataset
 
 
 def prepare_wkt_geom_for_gdal(wkt_geom: str):
@@ -96,7 +47,10 @@ def process_tpi_fuel_area():
     """
     Entry point for calculating the fuel layer masked area of each TPI class (valley bottom, mid slope and upper slope) per fire zone unit.
     """
-    masked_tpi_ds: gdal.Dataset = prepare_masked_tif()
+    set_s3_gdal_config()
+    bucket = config.get("OBJECT_STORE_BUCKET")
+    masked_tpi_key = f"/vsis3/{bucket}/dem/tpi/{config.get("CLASSIFIED_TPI_DEM_FUEL_MASKED_NAME")}"
+    masked_tpi_ds: gdal.Dataset = gdal.Open(masked_tpi_key, gdal.GA_ReadOnly)
     masked_tpi_pixel_size = masked_tpi_ds.GetGeoTransform()[1]
 
     with get_write_session_scope() as session:

--- a/api/app/auto_spatial_advisory/process_tpi_fuel_area.py
+++ b/api/app/auto_spatial_advisory/process_tpi_fuel_area.py
@@ -1,0 +1,118 @@
+import numpy as np
+from osgeo import gdal, ogr, osr
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+from app import config
+from app.auto_spatial_advisory.process_fuel_type_area import get_fuel_type_s3_key
+from app.db.database import get_write_session_scope
+from app.db.models.auto_spatial_advisory import Shape, TPIClassEnum, TPIFuelArea
+from app.utils.geospatial import GDALResamplingMethod, warp_to_match_raster
+from app.utils.s3 import set_s3_gdal_config
+
+
+REPROJECTED_FUEL_LAYER_NAME = "warped_fuel.tif"
+MASKED_TPI_NAME = "masked_tpi.tif"
+
+
+def store_tpi_area_data(session: Session, advisory_shape_id: int, data: np.ndarray, pixel_size: int):
+    """
+    Save TPIFuelArea records to the API database.
+
+        :param session: A synchronous sqlalchemy session object.
+        :param advisory_shape_id: A fire zone id used as a foreign key to the advisory_shapes table.
+        :param data: A numpy ndarray containing classified TPI values that have been masked by the fuel layer.
+        :param pixel_size: The size of the cells in the TPI layer.
+    """
+    unique_values, counts = np.unique(data, return_counts=True)
+    for value, count in zip(unique_values, counts):
+        if value in TPIClassEnum:
+            tpi_enum = TPIClassEnum(value)
+            fuel_area = count * pixel_size * pixel_size
+            tpi_fuel_area = TPIFuelArea(advisory_shape_id=advisory_shape_id, tpi_class=tpi_enum, fuel_area=fuel_area)
+            session.add(tpi_fuel_area)
+
+
+def prepare_masked_tif():
+    """
+    Creates a masked TPI raster using a classified TPI raster from S3 storage and masking it using the fuel layer
+    also from S3 storage
+    """
+    # Open up our rasters with gdal
+    set_s3_gdal_config()
+    bucket = config.get("OBJECT_STORE_BUCKET")
+    tpi_raster_name = config.get("CLASSIFIED_TPI_DEM_NAME")
+    fuel_raster_key = get_fuel_type_s3_key(bucket)
+    tpi_raster_key = f"/vsis3/{bucket}/dem/tpi/{tpi_raster_name}"
+    fuel_ds: gdal.Dataset = gdal.Open(fuel_raster_key, gdal.GA_ReadOnly)  # LCC projection
+    tpi_ds: gdal.Dataset = gdal.Open(tpi_raster_key, gdal.GA_ReadOnly)  # BC Albers 3005 projection
+
+    # Warp the fuel raster to match extent, spatial reference and cell size of the TPI raster
+    warped_fuel_path = f"/vsimem/{REPROJECTED_FUEL_LAYER_NAME}"
+    warped_fuel_ds: gdal.Dataset = warp_to_match_raster(fuel_ds, tpi_ds, warped_fuel_path, GDALResamplingMethod.NEAREST_NEIGHBOUR)
+
+    # Convert the warped fuel dataset into a binary mask by classifying fuel cells as 1 and non-fuel cells as 0.
+    warped_fuel_band: gdal.Band = warped_fuel_ds.GetRasterBand(1)
+    warped_fuel_data: np.ndarray = warped_fuel_band.ReadAsArray()
+    mask = np.where((warped_fuel_data > 0) & (warped_fuel_data < 99), 1, 0)
+
+    # Some helpful things for creating the final masked TPI raster
+    geo_transform = tpi_ds.GetGeoTransform()
+    tpi_ds_srs = tpi_ds.GetProjection()
+    tpi_band: gdal.Band = tpi_ds.GetRasterBand(1)
+    tpi_data = tpi_band.ReadAsArray()
+
+    # Apply the fuel layer mask to the classified TPI raster and store the result in an in-memory gdal dataset
+    masked_tpi_data = np.multiply(mask, tpi_data)
+    output_driver: gdal.Driver = gdal.GetDriverByName("MEM")
+    masked_tpi_dataset: gdal.Dataset = output_driver.Create(f"/vsimem/{MASKED_TPI_NAME}", xsize=tpi_band.XSize, ysize=tpi_band.YSize, bands=1, eType=gdal.GDT_Byte)
+    masked_tpi_dataset.SetGeoTransform(geo_transform)
+    masked_tpi_dataset.SetProjection(tpi_ds_srs)
+    masked_fuel_type_band: gdal.Band = masked_tpi_dataset.GetRasterBand(1)
+    masked_fuel_type_band.SetNoDataValue(0)
+    masked_fuel_type_band.WriteArray(masked_tpi_data)
+    fuel_ds = None
+    tpi_ds = None
+    return masked_tpi_dataset
+
+
+def prepare_wkt_geom_for_gdal(wkt_geom: str):
+    """
+    Given a wkt geometry as a string, convert it to an ogr.Geometry that can be used by gdal.
+
+    :param wkt_geom: The wky geometry string.
+    :return: An osr.Geometry.
+    """
+    geometry: ogr.Geometry = ogr.CreateGeometryFromWkt(wkt_geom)
+    source_srs = osr.SpatialReference()
+    source_srs.ImportFromEPSG(3005)
+    geometry.AssignSpatialReference(source_srs)
+    transform = osr.CoordinateTransformation(geometry.GetSpatialReference(), source_srs)
+    geometry.Transform(transform)
+    return geometry
+
+
+def process_tpi_fuel_area():
+    """
+    Entry point for calculating the fuel layer masked area of each TPI class (valley bottom, mid slope and upper slope) per fire zone unit.
+    """
+    masked_tpi_ds: gdal.Dataset = prepare_masked_tif()
+    masked_tpi_pixel_size = masked_tpi_ds.GetGeoTransform()[1]
+
+    with get_write_session_scope() as session:
+        # Iterate through the fire zone units from the advisory_shapes table
+        stmt = select(Shape.id, func.ST_AsText(Shape.geom))
+        result = session.execute(stmt)
+        for row in result:
+            # Convert the WKT geometry of a fire zone unit into a form that can be used by gdal
+            geometry = prepare_wkt_geom_for_gdal(row[1])
+
+            # Us gdal.Warp to clip out our fire zone unit from the masked tpi raster and then store areas in the tpi_fuel_area table
+            warp_options = gdal.WarpOptions(cutlineWKT=geometry, cutlineSRS=geometry.GetSpatialReference(), cropToCutline=True)
+            intersected_path = "/vsimem/intersected.tif"
+            intersected_ds: gdal.Dataset = gdal.Warp(intersected_path, masked_tpi_ds, options=warp_options)
+            intersected_band: gdal.Band = intersected_ds.GetRasterBand(1)
+            intersected_data: np.ndarray = intersected_band.ReadAsArray()
+            store_tpi_area_data(session, advisory_shape_id=row[0], data=intersected_data, pixel_size=masked_tpi_pixel_size)
+            intersected_ds = None
+    masked_tpi_ds = None

--- a/api/app/auto_spatial_advisory/process_tpi_fuel_area.py
+++ b/api/app/auto_spatial_advisory/process_tpi_fuel_area.py
@@ -1,19 +1,15 @@
 import numpy as np
+from geoalchemy2.shape import to_shape
 from osgeo import gdal, ogr, osr
-
-from sqlalchemy import func, select
-from sqlalchemy.orm import Session
 from app import config
-from app.db.database import get_write_session_scope
-from app.db.models.auto_spatial_advisory import Shape, TPIClassEnum, TPIFuelArea
+from app.db.models.auto_spatial_advisory import TPIClassEnum
 from app.utils.s3 import set_s3_gdal_config
 
 
-def store_tpi_area_data(session: Session, advisory_shape_id: int, data: np.ndarray, pixel_size: int):
+def calculate_tpi_area_data_for_zone(advisory_shape_id: int, data: np.ndarray, pixel_size: int):
     """
     Save TPIFuelArea records to the API database.
 
-        :param session: A synchronous sqlalchemy session object.
         :param advisory_shape_id: A fire zone id used as a foreign key to the advisory_shapes table.
         :param data: A numpy ndarray containing classified TPI values that have been masked by the fuel layer.
         :param pixel_size: The size of the cells in the TPI layer.
@@ -23,8 +19,7 @@ def store_tpi_area_data(session: Session, advisory_shape_id: int, data: np.ndarr
         if value in TPIClassEnum:
             tpi_enum = TPIClassEnum(value)
             fuel_area = count * pixel_size * pixel_size
-            tpi_fuel_area = TPIFuelArea(advisory_shape_id=advisory_shape_id, tpi_class=tpi_enum, fuel_area=fuel_area)
-            session.add(tpi_fuel_area)
+            yield (advisory_shape_id, tpi_enum, fuel_area)
 
 
 def prepare_wkt_geom_for_gdal(wkt_geom: str):
@@ -43,7 +38,7 @@ def prepare_wkt_geom_for_gdal(wkt_geom: str):
     return geometry
 
 
-def process_tpi_fuel_area():
+def calculate_masked_tpi_areas(zones):
     """
     Entry point for calculating the fuel layer masked area of each TPI class (valley bottom, mid slope and upper slope) per fire zone unit.
     """
@@ -53,20 +48,20 @@ def process_tpi_fuel_area():
     masked_tpi_ds: gdal.Dataset = gdal.Open(masked_tpi_key, gdal.GA_ReadOnly)
     masked_tpi_pixel_size = masked_tpi_ds.GetGeoTransform()[1]
 
-    with get_write_session_scope() as session:
-        # Iterate through the fire zone units from the advisory_shapes table
-        stmt = select(Shape.id, func.ST_AsText(Shape.geom))
-        result = session.execute(stmt)
-        for row in result:
-            # Convert the WKT geometry of a fire zone unit into a form that can be used by gdal
-            geometry = prepare_wkt_geom_for_gdal(row[1])
+    for zone in zones:
+        zone_wkb = zone.geom
+        shapely_zone_geom = to_shape(zone_wkb)
+        zone_wkt = shapely_zone_geom.wkt
+        zone_geom = prepare_wkt_geom_for_gdal(zone_wkt)
 
-            # Us gdal.Warp to clip out our fire zone unit from the masked tpi raster and then store areas in the tpi_fuel_area table
-            warp_options = gdal.WarpOptions(cutlineWKT=geometry, cutlineSRS=geometry.GetSpatialReference(), cropToCutline=True)
-            intersected_path = "/vsimem/intersected.tif"
-            intersected_ds: gdal.Dataset = gdal.Warp(intersected_path, masked_tpi_ds, options=warp_options)
-            intersected_band: gdal.Band = intersected_ds.GetRasterBand(1)
-            intersected_data: np.ndarray = intersected_band.ReadAsArray()
-            store_tpi_area_data(session, advisory_shape_id=row[0], data=intersected_data, pixel_size=masked_tpi_pixel_size)
-            intersected_ds = None
+        # Use gdal.Warp to clip out our fire zone unit from the masked tpi raster
+        warp_options = gdal.WarpOptions(cutlineWKT=zone_geom, cutlineSRS=zone_geom.GetSpatialReference(), cropToCutline=True)
+        intersected_path = "/vsimem/intersected.tif"
+        intersected_ds: gdal.Dataset = gdal.Warp(intersected_path, masked_tpi_ds, options=warp_options)
+        intersected_band: gdal.Band = intersected_ds.GetRasterBand(1)
+        intersected_data: np.ndarray = intersected_band.ReadAsArray()
+        intersected_ds = None
+        tpi_area_data = calculate_tpi_area_data_for_zone(advisory_shape_id=zone.id, data=intersected_data, pixel_size=masked_tpi_pixel_size)
+        for tpi_area in tpi_area_data:
+            yield tpi_area
     masked_tpi_ds = None

--- a/api/app/db/crud/auto_spatial_advisory.py
+++ b/api/app/db/crud/auto_spatial_advisory.py
@@ -455,9 +455,15 @@ async def get_centre_tpi_stats(session: AsyncSession, fire_centre_name: str, run
     result = await session.execute(stmt)
     return result.all()
 
+async def get_fire_zone_tpi_fuel_areas(session: AsyncSession, fire_zone_id):
+    stmt = select(TPIFuelArea).join(Shape, Shape.id == TPIFuelArea.advisory_shape_id).where(Shape.source_identifier == fire_zone_id)
+    result = await session.execute(stmt)
+    return result.all()
+
+
 async def get_fire_centre_tpi_fuel_areas(session: AsyncSession, fire_centre_name: str):
     stmt = (
-        select(TPIFuelArea, Shape.source_identifier)
+        select(TPIFuelArea.tpi_class, TPIFuelArea.fuel_area, Shape.source_identifier)
         .join(Shape, Shape.id == TPIFuelArea.advisory_shape_id)
         .join(FireCentre, FireCentre.id == Shape.fire_centre)
         .where(FireCentre.name == fire_centre_name)

--- a/api/app/db/crud/auto_spatial_advisory.py
+++ b/api/app/db/crud/auto_spatial_advisory.py
@@ -23,6 +23,7 @@ from app.db.models.auto_spatial_advisory import (
     AdvisoryElevationStats,
     AdvisoryTPIStats,
     ShapeType,
+    TPIFuelArea,
 )
 from app.db.models.hfi_calc import FireCentre
 
@@ -451,6 +452,16 @@ async def get_centre_tpi_stats(session: AsyncSession, fire_centre_name: str, run
         .where(FireCentre.name == fire_centre_name, AdvisoryTPIStats.run_parameters == run_parameters_id)
     )
 
+    result = await session.execute(stmt)
+    return result.all()
+
+async def get_fire_centre_tpi_fuel_areas(session: AsyncSession, fire_centre_name: str):
+    stmt = (
+        select(TPIFuelArea, Shape.source_identifier)
+        .join(Shape, Shape.id == TPIFuelArea.advisory_shape_id)
+        .join(FireCentre, FireCentre.id == Shape.fire_centre)
+        .where(FireCentre.name == fire_centre_name)
+    )
     result = await session.execute(stmt)
     return result.all()
 

--- a/api/app/db/models/auto_spatial_advisory.py
+++ b/api/app/db/models/auto_spatial_advisory.py
@@ -30,6 +30,11 @@ class RunTypeEnum(enum.Enum):
     forecast = "forecast"
     actual = "actual"
 
+class TPIClassEnum(enum.Enum):
+    valley_bottom = 1
+    mid_slope = 2
+    upper_slope = 3
+
 
 class ShapeType(Base):
     """Identify some kind of area type, e.g. "Zone", or "Fire" """
@@ -227,3 +232,15 @@ class CriticalHours(Base):
     fuel_type = Column(Integer, ForeignKey(SFMSFuelType.id), nullable=False, index=True)
     start_hour = Column(Integer, nullable=False)
     end_hour = Column(Integer, nullable=False)
+
+class TPIFuelArea(Base):
+    """
+    Combustible area in each TPI class per fire zone unit.
+    """
+
+    __tablename__ = "tpi_fuel_area"
+    __table_args__ = {"comment": "Combustible area in each TPI class per fire zone unit."}
+    id = Column(Integer, primary_key=True, index=True)
+    advisory_shape_id = Column(Integer, ForeignKey(Shape.id), nullable=False, index=True)
+    tpi_class = Column(Enum(TPIClassEnum), nullable=False)
+    fuel_area = Column(Float, nullable=False)

--- a/api/app/routers/fba.py
+++ b/api/app/routers/fba.py
@@ -27,7 +27,6 @@ from app.schemas.fba import (
     FireCentreTPIResponse,
     FireShapeAreaListResponse,
     FireShapeArea,
-    FireZoneTPIArea,
     FireZoneTPIStats,
     SFMSFuelType,
     HfiThreshold,

--- a/api/app/routers/fba.py
+++ b/api/app/routers/fba.py
@@ -11,6 +11,7 @@ from app.db.crud.auto_spatial_advisory import (
     get_all_sfms_fuel_types,
     get_all_hfi_thresholds,
     get_fire_centre_tpi_fuel_areas,
+    get_fire_zone_tpi_fuel_areas,
     get_hfi_area,
     get_precomputed_stats_for_shape,
     get_provincial_rollup,
@@ -168,11 +169,26 @@ async def get_fire_zone_tpi_stats(fire_zone_id: int, run_type: RunType, run_date
     async with get_async_read_session_scope() as session:
         stats = await get_zonal_tpi_stats(session, fire_zone_id, run_type, run_datetime, for_date)
         square_metres = math.pow(stats.pixel_size_metres, 2) if stats is not None else None
+        tpi_fuel_stats = await get_fire_zone_tpi_fuel_areas(session, fire_zone_id)
+        valley_bottom_tpi = None
+        mid_slope_tpi = None
+        upper_slope_tpi = None
+
+        for tpi_fuel_stat in tpi_fuel_stats:
+            if tpi_fuel_stat.tpi_class == TPIClassEnum.valley_bottom:
+                valley_bottom_tpi = tpi_fuel_stat.fuel_area
+            elif tpi_fuel_stat.tpi_class == TPIClassEnum.mid_slope:
+                mid_slope_tpi = tpi_fuel_stat.fuel_area
+            elif tpi_fuel_stat.tpi_class == TPIClassEnum.upper_slope:
+                upper_slope_tpi = tpi_fuel_stat.fuel_area
         return FireZoneTPIStats(
             fire_zone_id=fire_zone_id,
-            valley_bottom=stats.valley_bottom * square_metres if stats is not None else None,
-            mid_slope=stats.mid_slope * square_metres if stats is not None else None,
-            upper_slope=stats.upper_slope * square_metres if stats is not None else None,
+            valley_bottom_hfi=stats.valley_bottom * square_metres if stats is not None else None,
+            valley_bottom_tpi=valley_bottom_tpi,
+            mid_slope_hfi=stats.mid_slope * square_metres if stats is not None else None,
+            mid_slope_tpi=mid_slope_tpi,
+            upper_slope_hfi=stats.upper_slope * square_metres if stats is not None else None,
+            upper_slope_tpi=upper_slope_tpi,
         )
 
 
@@ -188,18 +204,18 @@ async def get_fire_centre_tpi_stats(fire_centre_name: str, run_type: RunType, ru
         for row in tpi_stats_for_centre:
             fire_zone_id = row.source_identifier
             square_metres = math.pow(row.pixel_size_metres, 2)
-            tpi_fuel_stats_for_zone = [stats[0] for stats in tpi_fuel_stats if stats[1] == fire_zone_id]
-            valley_bottom_tpi = 0
-            mid_slope_tpi = 0
-            upper_slope_tpi = 0
+            tpi_fuel_stats_for_zone = [stats for stats in tpi_fuel_stats if stats[2] == fire_zone_id]
+            valley_bottom_tpi = None
+            mid_slope_tpi = None
+            upper_slope_tpi = None
 
             for tpi_fuel_stat in tpi_fuel_stats_for_zone:
-                if tpi_fuel_stat.tpi_class == TPIClassEnum.valley_bottom:
-                    valley_bottom_tpi = tpi_fuel_stat.fuel_area
-                elif tpi_fuel_stat.tpi_class == TPIClassEnum.mid_slope:
-                    mid_slope_tpi = tpi_fuel_stat.fuel_area
-                elif tpi_fuel_stat.tpi_class == TPIClassEnum.upper_slope:
-                    upper_slope_tpi = tpi_fuel_stat.fuel_area
+                if tpi_fuel_stat[0] == TPIClassEnum.valley_bottom:
+                    valley_bottom_tpi = tpi_fuel_stat[1]
+                elif tpi_fuel_stat[0] == TPIClassEnum.mid_slope:
+                    mid_slope_tpi = tpi_fuel_stat[1]
+                elif tpi_fuel_stat[0] == TPIClassEnum.upper_slope:
+                    upper_slope_tpi = tpi_fuel_stat[1]
 
             hfi_tpi_areas_by_zone.append(
                 FireZoneTPIStats(

--- a/api/app/schemas/fba.py
+++ b/api/app/schemas/fba.py
@@ -124,9 +124,17 @@ class FireZoneTPIStats(BaseModel):
     """Classified TPI areas of the fire zone contributing to the HFI >4k. Each area is in square metres."""
 
     fire_zone_id: int
-    valley_bottom: Optional[int]
-    mid_slope: Optional[int]
-    upper_slope: Optional[int]
+    valley_bottom_hfi: Optional[int]
+    valley_bottom_tpi: Optional[float]
+    mid_slope_hfi: Optional[int]
+    mid_slope_tpi: Optional[float]
+    upper_slope_hfi: Optional[int]
+    upper_slope_tpi: Optional[float]
+
+
+class FireCentreTPIResponse(BaseModel):
+    fire_centre_name: str
+    firezone_tpi_stats: List[FireZoneTPIStats]
 
 
 class FireZoneElevationStatsByThreshold(BaseModel):

--- a/api/app/tests/fba/test_fba_endpoint.py
+++ b/api/app/tests/fba/test_fba_endpoint.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 from datetime import date, datetime, timezone
 from collections import namedtuple
-from app.db.models.auto_spatial_advisory import AdvisoryTPIStats, HfiClassificationThreshold, RunParameters, SFMSFuelType
+from app.db.models.auto_spatial_advisory import AdvisoryTPIStats, HfiClassificationThreshold, RunParameters, SFMSFuelType, TPIFuelArea, TPIClassEnum
 
 mock_fire_centre_name = "PGFireCentre"
 
@@ -12,12 +12,15 @@ get_fire_centres_url = "/api/fba/fire-centers"
 get_fire_zone_areas_url = "/api/fba/fire-shape-areas/forecast/2022-09-27/2022-09-27"
 get_fire_zone_tpi_stats_url = "/api/fba/fire-zone-tpi-stats/forecast/2022-09-27/2022-09-27/1"
 get_fire_centre_info_url = "/api/fba/fire-centre-hfi-stats/forecast/2022-09-27/2022-09-27/Kamloops%20Fire%20Centre"
-get_fire_zone_elevation_info_url = "/api/fba/fire-zone-elevation-info/forecast/2022-09-27/2022-09-27/1"
 get_fire_centre_tpi_stats_url = f"/api/fba/fire-centre-tpi-stats/forecast/2024-08-10/2024-08-10/{mock_fire_centre_name}"
 get_sfms_run_datetimes_url = "/api/fba/sfms-run-datetimes/forecast/2022-09-27"
 
 decode_fn = "jwt.decode"
 mock_tpi_stats = AdvisoryTPIStats(id=1, advisory_shape_id=1, valley_bottom=1, mid_slope=2, upper_slope=3, pixel_size_metres=50)
+mock_tpi_fuel_area_1 = TPIFuelArea(id=1, advisory_shape_id=1, tpi_class=TPIClassEnum.valley_bottom, fuel_area=1)
+mock_tpi_fuel_area_2 = TPIFuelArea(id=2, advisory_shape_id=1, tpi_class=TPIClassEnum.mid_slope, fuel_area=2)
+mock_tpi_fuel_area_3 = TPIFuelArea(id=3, advisory_shape_id=1, tpi_class=TPIClassEnum.upper_slope, fuel_area=3)
+mock_tpi_fuel_areas = [mock_tpi_fuel_area_1, mock_tpi_fuel_area_2, mock_tpi_fuel_area_3]
 mock_fire_centre_info = [(9.0, 11.0, 1, 1, 50)]
 mock_sfms_run_datetimes = [
     RunParameters(id=1, run_type="forecast", run_datetime=datetime(year=2024, month=1, day=1, hour=1, tzinfo=timezone.utc), for_date=date(year=2024, month=1, day=2))
@@ -26,6 +29,11 @@ mock_sfms_run_datetimes = [
 CentreHFIFuelResponse = namedtuple("CentreHFIFuelResponse", ["advisory_shape_id", "source_identifier", "valley_bottom", "mid_slope", "upper_slope", "pixel_size_metres"])
 mock_centre_tpi_stats_1 = CentreHFIFuelResponse(advisory_shape_id=1, source_identifier=1, valley_bottom=1, mid_slope=2, upper_slope=3, pixel_size_metres=2)
 mock_centre_tpi_stats_2 = CentreHFIFuelResponse(advisory_shape_id=2, source_identifier=2, valley_bottom=1, mid_slope=2, upper_slope=3, pixel_size_metres=2)
+
+CentreTPIFuelAreasResponse = namedtuple("CentreTPIFuelAreasResponse", ["tpi_class", "fuel_area", "source_identifier"])
+mock_centre_tpi_fuel_area_1 = CentreTPIFuelAreasResponse(tpi_class=TPIClassEnum.valley_bottom, fuel_area=1, source_identifier=1)
+mock_centre_tpi_fuel_area_2 = CentreTPIFuelAreasResponse(tpi_class=TPIClassEnum.mid_slope, fuel_area=2, source_identifier=1)
+mock_centre_tpi_fuel_area_3 = CentreTPIFuelAreasResponse(tpi_class=TPIClassEnum.upper_slope, fuel_area=3, source_identifier=1)
 
 
 async def mock_get_fire_centres(*_, **__):
@@ -43,9 +51,16 @@ async def mock_get_auth_header(*_, **__):
 async def mock_get_tpi_stats(*_, **__):
     return mock_tpi_stats
 
+async def mock_get_fire_zone_tpi_fuel_areas(*_, **__):
+    return mock_tpi_fuel_areas
+
 
 async def mock_get_tpi_stats_none(*_, **__):
     return None
+
+
+async def mock_get_fire_zone_tpi_fuel_areas_none(*_, **__):
+    return []
 
 
 async def mock_get_fire_centre_info(*_, **__):
@@ -54,6 +69,10 @@ async def mock_get_fire_centre_info(*_, **__):
 
 async def mock_get_centre_tpi_stats(*_, **__):
     return [mock_centre_tpi_stats_1, mock_centre_tpi_stats_2]
+
+
+async def mock_get_fire_centre_tpi_fuel_areas(*_, **__):
+    return [mock_centre_tpi_fuel_area_1, mock_centre_tpi_fuel_area_2, mock_centre_tpi_fuel_area_3]
 
 
 async def mock_get_sfms_run_datetimes(*_, **__):
@@ -128,6 +147,7 @@ def test_get_sfms_run_datetimes_authorized(client: TestClient):
 
 @patch("app.routers.fba.get_auth_header", mock_get_auth_header)
 @patch("app.routers.fba.get_zonal_tpi_stats", mock_get_tpi_stats)
+@patch("app.routers.fba.get_fire_zone_tpi_fuel_areas", mock_get_fire_zone_tpi_fuel_areas)
 @pytest.mark.usefixtures("mock_jwt_decode")
 def test_get_fire_zone_tpi_stats_authorized(client: TestClient):
     """Allowed to get fire zone tpi stats when authorized"""
@@ -135,38 +155,54 @@ def test_get_fire_zone_tpi_stats_authorized(client: TestClient):
     square_metres = math.pow(mock_tpi_stats.pixel_size_metres, 2)
     assert response.status_code == 200
     assert response.json()["fire_zone_id"] == 1
-    assert response.json()["valley_bottom"] == mock_tpi_stats.valley_bottom * square_metres
-    assert response.json()["mid_slope"] == mock_tpi_stats.mid_slope * square_metres
-    assert response.json()["upper_slope"] == mock_tpi_stats.upper_slope * square_metres
+    assert response.json()["valley_bottom_hfi"] == mock_tpi_stats.valley_bottom * square_metres
+    assert response.json()["mid_slope_hfi"] == mock_tpi_stats.mid_slope * square_metres
+    assert response.json()["upper_slope_hfi"] == mock_tpi_stats.upper_slope * square_metres
+    assert response.json()["valley_bottom_tpi"] == mock_tpi_fuel_area_1.fuel_area
+    assert response.json()["mid_slope_tpi"] == mock_tpi_fuel_area_2.fuel_area
+    assert response.json()["upper_slope_tpi"] == mock_tpi_fuel_area_3.fuel_area
 
 
 @patch("app.routers.fba.get_auth_header", mock_get_auth_header)
 @patch("app.routers.fba.get_zonal_tpi_stats", mock_get_tpi_stats_none)
+@patch("app.routers.fba.get_fire_zone_tpi_fuel_areas", mock_get_fire_zone_tpi_fuel_areas_none)
 @pytest.mark.usefixtures("mock_jwt_decode")
 def test_get_fire_zone_tpi_stats_authorized_none(client: TestClient):
     """Returns none for TPI stats when there are no stats available"""
     response = client.get(get_fire_zone_tpi_stats_url)
     assert response.status_code == 200
     assert response.json()["fire_zone_id"] == 1
-    assert response.json()["valley_bottom"] == None
-    assert response.json()["mid_slope"] == None
-    assert response.json()["upper_slope"] == None
+    assert response.json()["valley_bottom_hfi"] is None
+    assert response.json()["mid_slope_hfi"] is None
+    assert response.json()["upper_slope_hfi"] is None
+    assert response.json()["valley_bottom_tpi"] is None
+    assert response.json()["mid_slope_tpi"] is None
+    assert response.json()["upper_slope_tpi"] is None
 
 
 @patch("app.routers.fba.get_auth_header", mock_get_auth_header)
 @patch("app.routers.fba.get_centre_tpi_stats", mock_get_centre_tpi_stats)
+@patch("app.routers.fba.get_fire_centre_tpi_fuel_areas", mock_get_fire_centre_tpi_fuel_areas)
 @pytest.mark.usefixtures("mock_jwt_decode")
 def test_get_fire_centre_tpi_stats_authorized(client: TestClient):
     """Allowed to get fire zone tpi stats when authorized"""
     response = client.get(get_fire_centre_tpi_stats_url)
     square_metres = math.pow(mock_centre_tpi_stats_2.pixel_size_metres, 2)
     assert response.status_code == 200
-    assert response.json()[mock_fire_centre_name][0]["fire_zone_id"] == 1
-    assert response.json()[mock_fire_centre_name][0]["valley_bottom"] == mock_centre_tpi_stats_1.valley_bottom * square_metres
-    assert response.json()[mock_fire_centre_name][0]["mid_slope"] == mock_centre_tpi_stats_1.mid_slope * square_metres
-    assert response.json()[mock_fire_centre_name][0]["upper_slope"] == mock_centre_tpi_stats_1.upper_slope * square_metres
+    json_response = response.json()
+    assert json_response["fire_centre_name"] == mock_fire_centre_name
+    assert json_response["firezone_tpi_stats"][0]["fire_zone_id"] == 1
+    assert json_response["firezone_tpi_stats"][0]["valley_bottom_hfi"] == mock_centre_tpi_stats_1.valley_bottom * square_metres
+    assert json_response["firezone_tpi_stats"][0]["mid_slope_hfi"] == mock_centre_tpi_stats_1.mid_slope * square_metres
+    assert json_response["firezone_tpi_stats"][0]["upper_slope_hfi"] == mock_centre_tpi_stats_1.upper_slope * square_metres
+    assert json_response["firezone_tpi_stats"][0]["valley_bottom_tpi"] == mock_centre_tpi_fuel_area_1.fuel_area
+    assert json_response["firezone_tpi_stats"][0]["mid_slope_tpi"] == mock_centre_tpi_fuel_area_2.fuel_area
+    assert json_response["firezone_tpi_stats"][0]["upper_slope_tpi"] == mock_centre_tpi_fuel_area_3.fuel_area
 
-    assert response.json()[mock_fire_centre_name][1]["fire_zone_id"] == 2
-    assert response.json()[mock_fire_centre_name][1]["valley_bottom"] == mock_centre_tpi_stats_2.valley_bottom * square_metres
-    assert response.json()[mock_fire_centre_name][1]["mid_slope"] == mock_centre_tpi_stats_2.mid_slope * square_metres
-    assert response.json()[mock_fire_centre_name][1]["upper_slope"] == mock_centre_tpi_stats_2.upper_slope * square_metres
+    assert json_response["firezone_tpi_stats"][1]["fire_zone_id"] == 2
+    assert json_response["firezone_tpi_stats"][1]["valley_bottom_hfi"] == mock_centre_tpi_stats_2.valley_bottom * square_metres
+    assert json_response["firezone_tpi_stats"][1]["mid_slope_hfi"] == mock_centre_tpi_stats_2.mid_slope * square_metres
+    assert json_response["firezone_tpi_stats"][1]["upper_slope_hfi"] == mock_centre_tpi_stats_2.upper_slope * square_metres
+    assert json_response["firezone_tpi_stats"][1]["valley_bottom_tpi"] is None
+    assert json_response["firezone_tpi_stats"][1]["mid_slope_tpi"] is None
+    assert json_response["firezone_tpi_stats"][1]["upper_slope_tpi"] is None

--- a/mobile/asa-go/src/api/fbaAPI.ts
+++ b/mobile/asa-go/src/api/fbaAPI.ts
@@ -68,9 +68,17 @@ export interface FireZoneElevationInfoResponse {
 
 export interface FireZoneTPIStats {
   fire_zone_id: number;
-  valley_bottom?: number;
-  mid_slope?: number;
-  upper_slope?: number;
+  valley_bottom_hfi?: number;
+  valley_bottom_tpi?: number;
+  mid_slope_hfi?: number;
+  mid_slope_tpi?: number;
+  upper_slope_hfi?: number;
+  upper_slope_tpi?: number;
+}
+
+export interface FireCentreTPIResponse {
+  fire_centre_name: string
+  firezone_tpi_stats: FireZoneTPIStats[]
 }
 
 export interface FireShapeAreaListResponse {
@@ -196,7 +204,7 @@ export async function getFireCentreTPIStats(
   run_type: RunType,
   run_datetime: string,
   for_date: string
-): Promise<Record<string, FireZoneTPIStats[]>> {
+): Promise<FireCentreTPIResponse> {
   const url = `fba/fire-centre-tpi-stats/${run_type.toLowerCase()}/${run_datetime}/${for_date}/${fire_centre_name}`;
   const { data } = await axios.get(url);
   return data;

--- a/openshift/templates/deploy.yaml
+++ b/openshift/templates/deploy.yaml
@@ -306,6 +306,11 @@ objects:
                     configMapKeyRef:
                       name: ${GLOBAL_NAME}
                       key: env.classified_tpi_dem_name
+                - name: CLASSIFIED_TPI_DEM_FUEL_MASKED_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: env.classified_tpi_dem_fuel_masked_name
                 - name: REDIS_HOST
                   valueFrom:
                     configMapKeyRef:

--- a/openshift/templates/deploy.yaml
+++ b/openshift/templates/deploy.yaml
@@ -301,6 +301,11 @@ objects:
                     secretKeyRef:
                       name: ${GLOBAL_NAME}
                       key: object-store-bucket
+                - name: CLASSIFIED_TPI_DEM_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: env.classified_tpi_dem_name
                 - name: REDIS_HOST
                   valueFrom:
                     configMapKeyRef:

--- a/web/src/api/fbaAPI.ts
+++ b/web/src/api/fbaAPI.ts
@@ -68,9 +68,17 @@ export interface FireZoneElevationInfoResponse {
 
 export interface FireZoneTPIStats {
   fire_zone_id: number
-  valley_bottom?: number
-  mid_slope?: number
-  upper_slope?: number
+  valley_bottom_hfi?: number
+  valley_bottom_tpi?: number
+  mid_slope_hfi?: number
+  mid_slope_tpi?: number
+  upper_slope_hfi?: number
+  upper_slope_tpi?: number
+}
+
+export interface FireCentreTPIResponse {
+  fire_centre_name: string
+  firezone_tpi_stats: FireZoneTPIStats[]
 }
 
 export interface FireShapeAreaListResponse {
@@ -174,23 +182,12 @@ export async function getFireZoneElevationInfo(
   return data
 }
 
-export async function getFireZoneTPIStats(
-  fire_zone_id: number,
-  run_type: RunType,
-  run_datetime: string,
-  for_date: string
-): Promise<FireZoneTPIStats> {
-  const url = `fba/fire-zone-tpi-stats/${run_type.toLowerCase()}/${run_datetime}/${for_date}/${fire_zone_id}`
-  const { data } = await axios.get(url)
-  return data
-}
-
 export async function getFireCentreTPIStats(
   fire_centre_name: string,
   run_type: RunType,
   run_datetime: string,
   for_date: string
-): Promise<Record<string, FireZoneTPIStats[]>> {
+): Promise<FireCentreTPIResponse> {
   const url = `fba/fire-centre-tpi-stats/${run_type.toLowerCase()}/${run_datetime}/${for_date}/${fire_centre_name}`
   const { data } = await axios.get(url)
   return data

--- a/web/src/features/fba/components/infoPanel/FireZoneUnitSummary.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitSummary.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Grid, Typography } from '@mui/material'
-import { isNil, isNull, isUndefined } from 'lodash'
+import { isNil, isUndefined } from 'lodash'
 import { FireShape, FireZoneTPIStats, FireZoneFuelStats } from 'api/fbaAPI'
 import ElevationStatus from 'features/fba/components/viz/ElevationStatus'
 import { useTheme } from '@mui/material/styles'

--- a/web/src/features/fba/components/infoPanel/FireZoneUnitSummary.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitSummary.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Grid, Typography } from '@mui/material'
-import { isNull, isUndefined } from 'lodash'
+import { isNil, isNull, isUndefined } from 'lodash'
 import { FireShape, FireZoneTPIStats, FireZoneFuelStats } from 'api/fbaAPI'
 import ElevationStatus from 'features/fba/components/viz/ElevationStatus'
 import { useTheme } from '@mui/material/styles'
@@ -14,13 +14,12 @@ interface FireZoneUnitSummaryProps {
 
 function hasRequiredFields(stats: FireZoneTPIStats): stats is Required<FireZoneTPIStats> {
   return (
-    !isUndefined(stats.mid_slope) &&
-    !isNull(stats.mid_slope) &&
-    !isUndefined(stats.upper_slope) &&
-    !isNull(stats.upper_slope) &&
-    !isUndefined(stats.valley_bottom) &&
-    !isNull(stats.valley_bottom) &&
-    stats.mid_slope + stats.upper_slope + stats.mid_slope !== 0
+    !isNil(stats.mid_slope_hfi) &&
+    !isNil(stats.mid_slope_tpi) &&
+    !isNil(stats.upper_slope_hfi) &&
+    !isNil(stats.upper_slope_tpi) &&
+    !isNil(stats.valley_bottom_hfi) &&
+    !isNil(stats.valley_bottom_tpi)
   )
 }
 

--- a/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
@@ -7,7 +7,7 @@ import FireZoneUnitSummary from 'features/fba/components/infoPanel/FireZoneUnitS
 import InfoAccordion from 'features/fba/components/infoPanel/InfoAccordion'
 import TabPanel from 'features/fba/components/infoPanel/TabPanel'
 import { useFireCentreDetails } from 'features/fba/hooks/useFireCentreDetails'
-import { isEmpty, isNull, isUndefined } from 'lodash'
+import { isEmpty, isNil, isNull, isUndefined } from 'lodash'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 
@@ -69,8 +69,8 @@ const FireZoneUnitTabs = ({
   }
 
   const tpiStatsArray = useMemo(() => {
-    if (selectedFireCenter) {
-      return fireCentreTPIStats?.[selectedFireCenter.name]
+    if (selectedFireCenter && !isNil(fireCentreTPIStats)) {
+      return fireCentreTPIStats?.firezone_tpi_stats
     }
   }, [fireCentreTPIStats, selectedFireCenter])
 

--- a/web/src/features/fba/components/infoPanel/fireZoneUnitSummary.test.tsx
+++ b/web/src/features/fba/components/infoPanel/fireZoneUnitSummary.test.tsx
@@ -4,9 +4,12 @@ import { render } from '@testing-library/react'
 
 const fireZoneTPIStats = {
   fire_zone_id: 0,
-  valley_bottom: 0,
-  mid_slope: 100,
-  upper_slope: 0
+  valley_bottom_hfi: 0,
+  valley_bottom_tpi: 0,
+  mid_slope_hfi: 100,
+  mid_slope_tpi: 100,
+  upper_slope_hfi: 0,
+  upper_slope_tpi: 0
 }
 
 describe('FireZoneUnitSummary', () => {

--- a/web/src/features/fba/components/infoPanel/fireZoneUnitSummary.test.tsx
+++ b/web/src/features/fba/components/infoPanel/fireZoneUnitSummary.test.tsx
@@ -66,32 +66,13 @@ describe('FireZoneUnitSummary', () => {
       area_sqm: 10
     }
     const { getByTestId } = render(
-      <FireZoneUnitSummary fireZoneFuelStats={[]} fireZoneTPIStats={fireZoneTPIStats} selectedFireZoneUnit={fireShape} />
-    )
-    const fireZoneUnitInfo = getByTestId('elevation-status')
-    expect(fireZoneUnitInfo).toBeInTheDocument()
-  })
-
-  it('should not render TPI stats all zero', () => {
-    const fireShape: FireShape = {
-      fire_shape_id: 1,
-      mof_fire_zone_name: 'foo',
-      mof_fire_centre_name: 'fizz',
-      area_sqm: 10
-    }
-    const { queryByTestId } = render(
       <FireZoneUnitSummary
         fireZoneFuelStats={[]}
-        fireZoneTPIStats={{
-          fire_zone_id: 0,
-          valley_bottom: 0,
-          mid_slope: 0,
-          upper_slope: 0
-        }}
+        fireZoneTPIStats={fireZoneTPIStats}
         selectedFireZoneUnit={fireShape}
       />
     )
-    const fireZoneUnitInfo = queryByTestId('elevation-status')
-    expect(fireZoneUnitInfo).not.toBeInTheDocument()
+    const fireZoneUnitInfo = getByTestId('elevation-status')
+    expect(fireZoneUnitInfo).toBeInTheDocument()
   })
 })

--- a/web/src/features/fba/components/infoPanel/fireZoneUnitTabs.test.tsx
+++ b/web/src/features/fba/components/infoPanel/fireZoneUnitTabs.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import FireZoneUnitTabs from './FireZoneUnitTabs'
-import { FireCenter, FireCentreHFIStats, FireShape, FireShapeAreaDetail, FireZoneTPIStats } from 'api/fbaAPI'
+import { FireCenter, FireCentreHFIStats, FireCentreTPIResponse, FireShape, FireShapeAreaDetail } from 'api/fbaAPI'
 import { vi } from 'vitest'
 import { ADVISORY_ORANGE_FILL, ADVISORY_RED_FILL } from '@/features/fba/components/map/featureStylers'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
@@ -74,8 +74,19 @@ const mockSelectedFireCenter: FireCenter = {
   stations: []
 }
 
-const mockFireCentreTPIStats: Record<string, FireZoneTPIStats[]> = {
-  [fireCentre1]: [{ fire_zone_id: 1, valley_bottom: 10, mid_slope: 90, upper_slope: 10 }]
+const mockFireCentreTPIStats: FireCentreTPIResponse = {
+  fire_centre_name: 'test_name',
+  firezone_tpi_stats: [
+    {
+      fire_zone_id: 1,
+      valley_bottom_hfi: 10,
+      valley_bottom_tpi: 11,
+      mid_slope_hfi: 90,
+      mid_slope_tpi: 91,
+      upper_slope_hfi: 10,
+      upper_slope_tpi: 11
+    }
+  ]
 }
 
 const mockFireCentreHFIFuelStats: FireCentreHFIStats = {

--- a/web/src/features/fba/components/viz/ElevationStatus.tsx
+++ b/web/src/features/fba/components/viz/ElevationStatus.tsx
@@ -20,10 +20,12 @@ interface ElevationStatusProps {
 
 const ElevationStatus = ({ tpiStats }: ElevationStatusProps) => {
   const theme = useTheme()
-  const total = tpiStats.mid_slope + tpiStats.upper_slope + tpiStats.valley_bottom
-  const mid_percent = tpiStats.mid_slope === 0 ? 0 : Math.round((tpiStats.mid_slope / total) * 100)
-  const upper_percent = tpiStats.upper_slope === 0 ? 0 : Math.round((tpiStats.upper_slope / total) * 100)
-  const bottom_percent = tpiStats.valley_bottom === 0 ? 0 : Math.round((tpiStats.valley_bottom / total) * 100)
+  const mid_percent =
+    tpiStats.mid_slope_tpi === 0 ? 0 : Math.round((tpiStats.mid_slope_hfi / tpiStats.mid_slope_tpi) * 100)
+  const upper_percent =
+    tpiStats.upper_slope_tpi === 0 ? 0 : Math.round((tpiStats.upper_slope_hfi / tpiStats.upper_slope_tpi) * 100)
+  const bottom_percent =
+    tpiStats.valley_bottom_tpi === 0 ? 0 : Math.round((tpiStats.valley_bottom_hfi / tpiStats.valley_bottom_tpi) * 100)
   return (
     <Grid container xs={12} data-testid="elevation-status">
       <Grid container sx={{ height: theme.spacing(6) }} xs={12}>

--- a/web/src/features/fba/components/viz/elevationStatus.test.tsx
+++ b/web/src/features/fba/components/viz/elevationStatus.test.tsx
@@ -5,7 +5,17 @@ import ElevationStatus from 'features/fba/components/viz/ElevationStatus'
 describe('ElevationStatus', () => {
   it('should render all classifications and svg', () => {
     const { getByTestId } = render(
-      <ElevationStatus tpiStats={{ fire_zone_id: 1, valley_bottom: 0, mid_slope: 1, upper_slope: 2 }} />
+      <ElevationStatus
+        tpiStats={{
+          fire_zone_id: 1,
+          valley_bottom_hfi: 0,
+          valley_bottom_tpi: 10,
+          mid_slope_hfi: 1,
+          mid_slope_tpi: 3,
+          upper_slope_hfi: 2,
+          upper_slope_tpi: 3
+        }}
+      />
     )
 
     const tpiMountain = getByTestId('tpi-mountain')
@@ -26,7 +36,17 @@ describe('ElevationStatus', () => {
 
   it('should render all zero classifications', () => {
     const { getByTestId } = render(
-      <ElevationStatus tpiStats={{ fire_zone_id: 1, valley_bottom: 0, mid_slope: 0, upper_slope: 0 }} />
+      <ElevationStatus
+        tpiStats={{
+          fire_zone_id: 1,
+          valley_bottom_hfi: 0,
+          mid_slope_hfi: 0,
+          upper_slope_hfi: 0,
+          valley_bottom_tpi: 1,
+          mid_slope_tpi: 1,
+          upper_slope_tpi: 1
+        }}
+      />
     )
 
     const valleyBottom = getByTestId('valley-bottom')

--- a/web/src/features/fba/slices/fireCentreTPIStatsSlice.ts
+++ b/web/src/features/fba/slices/fireCentreTPIStatsSlice.ts
@@ -2,11 +2,11 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { AppThunk } from 'app/store'
 import { logError } from 'utils/error'
-import { FireZoneTPIStats, getFireCentreTPIStats, RunType } from 'api/fbaAPI'
+import { FireCentreTPIResponse, FireZoneTPIStats, getFireCentreTPIStats, RunType } from 'api/fbaAPI'
 
 export interface CentreTPIStatsState {
   error: string | null
-  fireCentreTPIStats: Record<string, FireZoneTPIStats[]> | null
+  fireCentreTPIStats: FireCentreTPIResponse | null
 }
 
 export const initialState: CentreTPIStatsState = {
@@ -24,10 +24,11 @@ const fireCentreTPIStatsSlice = createSlice({
     },
     getFireCentreTPIStatsFailed(state: CentreTPIStatsState, action: PayloadAction<string>) {
       state.error = action.payload
+      state.fireCentreTPIStats = null
     },
     getFireCentreTPIStatsSuccess(
       state: CentreTPIStatsState,
-      action: PayloadAction<Record<string, FireZoneTPIStats[]>>
+      action: PayloadAction<FireCentreTPIResponse>
     ) {
       state.error = null
       state.fireCentreTPIStats = action.payload

--- a/web/src/features/fba/slices/fireCentreTPIStatsSlice.ts
+++ b/web/src/features/fba/slices/fireCentreTPIStatsSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { AppThunk } from 'app/store'
 import { logError } from 'utils/error'
-import { FireCentreTPIResponse, FireZoneTPIStats, getFireCentreTPIStats, RunType } from 'api/fbaAPI'
+import { FireCentreTPIResponse, getFireCentreTPIStats, RunType } from 'api/fbaAPI'
 
 export interface CentreTPIStatsState {
   error: string | null


### PR DESCRIPTION
- Create a fuel layer masked classified TPI and store in S3.
- Calculate and store the area of each TPI class per fire zone unit.
- On the frontend, display TPI as the proportion of each TPI area to high HFI are per tpi class.
# Test Links:
[Landing Page](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[PSU Insights](https://wps-pr-4240-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
