### PR TITLE
Tooltips position and target

### DIFF
--- a/web/src/features/fba/components/viz/FuelDistribution.tsx
+++ b/web/src/features/fba/components/viz/FuelDistribution.tsx
@@ -10,11 +10,13 @@ interface FuelDistributionProps {
 // Represents the percent contribution of the given fuel type to the overall high HFI area.
 const FuelDistribution = ({ code, percent }: FuelDistributionProps) => {
   return (
-    <Tooltip title={`${percent.toFixed()}%`} placement="right">
-      <Box
-        data-testid="fuel-distribution-box"
-        sx={{ height: '75%', width: `${percent}%`, background: getColorByFuelTypeCode(code) }}
-      ></Box>
+    <Tooltip followCursor placement="right" title={`${percent.toFixed()}%`}>
+      <Box sx={{ display: 'flex', flexGrow: 1, height: '100%', alignItems: 'center' }}>
+        <Box
+          data-testid="fuel-distribution-box"
+          sx={{ height: '75%', width: `${percent}%`, background: getColorByFuelTypeCode(code) }}
+        ></Box>
+      </Box>
     </Tooltip>
   )
 }

--- a/web/src/features/fba/components/viz/FuelSummary.tsx
+++ b/web/src/features/fba/components/viz/FuelSummary.tsx
@@ -41,8 +41,8 @@ const columns: GridColDef[] = [
     minWidth: 120,
     renderHeader: (params: GridColumnHeaderParams) => <StyledHeader>{params.colDef.headerName}</StyledHeader>,
     renderCell: (params: GridRenderCellParams) => (
-      <Tooltip placement="right" title={params.row['description']}>
-        <Typography sx={{ fontSize: '0.75rem' }}>{params.row[params.field]}</Typography>
+      <Tooltip followCursor placement="right" title={params.row['description']}>
+        <Typography sx={{ fontSize: '0.75rem', display: 'flex', flexGrow: 1 }}>{params.row[params.field]}</Typography>
       </Tooltip>
     )
   },


### PR DESCRIPTION
- make entire cell the target for tooltips in the fuel table
- tooltips follow the cursor and are placed to the right of the cursor

Closes: #4424 
# Test Links:
[Landing Page](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4438-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
