### PR TITLE
Fix post merge integration action

### DIFF
--- a/.github/workflows/post_merge_integration.yml
+++ b/.github/workflows/post_merge_integration.yml
@@ -407,7 +407,7 @@ jobs:
   upload-code-coverage:
     name: Coverage with CodeCov
     runs-on: ubuntu-24.04
-    needs: [lint-and-test-web, test-api, test-jobs-shared, test-wps-shared]
+    needs: [lint-and-test-web, test-api, test-wps-jobs, test-wps-shared]
     steps:
       # we need to checkout, so that we have codecov.yml
       - name: Checkout repo


### PR DESCRIPTION
Fix for the `post-merge-integration.yml` action I borked with a typo.
# Test Links:
[Landing Page](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireBat](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireBat bookmark](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4415-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
