### PR TITLE
Refine interpolation logic

### DIFF
--- a/wps_jobs/tests/weather_models/test_ecmwf_prediction_processor.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf_prediction_processor.py
@@ -94,8 +94,10 @@ def test_process_model_run_for_station(setup_processor, mocker: MockerFixture):
         (datetime(2023, 10, 1, 18, 0), datetime(2023, 10, 1, 21, 0), True),
         # timestamps on the same day but not surrounding 20:00 UTC
         (datetime(2023, 10, 1, 10, 0), datetime(2023, 10, 1, 15, 0), False),
-        # timestamps on different days
-        (datetime(2023, 10, 1, 23, 0), datetime(2023, 10, 2, 1, 0), True),
+        # timestamps on different days, later timestamp earlier than 21:00 UTC
+        (datetime(2023, 10, 1, 21, 0), datetime(2023, 10, 2, 0, 0), False),
+        # timestamps on different days, later timestamp later than 21:00 UTC
+        (datetime(2023, 10, 1, 21, 0), datetime(2023, 10, 2, 22, 0), True),
     ],
 )
 def test_should_interpolate(prev_timestamp, next_timestamp, expected, mock_predictions):

--- a/wps_jobs/tests/weather_models/test_ecmwf_prediction_processor.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf_prediction_processor.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, create_autospec
+from unittest.mock import MagicMock
 from datetime import datetime, timedelta, timezone
 
 from pytest_mock import MockerFixture
@@ -9,9 +9,6 @@ from wps_jobs.weather_model_jobs.ecmwf_prediction_processor import ECMWFPredicti
 from wps_shared.schemas.stations import WeatherStation
 from wps_shared.db.crud.model_run_repository import ModelRunRepository
 from wps_shared.db.models.weather_models import ModelRunPrediction, PredictionModelRunTimestamp, WeatherStationModelPrediction
-
-import wps_jobs.weather_model_jobs.utils
-import wps_jobs.weather_model_jobs.utils.interpolate
 
 @pytest.fixture
 def setup_processor():
@@ -57,7 +54,7 @@ def test_process_model_run_for_station(setup_processor, mocker: MockerFixture):
 
     # Mock data
     station = WeatherStation(code=1, long=10.0, lat=50.0, name="Station 1")
-    model_run = create_autospec(PredictionModelRunTimestamp)
+    model_run = MagicMock(spec=PredictionModelRunTimestamp)
     model_run_predictions = [
         ModelRunPrediction(prediction_timestamp=datetime(2023, 10, 1, 18, 0), apcp_sfc_0=0.0),
         ModelRunPrediction(prediction_timestamp=datetime(2023, 10, 1, 21, 0), apcp_sfc_0=0.0),

--- a/wps_jobs/tests/weather_models/test_ecmwf_prediction_processor.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf_prediction_processor.py
@@ -91,13 +91,15 @@ def test_process_model_run_for_station(setup_processor, mocker: MockerFixture):
     "prev_timestamp, next_timestamp, expected",
     [
         # timestamps on the same day surrounding 20:00 UTC
-        (datetime(2023, 10, 1, 18, 0), datetime(2023, 10, 1, 21, 0), True),
+        (datetime(2023, 10, 1, 18, 0, tzinfo=timezone.utc), datetime(2023, 10, 1, 21, 0, tzinfo=timezone.utc), True),
         # timestamps on the same day but not surrounding 20:00 UTC
-        (datetime(2023, 10, 1, 10, 0), datetime(2023, 10, 1, 15, 0), False),
+        (datetime(2023, 10, 1, 10, 0, tzinfo=timezone.utc), datetime(2023, 10, 1, 15, 0, tzinfo=timezone.utc), False),
         # timestamps on different days, later timestamp earlier than 21:00 UTC
-        (datetime(2023, 10, 1, 21, 0), datetime(2023, 10, 2, 0, 0), False),
+        (datetime(2023, 10, 1, 21, 0, tzinfo=timezone.utc), datetime(2023, 10, 2, 0, 0, tzinfo=timezone.utc), True),
         # timestamps on different days, later timestamp later than 21:00 UTC
-        (datetime(2023, 10, 1, 21, 0), datetime(2023, 10, 2, 22, 0), True),
+        (datetime(2023, 10, 1, 21, 0, tzinfo=timezone.utc), datetime(2023, 10, 2, 22, 0, tzinfo=timezone.utc), True),
+        # 18:00 UTC and 00:00 UTC on subsequent days should return true
+        (datetime(2023, 10, 1, 18, 0, tzinfo=timezone.utc), datetime(2023, 10, 2, 00, 0, tzinfo=timezone.utc), True),
     ],
 )
 def test_should_interpolate(prev_timestamp, next_timestamp, expected, mock_predictions):

