### PR TITLE
ASA: Add zone title to bulletin and tab summary

### DIFF
--- a/web/src/features/fba/components/infoPanel/AdvisoryReport.tsx
+++ b/web/src/features/fba/components/infoPanel/AdvisoryReport.tsx
@@ -1,12 +1,12 @@
 import { calculateStatusText } from '@/features/fba/calculateZoneStatus'
 import { useFireCentreDetails } from '@/features/fba/hooks/useFireCentreDetails'
-import { Box, Tabs, Tab, Grid } from '@mui/material'
+import { Grid } from '@mui/material'
 import { FireCenter, FireShape } from 'api/fbaAPI'
 import { INFO_PANEL_CONTENT_BACKGROUND } from 'app/theme'
 import AdvisoryText from 'features/fba/components/infoPanel/AdvisoryText'
 import InfoAccordion from 'features/fba/components/infoPanel/InfoAccordion'
 import { DateTime } from 'luxon'
-import React, { useState } from 'react'
+import React from 'react'
 
 interface AdvisoryReportProps {
   issueDate: DateTime | null
@@ -16,20 +16,6 @@ interface AdvisoryReportProps {
   selectedFireZoneUnit?: FireShape
 }
 
-interface TabPanelProps {
-  children?: React.ReactNode
-  index: number
-  value: number
-}
-
-const TabPanel = ({ children, index, value }: TabPanelProps) => {
-  return (
-    <div hidden={value !== index} id={`tabpanel-${index}`} data-testid={`tabpanel-${index}`}>
-      {value === index && <Box paddingBottom={3}>{children}</Box>}
-    </div>
-  )
-}
-
 const AdvisoryReport = ({
   issueDate,
   forDate,
@@ -37,12 +23,6 @@ const AdvisoryReport = ({
   selectedFireCenter,
   selectedFireZoneUnit
 }: AdvisoryReportProps) => {
-  const [tabNumber, setTabNumber] = useState(0)
-
-  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
-    setTabNumber(newValue)
-  }
-
   const groupedFireZoneUnits = useFireCentreDetails(selectedFireCenter)
   const fireZoneUnitDetails = groupedFireZoneUnits.find(
     zone => zone.fire_shape_id === selectedFireZoneUnit?.fire_shape_id
@@ -59,20 +39,13 @@ const AdvisoryReport = ({
       >
         <Grid container justifyContent="center">
           <Grid item sx={{ width: '90%' }}>
-            <Box>
-              <Tabs value={tabNumber} onChange={handleTabChange}>
-                <Tab aria-label="bulletin" label="BULLETIN" />
-              </Tabs>
-            </Box>
-            <TabPanel value={tabNumber} index={0}>
-              <AdvisoryText
-                issueDate={issueDate}
-                forDate={forDate}
-                advisoryThreshold={advisoryThreshold}
-                selectedFireCenter={selectedFireCenter}
-                selectedFireZoneUnit={selectedFireZoneUnit}
-              ></AdvisoryText>
-            </TabPanel>
+            <AdvisoryText
+              issueDate={issueDate}
+              forDate={forDate}
+              advisoryThreshold={advisoryThreshold}
+              selectedFireCenter={selectedFireCenter}
+              selectedFireZoneUnit={selectedFireZoneUnit}
+            ></AdvisoryText>
           </Grid>
         </Grid>
       </InfoAccordion>

--- a/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
+++ b/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
@@ -211,7 +211,7 @@ const AdvisoryText = ({
           <Typography
             data-testid="bulletin-issue-date"
             sx={{ whiteSpace: 'pre-wrap' }}
-          >{`Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for today.\n\n`}</Typography>
+          >{`Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for ${displayForDate}.\n\n`}</Typography>
         )}
         {!isUndefined(zoneStatus) && zoneStatus === AdvisoryStatus.ADVISORY && (
           <Typography sx={{ whiteSpace: 'pre-line' }} data-testid="advisory-message-advisory">

--- a/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
+++ b/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
@@ -188,6 +188,7 @@ const AdvisoryText = ({
   }
 
   const renderAdvisoryText = () => {
+    const zoneTitle = `${selectedFireZoneUnit?.mof_fire_zone_name}:\n\n`
     const forToday = forDate.toISODate() === DateTime.now().toISODate()
     const displayForDate = forToday ? 'today' : forDate.toLocaleString({ month: 'short', day: 'numeric' })
     const zoneStatus = getZoneStatus()
@@ -201,6 +202,11 @@ const AdvisoryText = ({
 
     return (
       <>
+        {selectedFireZoneUnit && (
+          <Typography data-testid="fire-zone-unit-bulletin" sx={{ whiteSpace: 'pre-wrap' }}>
+            {zoneTitle}
+          </Typography>
+        )}
         {issueDate?.isValid && (
           <Typography
             sx={{ whiteSpace: 'pre-wrap' }}

--- a/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
+++ b/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
@@ -211,7 +211,7 @@ const AdvisoryText = ({
           <Typography
             data-testid="bulletin-issue-date"
             sx={{ whiteSpace: 'pre-wrap' }}
-          >{`Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for ${displayForDate}.\n\n`}</Typography>
+          >{`Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL)} for ${displayForDate}.\n\n`}</Typography>
         )}
         {!isUndefined(zoneStatus) && zoneStatus === AdvisoryStatus.ADVISORY && (
           <Typography sx={{ whiteSpace: 'pre-line' }} data-testid="advisory-message-advisory">

--- a/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
+++ b/web/src/features/fba/components/infoPanel/AdvisoryText.tsx
@@ -209,8 +209,9 @@ const AdvisoryText = ({
         )}
         {issueDate?.isValid && (
           <Typography
+            data-testid="bulletin-issue-date"
             sx={{ whiteSpace: 'pre-wrap' }}
-          >{`Issued on ${issueDate?.toLocaleString(DateTime.DATE_MED)} for ${displayForDate}.\n\n`}</Typography>
+          >{`Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for today.\n\n`}</Typography>
         )}
         {!isUndefined(zoneStatus) && zoneStatus === AdvisoryStatus.ADVISORY && (
           <Typography sx={{ whiteSpace: 'pre-line' }} data-testid="advisory-message-advisory">

--- a/web/src/features/fba/components/infoPanel/FireZoneUnitSummary.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitSummary.tsx
@@ -35,12 +35,7 @@ const FireZoneUnitSummary = ({
   }
   return (
     <div data-testid="fire-zone-unit-summary">
-      <Grid
-        container
-        alignItems={'center'}
-        direction={'column'}
-        sx={{ paddingBottom: theme.spacing(2), paddingTop: theme.spacing(2) }}
-      >
+      <Grid container alignItems={'center'} direction={'column'} sx={{ paddingBottom: theme.spacing(2) }}>
         <Grid item sx={{ paddingBottom: theme.spacing(2), width: '95%' }}>
           <FuelSummary selectedFireZoneUnit={selectedFireZoneUnit} fireZoneFuelStats={fireZoneFuelStats} />
         </Grid>

--- a/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
@@ -139,7 +139,7 @@ const FireZoneUnitTabs = ({
                     color: '#003366',
                     fontWeight: 'bold',
                     textAlign: 'left',
-                    width: '50%'
+                    paddingLeft: theme.spacing(2)
                   }}
                 >
                   {zone.fire_shape_name}

--- a/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
@@ -133,6 +133,17 @@ const FireZoneUnitTabs = ({
             </Box>
             {sortedGroupedFireZoneUnits.map((zone, index) => (
               <TabPanel key={zone.fire_shape_id} value={tabNumber} index={index}>
+                <Typography
+                  data-testid="fire-zone-title-tabs"
+                  sx={{
+                    color: '#003366',
+                    fontWeight: 'bold',
+                    textAlign: 'left',
+                    width: '50%'
+                  }}
+                >
+                  {zone.fire_shape_name}
+                </Typography>
                 <FireZoneUnitSummary
                   fireZoneFuelStats={hfiFuelStats ? { [zone.fire_shape_id]: hfiFuelStats[zone.fire_shape_id] } : {}}
                   fireZoneTPIStats={

--- a/web/src/features/fba/components/infoPanel/advisoryReport.test.tsx
+++ b/web/src/features/fba/components/infoPanel/advisoryReport.test.tsx
@@ -53,20 +53,6 @@ describe('AdvisoryReport', () => {
     const advisoryReport = getByTestId('advisory-report')
     expect(advisoryReport).toBeInTheDocument()
   })
-  it('should render the first bulletin tab', () => {
-    const { getByTestId } = render(
-      <Provider store={testStore}>
-        <AdvisoryReport
-          issueDate={issueDate}
-          forDate={forDate}
-          advisoryThreshold={advisoryThreshold}
-          selectedFireCenter={mockFireCenter}
-        />
-      </Provider>
-    )
-    const tabPanel = getByTestId('tabpanel-0')
-    expect(tabPanel).toBeInTheDocument()
-  })
   it('should render advisoryText as children', () => {
     const { getByTestId } = render(
       <Provider store={testStore}>

--- a/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
+++ b/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
@@ -138,17 +138,19 @@ describe('AdvisoryText', () => {
   })
 
   it('should render default message when no fire center is selected', () => {
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <Provider store={testStore}>
         <AdvisoryText issueDate={issueDate} forDate={forDate} advisoryThreshold={advisoryThreshold} />
       </Provider>
     )
     const message = getByTestId('default-message')
     expect(message).toBeInTheDocument()
+    const bulletinIssueDate = queryByTestId('bulletin-issue-date')
+    expect(bulletinIssueDate).not.toBeInTheDocument()
   })
 
   it('should render default message when no fire zone unit is selected', () => {
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <Provider store={testStore}>
         <AdvisoryText
           issueDate={issueDate}
@@ -160,16 +162,20 @@ describe('AdvisoryText', () => {
     )
     const message = getByTestId('default-message')
     expect(message).toBeInTheDocument()
+    const bulletinIssueDate = queryByTestId('bulletin-issue-date')
+    expect(bulletinIssueDate).not.toBeInTheDocument()
   })
 
   it('should render no data message when the issueDate is invalid', () => {
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <Provider store={testStore}>
         <AdvisoryText issueDate={DateTime.invalid('test')} forDate={forDate} advisoryThreshold={advisoryThreshold} />
       </Provider>
     )
     const message = getByTestId('no-data-message')
     expect(message).toBeInTheDocument()
+    const bulletinIssueDate = queryByTestId('bulletin-issue-date')
+    expect(bulletinIssueDate).not.toBeInTheDocument()
   })
 
   it('should render a no advisories message when there are no advisories/warnings', () => {
@@ -193,12 +199,17 @@ describe('AdvisoryText', () => {
     const proportionMessage = queryByTestId('advisory-message-proportion')
     const noAdvisoryMessage = queryByTestId('no-advisory-message')
     const zoneBulletinMessage = queryByTestId('fire-zone-unit-bulletin')
+    const bulletinIssueDate = queryByTestId('bulletin-issue-date')
     expect(advisoryMessage).not.toBeInTheDocument()
     expect(warningMessage).not.toBeInTheDocument()
     expect(proportionMessage).not.toBeInTheDocument()
     expect(noAdvisoryMessage).toBeInTheDocument()
     expect(zoneBulletinMessage).toBeInTheDocument()
     expect(zoneBulletinMessage).toHaveTextContent(`${mockFireZoneUnit.mof_fire_zone_name}:`)
+    expect(bulletinIssueDate).toBeInTheDocument()
+    expect(bulletinIssueDate).toHaveTextContent(
+      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for today.`
+    )
   })
 
   it('should render warning status', () => {
@@ -221,11 +232,16 @@ describe('AdvisoryText', () => {
     const warningMessage = queryByTestId('advisory-message-warning')
     const proportionMessage = queryByTestId('advisory-message-proportion')
     const zoneBulletinMessage = queryByTestId('fire-zone-unit-bulletin')
+    const bulletinIssueDate = queryByTestId('bulletin-issue-date')
     expect(advisoryMessage).not.toBeInTheDocument()
     expect(proportionMessage).toBeInTheDocument()
     expect(warningMessage).toBeInTheDocument()
     expect(zoneBulletinMessage).toBeInTheDocument()
     expect(zoneBulletinMessage).toHaveTextContent(`${mockFireZoneUnit.mof_fire_zone_name}:`)
+    expect(bulletinIssueDate).toBeInTheDocument()
+    expect(bulletinIssueDate).toHaveTextContent(
+      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for today.`
+    )
   })
 
   it('should render advisory status', () => {
@@ -244,11 +260,16 @@ describe('AdvisoryText', () => {
     const warningMessage = queryByTestId('advisory-message-warning')
     const proportionMessage = queryByTestId('advisory-message-proportion')
     const zoneBulletinMessage = queryByTestId('fire-zone-unit-bulletin')
+    const bulletinIssueDate = queryByTestId('bulletin-issue-date')
     expect(advisoryMessage).toBeInTheDocument()
     expect(proportionMessage).toBeInTheDocument()
     expect(warningMessage).not.toBeInTheDocument()
     expect(zoneBulletinMessage).toBeInTheDocument()
     expect(zoneBulletinMessage).toHaveTextContent(`${mockAdvisoryFireZoneUnit.mof_fire_zone_name}:`)
+    expect(bulletinIssueDate).toBeInTheDocument()
+    expect(bulletinIssueDate).toHaveTextContent(
+      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for today.`
+    )
   })
 
   it('should render critical hours missing message when critical hours start time is missing', () => {

--- a/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
+++ b/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
@@ -195,7 +195,7 @@ describe('AdvisoryText', () => {
     const bulletinIssueDate = queryByTestId('bulletin-issue-date')
     expect(bulletinIssueDate).toBeInTheDocument()
     expect(bulletinIssueDate).toHaveTextContent(
-      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for ${forDate.toLocaleString({ month: 'short', day: 'numeric' })}.`
+      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL)} for ${forDate.toLocaleString({ month: 'short', day: 'numeric' })}.`
     )
   })
 
@@ -229,7 +229,7 @@ describe('AdvisoryText', () => {
     expect(zoneBulletinMessage).toHaveTextContent(`${mockFireZoneUnit.mof_fire_zone_name}:`)
     expect(bulletinIssueDate).toBeInTheDocument()
     expect(bulletinIssueDate).toHaveTextContent(
-      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for today.`
+      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL)} for today.`
     )
   })
 
@@ -261,7 +261,7 @@ describe('AdvisoryText', () => {
     expect(zoneBulletinMessage).toHaveTextContent(`${mockFireZoneUnit.mof_fire_zone_name}:`)
     expect(bulletinIssueDate).toBeInTheDocument()
     expect(bulletinIssueDate).toHaveTextContent(
-      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for today.`
+      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL)} for today.`
     )
   })
 
@@ -289,7 +289,7 @@ describe('AdvisoryText', () => {
     expect(zoneBulletinMessage).toHaveTextContent(`${mockAdvisoryFireZoneUnit.mof_fire_zone_name}:`)
     expect(bulletinIssueDate).toBeInTheDocument()
     expect(bulletinIssueDate).toHaveTextContent(
-      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for today.`
+      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL)} for today.`
     )
   })
 

--- a/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
+++ b/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
@@ -192,10 +192,13 @@ describe('AdvisoryText', () => {
     const advisoryMessage = queryByTestId('advisory-message-advisory')
     const proportionMessage = queryByTestId('advisory-message-proportion')
     const noAdvisoryMessage = queryByTestId('no-advisory-message')
+    const zoneBulletinMessage = queryByTestId('fire-zone-unit-bulletin')
     expect(advisoryMessage).not.toBeInTheDocument()
     expect(warningMessage).not.toBeInTheDocument()
     expect(proportionMessage).not.toBeInTheDocument()
     expect(noAdvisoryMessage).toBeInTheDocument()
+    expect(zoneBulletinMessage).toBeInTheDocument()
+    expect(zoneBulletinMessage).toHaveTextContent(`${mockFireZoneUnit.mof_fire_zone_name}:`)
   })
 
   it('should render warning status', () => {
@@ -217,9 +220,12 @@ describe('AdvisoryText', () => {
     const advisoryMessage = queryByTestId('advisory-message-advisory')
     const warningMessage = queryByTestId('advisory-message-warning')
     const proportionMessage = queryByTestId('advisory-message-proportion')
+    const zoneBulletinMessage = queryByTestId('fire-zone-unit-bulletin')
     expect(advisoryMessage).not.toBeInTheDocument()
     expect(proportionMessage).toBeInTheDocument()
     expect(warningMessage).toBeInTheDocument()
+    expect(zoneBulletinMessage).toBeInTheDocument()
+    expect(zoneBulletinMessage).toHaveTextContent(`${mockFireZoneUnit.mof_fire_zone_name}:`)
   })
 
   it('should render advisory status', () => {
@@ -237,9 +243,12 @@ describe('AdvisoryText', () => {
     const advisoryMessage = queryByTestId('advisory-message-advisory')
     const warningMessage = queryByTestId('advisory-message-warning')
     const proportionMessage = queryByTestId('advisory-message-proportion')
+    const zoneBulletinMessage = queryByTestId('fire-zone-unit-bulletin')
     expect(advisoryMessage).toBeInTheDocument()
     expect(proportionMessage).toBeInTheDocument()
     expect(warningMessage).not.toBeInTheDocument()
+    expect(zoneBulletinMessage).toBeInTheDocument()
+    expect(zoneBulletinMessage).toHaveTextContent(`${mockAdvisoryFireZoneUnit.mof_fire_zone_name}:`)
   })
 
   it('should render critical hours missing message when critical hours start time is missing', () => {

--- a/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
+++ b/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
@@ -178,6 +178,27 @@ describe('AdvisoryText', () => {
     expect(bulletinIssueDate).not.toBeInTheDocument()
   })
 
+  it('should render forDate as mmm/dd when different than issue date', () => {
+    const issueDate = DateTime.fromObject({ year: 2025, month: 3, day: 24 })
+    const forDate = DateTime.fromObject({ year: 2025, month: 3, day: 25 })
+    const { queryByTestId } = render(
+      <Provider store={testStore}>
+        <AdvisoryText
+          issueDate={issueDate}
+          forDate={forDate}
+          advisoryThreshold={advisoryThreshold}
+          selectedFireCenter={mockFireCenter}
+          selectedFireZoneUnit={mockFireZoneUnit}
+        />
+      </Provider>
+    )
+    const bulletinIssueDate = queryByTestId('bulletin-issue-date')
+    expect(bulletinIssueDate).toBeInTheDocument()
+    expect(bulletinIssueDate).toHaveTextContent(
+      `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)} for ${forDate.toLocaleString({ month: 'short', day: 'numeric' })}.`
+    )
+  })
+
   it('should render a no advisories message when there are no advisories/warnings', () => {
     const noAdvisoryStore = buildTestStore({
       ...provSummaryInitialState,

--- a/web/src/features/fba/components/infoPanel/fireZoneUnitTabs.test.tsx
+++ b/web/src/features/fba/components/infoPanel/fireZoneUnitTabs.test.tsx
@@ -148,6 +148,7 @@ describe('FireZoneUnitTabs', () => {
 
     const summaryTabs = getByTestId('firezone-summary-tabs')
     expect(summaryTabs).toBeInTheDocument()
+    expect(getByTestId('fire-zone-title-tabs')).toBeInTheDocument()
   })
 
   it('should render tabs for each zone in a centre', () => {
@@ -180,10 +181,11 @@ describe('FireZoneUnitTabs', () => {
       mof_fire_zone_name: zoneB
     })
     expect(setZoomSourceMock).toHaveBeenCalledWith('fireShape')
+    expect(screen.getByTestId('fire-zone-title-tabs')).toHaveTextContent(zoneB)
   })
 
   it('should render empty if there is no selected Fire Centre', () => {
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <Provider store={testStore}>
         <FireZoneUnitTabs
           selectedFireZoneUnit={undefined}
@@ -197,6 +199,7 @@ describe('FireZoneUnitTabs', () => {
 
     const emptyTabs = getByTestId('fire-zone-unit-tabs-empty')
     expect(emptyTabs).toBeInTheDocument()
+    expect(queryByTestId('fire-zone-title-tabs')).not.toBeInTheDocument()
   })
 
   it('should render tabs with the correct advisory colour', () => {


### PR DESCRIPTION
- Adds zone title to make it clear what the bullet and zone summary sections relate to
- Updates issue date formatting to include time
- Removes bulletin tab that advisory text was housed in

Closes #4293 
# Test Links:
[Landing Page](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4368-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
