### PR TITLE
Historical snow processing

### DIFF
--- a/api/app/jobs/viirs_snow.py
+++ b/api/app/jobs/viirs_snow.py
@@ -283,7 +283,6 @@ class ViirsSnowJob():
             logger.info("Downloading bc_boundary.geojson from S3.")
             await self._get_bc_boundary_from_s3(temp_dir)
             while next_date <= end_date:
-                start = datetime.now()
                 date_string = next_date.strftime('%Y-%m-%d')
                 logger.info(f"Processing snow coverage data for date: {date_string}")
                 tz_aware_datetime = vancouver_tz.localize(datetime.combine(next_date, datetime.min.time()))
@@ -305,8 +304,6 @@ class ViirsSnowJob():
                         # If a different HTTPError occurred re-raise and let the next exception handler send a notification to RocketChat.
                         raise http_error
                 next_date = next_date + timedelta(days=1)
-                end = datetime.now()
-                print(f"Snow time: {end - start}")
 
     async def _run_viirs_snow(self, args: argparse.Namespace):
         """Entry point for running the job."""

--- a/api/app/tests/jobs/test_viirs_snow.py
+++ b/api/app/tests/jobs/test_viirs_snow.py
@@ -14,8 +14,7 @@ async def mock__get_bc_boundary_from_s3(self, temp_dir):
     return
 
 
-def test_viirs_snow_job_fail(mocker: MockerFixture,
-                                 monkeypatch):
+def test_viirs_snow_job_fail(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch):
     """
     Test that when the bot fails, a message is sent to rocket-chat, and our exit code is 1.
     """
