### PR TITLE
Fix ASA Crash

### DIFF
--- a/web/src/components/FireCenterDropdown.tsx
+++ b/web/src/components/FireCenterDropdown.tsx
@@ -16,7 +16,7 @@ const FireCenterDropdown = (props: FireCenterDropdownProps) => {
   const changeHandler = (_: React.ChangeEvent<{}>, value: any | null) => {
     if (!isEqual(props.selectedFireCenter, value)) {
       props.setSelectedFireShape(undefined)
-      props.setSelectedFireCenter(value)
+      props.setSelectedFireCenter(value ?? undefined)
       props.setZoomSource('fireCenter')
     }
     if (isNull(value)) {

--- a/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
+++ b/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
@@ -177,10 +177,14 @@ const AdvisoryText = ({
   }
 
   const getZoneStatus = () => {
-    const fireCenterSummary = provincialSummary[selectedFireCenter!.name]
-    const fireZoneUnitInfos = fireCenterSummary?.filter(fc => fc.fire_shape_id === selectedFireZoneUnit?.fire_shape_id)
-    const zoneStatus = calculateStatusText(fireZoneUnitInfos, advisoryThreshold)
-    return zoneStatus
+    if (selectedFireCenter) {
+      const fireCenterSummary = provincialSummary[selectedFireCenter.name]
+      const fireZoneUnitInfos = fireCenterSummary?.filter(
+        fc => fc.fire_shape_id === selectedFireZoneUnit?.fire_shape_id
+      )
+      const zoneStatus = calculateStatusText(fireZoneUnitInfos, advisoryThreshold)
+      return zoneStatus
+    }
   }
 
   const renderAdvisoryText = () => {


### PR DESCRIPTION
Typing throughout ASA specifies the `selectedFireCenter` as either a `fireCenter` or `undefined`. The dropdown selector was setting it to `null`. 
This sets it to `undefined` so all of our typing is correct

# Test Links:
[Landing Page](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4352-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