--- a/wps_jobs/tests/weather_models/test_ecmwf_prediction_processor.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf_prediction_processor.py
@@ -95,7 +95,7 @@ def test_process_model_run_for_station(setup_processor, mocker: MockerFixture):
         # timestamps on the same day but not surrounding 20:00 UTC
         (datetime(2023, 10, 1, 10, 0, tzinfo=timezone.utc), datetime(2023, 10, 1, 15, 0, tzinfo=timezone.utc), False),
         # timestamps on different days, later timestamp earlier than 21:00 UTC
-        (datetime(2023, 10, 1, 21, 0, tzinfo=timezone.utc), datetime(2023, 10, 2, 0, 0, tzinfo=timezone.utc), True),
+        (datetime(2023, 10, 1, 21, 0, tzinfo=timezone.utc), datetime(2023, 10, 2, 0, 0, tzinfo=timezone.utc), False),
         # timestamps on different days, later timestamp later than 21:00 UTC
         (datetime(2023, 10, 1, 21, 0, tzinfo=timezone.utc), datetime(2023, 10, 2, 22, 0, tzinfo=timezone.utc), True),
         # 18:00 UTC and 00:00 UTC on subsequent days should return true

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -208,7 +208,7 @@ def main():
     except Exception as exception:
         # Exit non 0 - failure.
         logger.error("An error occurred while processing ECMWF model.", exc_info=exception)
-        rc_message = f':poop: Encountered error retrieving {sys.argv[1]} model data from Env Canada'
+        rc_message = f':poop: Encountered error retrieving model data from ECMWF'
         send_rocketchat_notification(rc_message, exception)
         sys.exit(os.EX_SOFTWARE)
 

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -183,8 +183,8 @@ async def process_models():
     with get_write_session_scope() as session:
         with tempfile.TemporaryDirectory() as temp_dir:
             model_run_repository = ModelRunRepository(session)
-            # ecmwf = ECMWF(temp_dir, stations, model_run_repository)
-            # ecmwf.process()
+            ecmwf = ECMWF(temp_dir, stations, model_run_repository)
+            ecmwf.process()
 
             # interpolate and machine learn everything that needs interpolating.
             ecmwf_prediction_processor = ECMWFPredictionProcessor(stations, model_run_repository)

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -183,8 +183,8 @@ async def process_models():
     with get_write_session_scope() as session:
         with tempfile.TemporaryDirectory() as temp_dir:
             model_run_repository = ModelRunRepository(session)
-            ecmwf = ECMWF(temp_dir, stations, model_run_repository)
-            ecmwf.process()
+            # ecmwf = ECMWF(temp_dir, stations, model_run_repository)
+            # ecmwf.process()
 
             # interpolate and machine learn everything that needs interpolating.
             ecmwf_prediction_processor = ECMWFPredictionProcessor(stations, model_run_repository)

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -208,7 +208,7 @@ def main():
     except Exception as exception:
         # Exit non 0 - failure.
         logger.error("An error occurred while processing ECMWF model.", exc_info=exception)
