### PR TITLE
HRDPS Job: Forbid concurrent runs to keep logs around

### DIFF
--- a/openshift/templates/env_canada_hrdps.cronjob.yaml
+++ b/openshift/templates/env_canada_hrdps.cronjob.yaml
@@ -48,8 +48,10 @@ objects:
       # We use the "Replace" policy, because we never want the cronjobs to run concurrently,
       # and if for whatever reason a cronjob gets stuck, we want the next run to proceed.
       # If we were to use Forbid, and a cronjob gets stuck, then we'd stop gathering data until someone
-      # noticed. We don't want that.
-      concurrencyPolicy: "Replace"
+      # noticed. We don't want that. Edit: Forbid here is temporary...
+      concurrencyPolicy: "Forbid"
+      failedJobsHistoryLimit: 1
+      successfulJobsHistoryLimit: 2
       jobTemplate:
         metadata:
           labels:


### PR DESCRIPTION
This is temporary since if we leave it and jobs fail they won't restart.