### PR TITLE
Fix Morecast WFWXWeatherStation unhashable submission error

### DIFF
--- a/wps_shared/wps_shared/wildfire_one/schema_parsers.py
+++ b/wps_shared/wps_shared/wildfire_one/schema_parsers.py
@@ -31,7 +31,7 @@ class WF1RecordTypeEnum(enum.Enum):
 class WFWXWeatherStation(BaseModel):
     """A WFWX station includes a code and WFWX API-specific ID"""
 
-    model_config = ConfigDict(populate_by_name=True)  # allows populating by alias name
+    model_config = ConfigDict(populate_by_name=True, frozen=True)  # allows populating by alias name, and frozen makes it hashable for collections
 
     wfwx_id: str
     code: int


### PR DESCRIPTION
Pydantic models are unhashable by default (not sure when this change was made), the `frozen` config option makes instances immutable and hashable: https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.frozen

We put `WFWXWeatherStation` into a set to guarantee uniqueness before submitting them to WF1 which is where this error shows up.

Reproduced bug and tested fix locally.

# Test Links:
[Landing Page](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[PSU Insights](https://wps-pr-4322-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
