### PR TITLE
HFI stats tweaks

### DIFF
--- a/api/app/auto_spatial_advisory/critical_hours.py
+++ b/api/app/auto_spatial_advisory/critical_hours.py
@@ -284,6 +284,9 @@ def calculate_critical_hours_by_fuel_type(wfwx_stations: List[WFWXWeatherStation
                 elif fuel_type_key.startswith("M"):
                     # Raster fuel grid doesn't differentiate between M1 and M2 so we use SFMS dates to choose which one we want
                     fuel_type_enum = FuelTypeEnum.M2 if is_greenup_period else FuelTypeEnum.M1
+                elif fuel_type_key.startswith("D"):
+                    # Raster fuel grid doesn't differentiate between D1 and D2 so we use SFMS dates to choose which one we want
+                    fuel_type_enum = FuelTypeEnum.D2 if is_greenup_period else FuelTypeEnum.D1
                 else:
                     fuel_type_enum = FuelTypeEnum(fuel_type_key.replace("-", ""))
                 try:
@@ -463,7 +466,7 @@ async def store_critical_hours_inputs_outputs(critical_hours_data: Dict[int, Cri
                     )
                 )
             except Exception as e:
-                logger.error(f"Error converting critical hours data to json - {e}")
+                logger.error(f"Error writing critical hours data to s3 - {e}")
 
 
 async def calculate_critical_hours(run_type: RunType, run_datetime: datetime, for_date: date):

--- a/wps_shared/wps_shared/db/crud/auto_spatial_advisory.py
+++ b/wps_shared/wps_shared/db/crud/auto_spatial_advisory.py
@@ -197,6 +197,7 @@ async def get_precomputed_stats_for_shape(session: AsyncSession, run_type: RunTy
                 AdvisoryFuelStats.fuel_type == CriticalHours.fuel_type,
                 AdvisoryFuelStats.advisory_shape_id == CriticalHours.advisory_shape_id,
             ),
+            isouter=True,
         )
         .join(Shape, AdvisoryFuelStats.advisory_shape_id == Shape.id)
         .join(


### PR DESCRIPTION
- Fixes `ValueError: 'D1/D2' is not a valid FuelTypeEnum`
- Updates SQL to return stats with no critical hours. Critical hours can run into missing station data problems, but sometimes it's expected that there are no critical hours for a fuel type

# Test Links:
[Landing Page](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4345-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