@@ -25,6 +24,8 @@ def test_viirs_snow_job_fail(mocker: MockerFixture,
 
     monkeypatch.setattr(ViirsSnowJob, '_get_last_processed_date', mock__get_last_processed_date)
     rocket_chat_spy = mocker.spy(viirs_snow, 'send_rocketchat_notification')
+    # mock sys.argv with a random path, otherwise argparser will pickup the sys.argv args from pytest
+    mocker.patch("sys.argv", ["/test"])
 
     with pytest.raises(SystemExit) as excinfo:
         viirs_snow.main()
@@ -34,7 +35,7 @@ def test_viirs_snow_job_fail(mocker: MockerFixture,
     assert rocket_chat_spy.call_count == 1
 
 
-def test_viirs_snow_job_exits_without_error_when_no_work_required(monkeypatch):
+def test_viirs_snow_job_exits_without_error_when_no_work_required(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch):
     """ Test that viirs_snow_job exits without error when no data needs to be processed.
     """
 
@@ -42,6 +43,8 @@ def test_viirs_snow_job_exits_without_error_when_no_work_required(monkeypatch):
         return date.today() - timedelta(days=1)
     
     monkeypatch.setattr(ViirsSnowJob, '_get_last_processed_date', mock__get_last_processed_date)
+    # mock sys.argv with a random path, otherwise argparser will pickup the sys.argv args from pytest
+    mocker.patch("sys.argv", ["/test"])
 
     with pytest.raises(SystemExit) as excinfo:
         viirs_snow.main()
@@ -49,7 +52,7 @@ def test_viirs_snow_job_exits_without_error_when_no_work_required(monkeypatch):
     assert excinfo.value.code == os.EX_OK
     
 
-def test_viirs_snow_job_exits_cleanly_when_no_viirs_data(monkeypatch):
+def test_viirs_snow_job_exits_cleanly_when_no_viirs_data(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch):
     """ Test that viirs_snow_job exits cleanly when attempt to download data that doesn't exist
     throws a HTTPError with status code of 501.
     """
@@ -66,7 +69,8 @@ def test_viirs_snow_job_exits_cleanly_when_no_viirs_data(monkeypatch):
     monkeypatch.setattr(ViirsSnowJob, '_get_last_processed_date', mock__get_last_processed_date)
     monkeypatch.setattr(ViirsSnowJob, '_get_bc_boundary_from_s3', mock__get_bc_boundary_from_s3)
     monkeypatch.setattr(ViirsSnowJob, '_download_viirs_granules_by_date', mock__download_viirs_granules_by_date)
-
+    # mock sys.argv with a random path, otherwise argparser will pickup the sys.argv args from pytest
+    mocker.patch("sys.argv", ["/test"])
 
     with pytest.raises(SystemExit) as excinfo:
         viirs_snow.main()
@@ -74,7 +78,7 @@ def test_viirs_snow_job_exits_cleanly_when_no_viirs_data(monkeypatch):
     assert excinfo.value.code == os.EX_OK
 
 
-def test_viirs_snow_job_fails_on_nsidc_auth_failure(mocker: MockerFixture, monkeypatch):
+def test_viirs_snow_job_fails_on_nsidc_auth_failure(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch):
     """
     Test that when authentication with the NSIDC fails a message is sent to rocket-chat and our exit code is 1.
     """
@@ -90,6 +94,8 @@ def test_viirs_snow_job_fails_on_nsidc_auth_failure(mocker: MockerFixture, monke
     monkeypatch.setattr(ViirsSnowJob, '_get_last_processed_date', mock__get_last_processed_date)   
     monkeypatch.setattr(ViirsSnowJob, '_get_bc_boundary_from_s3', mock__get_bc_boundary_from_s3)
     monkeypatch.setattr(ViirsSnowJob, '_download_viirs_granules_by_date', mock__download_viirs_granules_by_date)
+    # mock sys.argv with a random path, otherwise argparser will pickup the sys.argv args from pytest
+    mocker.patch("sys.argv", ["/test"])
 
     rocket_chat_spy = mocker.spy(viirs_snow, 'send_rocketchat_notification')
 

--- a/docs/DATA_REPROCESSING.md
+++ b/docs/DATA_REPROCESSING.md
@@ -1,0 +1,9 @@
+# How to reprocess historical data
+
+## Reprocessing snow data
+- Reprocessing of snow data for specific dates can be done by manually deploying an OpenShift job using a provisioning script.
+- OpenShift template: /openshift/templates/historic-snow-job.yaml
+- Provisioning script: /openshift/scripts/oc_provision_historic_snow_job.sh
+
+Example usage:
+`PROJ_DEV="e1e498-dev" START_DATETIME="2024-06-28T12:00:00" END_DATETIME="2024-06-29T12:00:00" bash openshift/scripts/oc_provision_historic_snow_job.sh {SUFFIX} apply -f - `

--- a/openshift/scripts/oc_provision_historic_snow_job.sh
+++ b/openshift/scripts/oc_provision_historic_snow_job.sh
@@ -19,7 +19,7 @@ source "$(dirname ${0})/common/common"
 PROJ_TARGET="${PROJ_TARGET:-${PROJ_DEV}}"
 
 # Process template
-OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/historical_snow_job.yaml \
+OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/historic-snow-job.yaml \
 -p NAME=${APP_NAME} \
 -p SUFFIX=${SUFFIX} \
 -p CRUNCHYDB_USER=${CRUNCHY_NAME}-${SUFFIX}-pguser-${CRUNCHY_NAME}-${SUFFIX} \

--- a/openshift/scripts/oc_provision_historical_snow_job.sh
+++ b/openshift/scripts/oc_provision_historical_snow_job.sh
@@ -1,0 +1,42 @@
+#!/bin/sh -l
+#
+source "$(dirname ${0})/common/common"
+
+#%
+#% OpenShift Deploy Helper
+#%
+#%   Intended for use with a pull request-based pipeline.
+#%   Suffixes incl.: pr-###.
+#%
+#% Usage:
+#%
+#%    [PROJ_TARGET] [PG_DATABASE] [TABLE] ${THIS_FILE} [SUFFIX]
+#%
+#% Examples:
+#%
+#%   PROJ_TARGET=e1e498-dev PG_DATABASE=wps TABLE=table ${THIS_FILE} pr-0
+
+PROJ_TARGET="${PROJ_TARGET:-${PROJ_DEV}}"
+
+# Process template
+OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/historical_snow_job.yaml \
+-p NAME=${APP_NAME} \
+-p SUFFIX=${SUFFIX} \
+-p CRUNCHYDB_USER=${CRUNCHY_NAME}-${SUFFIX}-pguser-${CRUNCHY_NAME}-${SUFFIX} \
+-p START_DATETIME=${START_DATETIME} \
+-p END_DATETIME=${END_DATETIME}"
+
+
+# Apply template (apply or use --dry-run)
+#
+OC_APPLY="oc -n ${PROJ_TARGET} apply -f -"
+[ "${APPLY}" ] || OC_APPLY="${OC_APPLY} --dry-run"
+
+# Execute commands
+#
+eval "${OC_PROCESS}"
+eval "${OC_PROCESS} | ${OC_APPLY}"
+
+# Provide oc command instruction
+#
+display_helper "${OC_PROCESS} | ${OC_APPLY}"

--- a/openshift/templates/historic-snow-job.yaml
+++ b/openshift/templates/historic-snow-job.yaml
@@ -1,0 +1,135 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: historic-snow-job-template
+  annotations:
+    description: "Template for re-processing historic snow data."
+parameters:
+  - name: NAME
+    description: Module name
+    value: wps
+  - name: SUFFIX
+    description: Deployment suffix, e.g. pr-###
+    required: true
+  - name: GLOBAL_NAME
+    description: Name of global Module
+    value: wps-global
+  - name: CRUNCHYDB_USER
+    value: wps-crunchydb-16-${SUFFIX}-pguser-wps-crunchydb-16-${SUFFIX}
+  - name: START_DATETIME
+    description: The start day for processing snow data.
+    required: true
+  - name: END_DATETIME
+    description: The last day to process snow data for.
+    required: true
+objects:
+  - kind: Job
+    apiVersion: batch/v1
+    metadata:
+      name: historic-snow-${NAME}-${SUFFIX}
+      labels:
+        app: ${NAME}-${SUFFIX}
+    spec:
+      parallelism: 1
+      completions: 1
+      backoffLimit: 6
+      template:
+        spec:
+          containers:
+            - name: historic-snow-container
+              image: image-registry.openshift-image-registry.svc:5000/e1e498-tools/wps-api-${SUFFIX}:${SUFFIX}
+              command:
+                - poetry
+                - run
+                - python
+                - "-m"
+                - app.jobs.viirs_snow
+                - "s"
+                - "${START_DATETIME}"
+                - "e"
+                - "${END_DATETIME}"
+              env:
+                - name: POSTGRES_DATABASE
+                  value: ${NAME}
+                - name: POSTGRES_WRITE_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${CRUNCHYDB_USER}
+                      key: user
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${CRUNCHYDB_USER}
+                      key: password
+                - name: POSTGRES_WRITE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${CRUNCHYDB_USER}
+                      key: pgbouncer-host
+                - name: POSTGRES_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${CRUNCHYDB_USER}
+                      key: pgbouncer-port
+                - name: SUFFIX
+                  value: ${SUFFIX}
+                - name: ROCKET_URL_POST_MESSAGE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: rocket.chat-url-post-message
+                - name: ROCKET_CHANNEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: rocket.chat-channel
+                - name: ROCKET_USER_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: rocket.chat-user-id-secret
+                - name: ROCKET_AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: rocket.chat-auth-token-secret
+                - name: OBJECT_STORE_SERVER
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: object-store-server
+                - name: OBJECT_STORE_USER_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: object-store-user-id
+                - name: OBJECT_STORE_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: object-store-secret
+                - name: OBJECT_STORE_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: object-store-bucket
+                - name: FUEL_RASTER_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: env.fuel_raster_name
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+                requests:
+                  cpu: 500m
+                  memory: 512Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+          restartPolicy: OnFailure
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler

--- a/openshift/templates/historic-snow-job.yaml
+++ b/openshift/templates/historic-snow-job.yaml
@@ -44,9 +44,9 @@ objects:
                 - python
                 - "-m"
                 - app.jobs.viirs_snow
-                - "s"
+                - "-s"
                 - "${START_DATETIME}"
-                - "e"
+                - "-e"
                 - "${END_DATETIME}"
               env:
                 - name: POSTGRES_DATABASE
@@ -118,13 +118,23 @@ objects:
                     configMapKeyRef:
                       name: ${GLOBAL_NAME}
                       key: env.fuel_raster_name
+                - name: NASA_EARTHDATA_USER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: env.nasa-earthdata-user
+                - name: NASA_EARTHDATA_PWD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${GLOBAL_NAME}
+                      key: nasa-earthdata-pwd
               resources:
                 limits:
                   cpu: "1"
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
                   cpu: 500m
-                  memory: 512Mi
+                  memory: 1Gi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               imagePullPolicy: Always


### PR DESCRIPTION
- refactor `viirs_snow.py` to accept optional command line arguments which specify a start/end date for processing snow data
- adds an OpenShift job template and deployment script which can be run manually with start/end dates to re-process snow data 

# Test Links:
[Landing Page](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4350-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
