### PR TITLE
Percent conifer async fix

### DIFF
--- a/api/app/auto_spatial_advisory/hfi_percent_conifer.py
+++ b/api/app/auto_spatial_advisory/hfi_percent_conifer.py
@@ -67,9 +67,9 @@ async def process_hfi_percent_conifer(run_type: RunType, run_datetime: datetime,
         stmt = select(AdvisoryHFIPercentConifer).where(AdvisoryHFIPercentConifer.run_parameters == run_parameters_id)
         exists = (await session.execute(stmt)).scalars().first() is not None
 
-        # if exists:
-        #     logger.info("HFI percent conifer already processed.")
-        #     return
+        if exists:
+            logger.info("HFI percent conifer already processed.")
+            return
 
         await process_min_percent_conifer_by_zone(session, run_parameters_id, RunType(run_type), run_datetime, for_date)
 


### PR DESCRIPTION
#4470 didn't take into account the async nature of the S3Client
# Test Links:
[Landing Page](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4471-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