-        rc_message = f':poop: Encountered error retrieving model data from ECMWF'
+        rc_message = ':poop: Encountered error retrieving model data from ECMWF'
         send_rocketchat_notification(rc_message, exception)
         sys.exit(os.EX_SOFTWARE)
 

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
@@ -77,8 +77,9 @@ class ECMWFPredictionProcessor:
             # Timestamps on the same day but surround 20:00 UTC should be interpolated
             return prev_timestamp.hour <= 18 and next_timestamp.hour >= 21
         
-        # Otherwise the next timestamp is on the next day and should always be interpolated for 20:00 UTC
-        return True
+        # datetimes are on different days, interpolate if next is after 20:00 UTC
+        return next_timestamp.hour > 20
+
 
     def _weather_station_prediction_initializer(self, station: WeatherStation, model_run: PredictionModelRunTimestamp, prediction: ModelRunPrediction) -> WeatherStationModelPrediction:
         """Initialize a WeatherStationModelPrediction object."""

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
@@ -75,10 +75,10 @@ class ECMWFPredictionProcessor:
         # Check if datetimes are on the same day
         if prev_timestamp.date() == next_timestamp.date():
             # Timestamps on the same day but surround 20:00 UTC should be interpolated
-            return prev_timestamp.hour <= 18 and next_timestamp.hour >= 21
+            return prev_timestamp.hour < 20 and next_timestamp.hour > 20
         
-        # datetimes are on different days, interpolate if next is after 20:00 UTC
-        return next_timestamp.hour > 20
+        # datetimes are on different days, interpolate if next is not 20:00 UTC
+        return next_timestamp.hour != 20
 
 
     def _weather_station_prediction_initializer(self, station: WeatherStation, model_run: PredictionModelRunTimestamp, prediction: ModelRunPrediction) -> WeatherStationModelPrediction:

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
@@ -78,7 +78,7 @@ class ECMWFPredictionProcessor:
             # Timestamps on the same day but surround 20:00 UTC should be interpolated
             return prev_timestamp.hour < 20 and next_timestamp.hour > 20
         
-        # datetimes are on different days, interpolate if next is not 20:00 UTC
+        # datetimes are on different days, interpolate if previous is before 20:00 UTC
         return prev_timestamp.hour < 20
 
 

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
@@ -1,4 +1,3 @@
-
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List
@@ -72,13 +71,15 @@ class ECMWFPredictionProcessor:
         prev_timestamp: datetime = prev_prediction.prediction_timestamp
         next_timestamp: datetime = prediction.prediction_timestamp
         assert next_timestamp > prev_timestamp, "Next timestamp must be greater than previous timestamp"
+        # Assert the hour difference is 24 or less
+        assert (next_timestamp - prev_timestamp).total_seconds() <= 24 * 3600, "Timestamps must be no more than 24 hours apart"
         # Check if datetimes are on the same day
         if prev_timestamp.date() == next_timestamp.date():
             # Timestamps on the same day but surround 20:00 UTC should be interpolated
             return prev_timestamp.hour < 20 and next_timestamp.hour > 20
         
         # datetimes are on different days, interpolate if next is not 20:00 UTC
-        return next_timestamp.hour != 20
+        return prev_timestamp.hour < 20
 
 
     def _weather_station_prediction_initializer(self, station: WeatherStation, model_run: PredictionModelRunTimestamp, prediction: ModelRunPrediction) -> WeatherStationModelPrediction:


### PR DESCRIPTION
This PR refines interpolation logic in the ECMWF prediction processor by adjusting conditions to perform interpolation only when the next day's hour exceeds 20:00 UTC and by enforcing that timestamps are within a 24‐hour window. Key changes include:

- Adding an assertion to ensure the timestamp difference does not exceed 24 hours.
- Updating the interpolation condition for timestamps on the same day (now checking for crossing the 20:00 UTC threshold).
- Modifying tests to use timezone-aware datetimes.

# Test Links:
[Landing Page](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4496-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
