### PR TITLE
Optimize pytest

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,12 +121,12 @@ jobs:
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
           poetry run pytest --cov=app --cov-branch --cov-report=xml:coverage-reports/api-coverage-report.xml app/tests -x -o log_cli=true --disable-warnings -vvv
-      - name: Create coverage report (api)
-        working-directory: ./api
-        shell: bash
-        run: |
-          poetry run coverage report
-          poetry run coverage xml -o coverage-reports/api-coverage-report.xml
+      # - name: Create coverage report (api)
+      #   working-directory: ./api
+      #   shell: bash
+      #   run: |
+      #     poetry run coverage report
+      #     poetry run coverage xml -o coverage-reports/api-coverage-report.xml
       - name: Archive coverage report (api)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,9 +100,8 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
         run: |
-          # Install JDK
           apt-get update --fix-missing
-          apt-get -y install default-jdk
+          apt-get -y install default-jdk wkhtmltopdf libudunits2-dev r-base-dev build-essential libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev          
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -208,7 +208,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run pytest -n auto --cov=wps_shared --cov-branch --cov-report=xml:coverage-reports/wps-shared-coverage-report.xml wps_shared/tests -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest -n auto --cov=wps_shared --cov-branch --cov-report=xml:coverage-reports/wps-shared-coverage-report.xml -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_shared)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,6 +83,7 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
+      options: --user 0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,12 +121,6 @@ jobs:
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
           poetry run pytest -n auto --cov=app --cov-branch --cov-report=xml:coverage-reports/api-coverage-report.xml app/tests -x -o log_cli=true --disable-warnings -vvv
-      # - name: Create coverage report (api)
-      #   working-directory: ./api
-      #   shell: bash
-      #   run: |
-      #     poetry run coverage report
-      #     poetry run coverage xml -o coverage-reports/api-coverage-report.xml
       - name: Archive coverage report (api)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -175,55 +175,15 @@ jobs:
   test-wps-shared:
     name: Python - WPS Shared Test with coverage
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        # Match versions for python to Ubuntu 24.04 LTS at the time of writing. Keep R at same version.
-        python-version: [3.12.3]
+    container:
+      image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
+      options: --user 0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           # For sonar-scanner to work properly we can't use a shallow fetch.
           fetch-depth: 0
-      - name: Install ubuntu pre-requisites (wps_shared)
-        # The python gdal relies on libgdal-dev being installed.
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install build-essential libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev
-      - name: Setup Python ${{ matrix.python-version }} (wps_shared)
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache poetry installer
-        uses: actions/cache@v4
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "poetry-installer-1.8.3"
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo
-          mkdir ~/poetry_installer
-          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
-      - name: Install poetry (wps_shared)
-        run: |
-          cd ~/poetry_installer
-          python install-poetry.py --version 1.8.3
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-      # poetry cache folder: /home/runner/.cache/pypoetry
-      - name: Cache poetry
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.8.3-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-1.8.3-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v4
@@ -234,6 +194,11 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./wps_shared
         run: |
+          # Install JDK
+          apt-get update --fix-missing
+          apt-get -y install default-jdk
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip
           poetry install
           poetry run python -m pip install -U setuptools wheel
@@ -243,13 +208,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run coverage run --source=wps_shared -m pytest ./wps_shared/tests -x -o log_cli=true --disable-warnings -vvv
-      - name: Create coverage report (wps_shared)
-        working-directory: ./wps_shared
-        shell: bash
-        run: |
-          poetry run coverage report
-          poetry run coverage xml -o coverage-reports/wps-shared-coverage-report.xml
+          poetry run pytest -n auto --cov=wps_shared --cov-branch --cov-report=xml:coverage-reports/wps-shared-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_shared)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,6 +100,9 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
         run: |
+          # Install JDK
+          apt-get update --fix-missing
+          apt-get -y install default-jdk
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -129,55 +129,15 @@ jobs:
   test-wps-jobs:
     name: Python - WPS Jobs Test with coverage
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        # Match versions for python to Ubuntu 24.04 LTS at the time of writing. Keep R at same version.
-        python-version: [3.12.3]
+    container:
+      image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
+      options: --user 0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           # For sonar-scanner to work properly we can't use a shallow fetch.
           fetch-depth: 0
-      - name: Install ubuntu pre-requisites (wps_jobs)
-        # The python gdal relies on libgdal-dev being installed.
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install build-essential libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev
-      - name: Setup Python ${{ matrix.python-version }} (wps_jobs)
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache poetry installer
-        uses: actions/cache@v4
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "poetry-installer-1.8.3"
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo
-          mkdir ~/poetry_installer
-          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
-      - name: Install poetry (wps_jobs)
-        run: |
-          cd ~/poetry_installer
-          python install-poetry.py --version 1.8.3
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-      # poetry cache folder: /home/runner/.cache/pypoetry
-      - name: Cache poetry
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.8.3-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-1.8.3-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v4
@@ -188,6 +148,11 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./wps_jobs
         run: |
+          # Install JDK
+          apt-get update --fix-missing
+          apt-get -y install default-jdk
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip
           poetry install
           poetry run python -m pip install -U setuptools wheel
@@ -201,13 +166,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run coverage run --source=wps_jobs -m pytest tests -x -o log_cli=true --disable-warnings -vvv
-      - name: Create coverage report (wps_jobs)
-        working-directory: ./wps_jobs
-        shell: bash
-        run: |
-          poetry run coverage report
-          poetry run coverage xml -o coverage-reports/wps-jobs-coverage-report.xml
+          poetry run pytest --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml app/tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_jobs)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,8 +100,9 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
         run: |
+          # Install JDK
           apt-get update --fix-missing
-          apt-get -y install default-jdk wkhtmltopdf libudunits2-dev r-base-dev build-essential libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev          
+          apt-get -y install default-jdk
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip
@@ -119,7 +120,7 @@ jobs:
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATH
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run coverage run --source=app -m pytest app/tests -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest --cov=app --cov-branch --cov-report=xml:coverage-reports/api-coverage-report.xml app/tests -x -o log_cli=true --disable-warnings -vvv
       - name: Create coverage report (api)
         working-directory: ./api
         shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,6 +100,8 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
         run: |
+          # Install JDK
+          apt-get -y install default-jdk
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -166,7 +166,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run pytest --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml app/tests -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_jobs)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -175,7 +175,7 @@ jobs:
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATH
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          COVERAGE_CORE=sysmon poetry run coverage run --source=app -m pytest app/tests -x -o log_cli=true --disable-warnings -vvv --numprocesses=auto
+          poetry run coverage run --source=app -m pytest app/tests -x -o log_cli=true --disable-warnings -vvv --numprocesses=auto
       - name: Create coverage report (api)
         working-directory: ./api
         shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -208,7 +208,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run pytest -n auto --cov=wps_shared --cov-branch --cov-report=xml:coverage-reports/wps-shared-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest -n auto --cov=wps_shared --cov-branch --cov-report=xml:coverage-reports/wps-shared-coverage-report.xml wps_shared/tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_shared)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -208,7 +208,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run pytest -n auto --cov=wps_shared --cov-branch --cov-report=xml:coverage-reports/wps-shared-coverage-report.xml -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest --cov=wps_shared --cov-branch --cov-report=xml:coverage-reports/wps-shared-coverage-report.xml wps_shared/tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_shared)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,58 +81,14 @@ jobs:
   test-api:
     name: Python - Test with coverage
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        # Match versions for python to Ubuntu 24.04 LTS at the time of writing. Keep R at same version.
-        python-version: [3.12.3]
-        R: ["4.1.2"]
+    container:
+      image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           # For sonar-scanner to work properly we can't use a shallow fetch.
           fetch-depth: 0
-      - name: Install ubuntu pre-requisites (api)
-        # The python gdal and R component relies on libgdal-dev being installed.
-        # cffdrs requires libudunits2-dev
-        # The api uses wkhtmltopdf to generate pdf's.
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install wkhtmltopdf libudunits2-dev r-base-dev build-essential libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev
-      - name: Setup Python ${{ matrix.python-version }} (api)
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache poetry installer
-        uses: actions/cache@v4
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "poetry-installer-1.8.3"
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo
-          mkdir ~/poetry_installer
-          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
-      - name: Install poetry (api)
-        run: |
-          cd ~/poetry_installer
-          python install-poetry.py --version 1.8.3
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-      # poetry cache folder: /home/runner/.cache/pypoetry
-      - name: Cache poetry
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.8.3-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-1.8.3-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v4
@@ -143,6 +99,8 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
         run: |
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip
           poetry install
           poetry run python -m pip install -U setuptools wheel
@@ -151,23 +109,6 @@ jobs:
         working-directory: ./api
         run: |
           poetry run python -m pip install --no-deps --force-reinstall ../wps_shared
-      - uses: r-lib/actions/setup-r@v2
-        # r-lib/actions/setup-r@v2 is supposed to install version ${{ matrix.R }}, BUT, it doesn't.
-        # When asking for 4.1.2 - it's installing a new version! Or at least reporting a newer
-        # version.
-        with:
-          r-version: ${{ matrix.R }}
-      - name: Cache /home/runner/work/_temp/Library
-        # When installing cffdrs, a bunch of stuff is downloaded and compiled and placed in
-        # /home/runner/work/_temp/Library ; By caching this folder, subsequent calls to
-        # install cffdrs run much faster.
-        id: cache-r-cffdrs
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/work/_temp/Library
-          key: ${{ runner.os }}-r-${{ matrix.R }}-cffdrs
-      - name: Install R dependencies (api)
-        run: R -e "install.packages('cffdrs')"
       - name: Unit Test with coverage (api)
         working-directory: ./api
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run pytest --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest -n auto --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_jobs)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -120,7 +120,7 @@ jobs:
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATH
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run pytest --cov=app --cov-branch --cov-report=xml:coverage-reports/api-coverage-report.xml app/tests -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest -n auto --cov=app --cov-branch --cov-report=xml:coverage-reports/api-coverage-report.xml app/tests -x -o log_cli=true --disable-warnings -vvv
       # - name: Create coverage report (api)
       #   working-directory: ./api
       #   shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -101,6 +101,7 @@ jobs:
         working-directory: ./api
         run: |
           # Install JDK
+          apt-get update --fix-missing
           apt-get -y install default-jdk
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ jobs:
           poetry run ruff check app/*.py app/**/*.py ../wps_shared/wps_shared/*.py ../wps_shared/wps_shared/**/*.py ../wps_jobs/wps_jobs/*.py ../wps_jobs/wps_jobs/**/*.py
 
   test-api:
-    name: Python - Test with coverage
+    name: Python - API Test with coverage
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run pytest -n auto --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_jobs)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,9 +100,6 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
         run: |
-          # Install JDK
-          apt-get update --fix-missing
-          apt-get -y install default-jdk
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -175,7 +175,7 @@ jobs:
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATH
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run coverage run --source=app -m pytest app/tests -x -o log_cli=true --disable-warnings -vvv --numprocesses=auto
+          poetry run coverage run --source=app -m pytest app/tests -x -o log_cli=true --disable-warnings -vvv
       - name: Create coverage report (api)
         working-directory: ./api
         shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,51 +8,12 @@ jobs:
   lint-api:
     name: Python - Lint
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        python-version: [3.12.3]
+    container:
+      image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
+      options: --user 0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install ubuntu pre-requisites (api)
-        # The python gdal and R component relies on libgdal-dev being installed.
-        # cffdrs requires libudunits2-dev
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libudunits2-dev r-base-dev libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev
-      - name: Setup Python ${{ matrix.python-version }} (api)
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache poetry installer
-        uses: actions/cache@v4
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "poetry-installer-1.8.3"
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo
-          mkdir ~/poetry_installer
-          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
-      - name: Install poetry (api)
-        run: |
-          cd ~/poetry_installer
-          python install-poetry.py --version 1.8.3
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-      - name: Cache poetry
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.8.3-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-1.8.3-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -175,7 +175,7 @@ jobs:
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATH
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run coverage run --source=app -m pytest app/tests -x -o log_cli=true --disable-warnings -vvv
+          COVERAGE_CORE=sysmon poetry run coverage run --source=app -m pytest app/tests -x -o log_cli=true --disable-warnings -vvv --numprocesses=auto
       - name: Create coverage report (api)
         working-directory: ./api
         shell: bash

--- a/.github/workflows/post_merge_integration.yml
+++ b/.github/workflows/post_merge_integration.yml
@@ -9,51 +9,12 @@ jobs:
   lint-api:
     name: Python - Lint
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        python-version: [3.12.3]
+    container:
+      image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
+      options: --user 0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install ubuntu pre-requisites (api)
-        # The python gdal and R component relies on libgdal-dev being installed.
-        # cffdrs requires libudunits2-dev
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libudunits2-dev r-base-dev libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev
-      - name: Setup Python ${{ matrix.python-version }} (api)
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache poetry installer
-        uses: actions/cache@v4
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "poetry-installer-1.8.3"
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo
-          mkdir ~/poetry_installer
-          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
-      - name: Install poetry (api)
-        run: |
-          cd ~/poetry_installer
-          python install-poetry.py --version 1.8.3
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-      - name: Cache poetry
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.8.3-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-1.8.3-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v4
@@ -81,58 +42,15 @@ jobs:
   test-api:
     name: Python - API Test with coverage
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        # Match versions for python + R to Ubuntu 24.04 LTS at the time of writing.
-        python-version: [3.12.3]
-        R: ["4.1.2"]
+    container:
+      image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
+      options: --user 0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           # For sonar-scanner to work properly we can't use a shallow fetch.
           fetch-depth: 0
-      - name: Install ubuntu pre-requisites (api)
-        # The python gdal and R component relies on libgdal-dev being installed.
-        # cffdrs requires libudunits2-dev
-        # The api uses wkhtmltopdf to generate pdf's.
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libgdal-dev wkhtmltopdf libudunits2-dev r-base-dev libproj-dev libgeos-dev libsqlite3-dev
-      - name: Setup Python ${{ matrix.python-version }} (api)
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache poetry installer
-        uses: actions/cache@v4
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "poetry-installer-1.8.3"
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo
-          mkdir ~/poetry_installer
-          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
-      - name: Install poetry (api)
-        run: |
-          cd ~/poetry_installer
-          python install-poetry.py --version 1.8.3
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-      # poetry cache folder: /home/runner/.cache/pypoetry
-      - name: Cache poetry
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.8.3-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-1.8.3-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v4
@@ -143,6 +61,11 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./api
         run: |
+          # Install JDK
+          apt-get update --fix-missing
+          apt-get -y install default-jdk
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip
           poetry install
           poetry run python -m pip install --no-build-isolation --no-cache-dir --force-reinstall gdal==$(gdal-config --version)
@@ -150,17 +73,6 @@ jobs:
         working-directory: ./api
         run: |
           poetry run python -m pip install --no-deps --force-reinstall ../wps_shared
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.R }}
-      - name: Cache /home/runner/work/_temp/Library
-        id: cache-r-cffdrs
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/work/_temp/Library
-          key: ${{ runner.os }}-r-${{ matrix.R }}-cffdrs
-      - name: Install R dependencies (api)
-        run: R -e "install.packages('cffdrs')"
       - name: Unit Test with coverage (api)
         working-directory: ./api
         run: |
@@ -168,13 +80,7 @@ jobs:
           export CLASSPATH=./libs/REDapp_Lib.jar:./libs/WTime.jar:./libs/hss-java.jar:$CLASSPATH
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run coverage run --source=app -m pytest app/tests -x -o log_cli=true --disable-warnings -vvv
-      - name: Create coverage report (api)
-        working-directory: ./api
-        shell: bash
-        run: |
-          poetry run coverage report
-          poetry run coverage xml -o coverage-reports/api-coverage-report.xml
+          poetry run pytest -n auto --cov=app --cov-branch --cov-report=xml:coverage-reports/api-coverage-report.xml app/tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (api)
         uses: actions/upload-artifact@v4
         with:
@@ -183,56 +89,15 @@ jobs:
   test-wps-jobs:
     name: Python - WPS Jobs Test with coverage
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        # Match versions for python to Ubuntu 24.04 LTS at the time of writing. Keep R at same version.
-        python-version: [3.12.3]
-        R: ["4.1.2"]
+    container:
+      image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
+      options: --user 0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           # For sonar-scanner to work properly we can't use a shallow fetch.
           fetch-depth: 0
-      - name: Install ubuntu pre-requisites (wps_jobs)
-        # The python gdal relies on libgdal-dev being installed.
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install build-essential libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev
-      - name: Setup Python ${{ matrix.python-version }} (wps_jobs)
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache poetry installer
-        uses: actions/cache@v4
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "poetry-installer-1.8.3"
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo
-          mkdir ~/poetry_installer
-          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
-      - name: Install poetry (wps_jobs)
-        run: |
-          cd ~/poetry_installer
-          python install-poetry.py --version 1.8.3
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-      # poetry cache folder: /home/runner/.cache/pypoetry
-      - name: Cache poetry
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.8.3-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-1.8.3-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v4
@@ -243,6 +108,11 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./wps_jobs
         run: |
+          # Install JDK
+          apt-get update --fix-missing
+          apt-get -y install default-jdk
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip
           poetry install
           poetry run python -m pip install -U setuptools wheel
@@ -256,13 +126,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run coverage run --source=wps_jobs -m pytest tests -x -o log_cli=true --disable-warnings -vvv
-      - name: Create coverage report (wps_jobs)
-        working-directory: ./wps_jobs
-        shell: bash
-        run: |
-          poetry run coverage report
-          poetry run coverage xml -o coverage-reports/wps-jobs-coverage-report.xml
+          poetry run pytest --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_jobs)
         uses: actions/upload-artifact@v4
         with:
@@ -271,55 +135,15 @@ jobs:
   test-wps-shared:
     name: Python - WPS Shared Test with coverage
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        # Match versions for python to Ubuntu 24.04 LTS at the time of writing. Keep R at same version.
-        python-version: [3.12.3]
+    container:
+      image: ghcr.io/bcgov/wps/wps-api-base:04-23-2025
+      options: --user 0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           # For sonar-scanner to work properly we can't use a shallow fetch.
           fetch-depth: 0
-      - name: Install ubuntu pre-requisites (wps_shared)
-        # The python gdal relies on libgdal-dev being installed.
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install build-essential libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libtirpc-dev
-      - name: Setup Python ${{ matrix.python-version }} (wps_shared)
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache poetry installer
-        uses: actions/cache@v4
-        id: cache-poetry-installer
-        env:
-          cache-name: cache-poetry-installer
-        with:
-          path: "~/poetry_installer"
-          key: "poetry-installer-1.8.3"
-      - name: Download poetry installer
-        if: steps.cache-poetry-installer.outputs.cache-hit != 'true'
-        run: |
-          echo
-          mkdir ~/poetry_installer
-          curl -sSL https://install.python-poetry.org > ~/poetry_installer/install-poetry.py
-      - name: Install poetry (wps_shared)
-        run: |
-          cd ~/poetry_installer
-          python install-poetry.py --version 1.8.3
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-      # poetry cache folder: /home/runner/.cache/pypoetry
-      - name: Cache poetry
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-poetry
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-1.8.3-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-1.8.3-cache-
       - name: Cache .venv
         id: cache-venv
         uses: actions/cache@v4
@@ -330,6 +154,11 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         working-directory: ./wps_shared
         run: |
+          # Install JDK
+          apt-get update --fix-missing
+          apt-get -y install default-jdk
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project false
           poetry run python -m pip install --upgrade pip
           poetry install
           poetry run python -m pip install -U setuptools wheel
@@ -339,13 +168,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run coverage run --source=wps_shared -m pytest ./wps_shared/tests -x -o log_cli=true --disable-warnings -vvv
-      - name: Create coverage report (wps_shared)
-        working-directory: ./wps_shared
-        shell: bash
-        run: |
-          poetry run coverage report
-          poetry run coverage xml -o coverage-reports/wps-shared-coverage-report.xml
+          poetry run pytest --cov=wps_shared --cov-branch --cov-report=xml:coverage-reports/wps-shared-coverage-report.xml wps_shared/tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_shared)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/post_merge_integration.yml
+++ b/.github/workflows/post_merge_integration.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           export ORIGINS=testorigin
           export SFMS_SECRET=secret
-          poetry run pytest --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
+          poetry run pytest -n auto --cov=wps_jobs --cov-branch --cov-report=xml:coverage-reports/wps-jobs-coverage-report.xml tests -x -o log_cli=true --disable-warnings -vvv
       - name: Archive coverage report (wps_jobs)
         uses: actions/upload-artifact@v4
         with:

--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -1,5 +1,3 @@
 [run]
 omit =
-    app/tests/fba_calc/test_fba_error_random_sample.py
-    app/tests/fba_calc/test_fba_error_redapp.py
     app/utils/redapp.py

--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+    app/tests/fba_calc/test_fba_error_random_sample.py
+    app/tests/fba_calc/test_fba_error_redapp.py
+    app/utils/redapp.py

--- a/api/app/tests/fba_calc/test_fba_error_random_sample.py
+++ b/api/app/tests/fba_calc/test_fba_error_random_sample.py
@@ -65,6 +65,7 @@ acceptable_margin_of_error: Final = 0.01
         ("S3", None, None, None, None, 0.01, 0.01, 0.01, 0.01, 0.01, 20),
     ],
 )
+@pytest.mark.skip(reason="Only used for initial validation of FireCalc and REDapp")
 def test_get_endpoints_unauthorized(
     fuel_type,
     percentage_conifer,

--- a/api/app/tests/fba_calc/test_fba_error_redapp.py
+++ b/api/app/tests/fba_calc/test_fba_error_redapp.py
@@ -67,6 +67,7 @@ logger = logging.getLogger(__name__)
         ("S3", 780, 50.6733333, -120.4816667, date.fromisoformat("2021-07-12"), 6.2, 3, None, None, None, None, 11.5, 186.8, 94.8, 126.1, 900.3, 0.01, 0.01, 0.01, 0.01)
     ],
 )
+@pytest.mark.skip(reason="Only used for initial validation of FireCalc and REDapp")
 def test_redapp_vs_fba(
     fuel_type,
     elevation,

--- a/api/sitecustomize.py
+++ b/api/sitecustomize.py
@@ -1,0 +1,5 @@
+try:
+    import coverage
+    coverage.process_startup()
+except ImportError:
+    pass

--- a/api/sitecustomize.py
+++ b/api/sitecustomize.py
@@ -1,5 +1,0 @@
-try:
-    import coverage
-    coverage.process_startup()
-except ImportError:
-    pass

--- a/wps_jobs/poetry.lock
+++ b/wps_jobs/poetry.lock
@@ -782,6 +782,21 @@ findlibs = "*"
 numpy = "*"
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -2231,6 +2246,27 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -3224,4 +3260,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12.3,<4.0"
-content-hash = "6f47fe3eac1f961c6ce4109aa49c141ac967e32d4b6ee9748616a0a1823058cb"
+content-hash = "8e4ce46dc64f394a505e7c31e529af34857836905be8b1f4d5c3c0552f96b6dc"

--- a/wps_jobs/pyproject.toml
+++ b/wps_jobs/pyproject.toml
@@ -28,6 +28,7 @@ coverage = "^7.6.4"
 ruff = "^0.11.5"
 ipykernel = "^6.29.5"
 pytest-cov = "^6.1.1"
+pytest-xdist = "^3.6.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/wps_jobs/tests/weather_models/test_ecmwf.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf.py
@@ -261,7 +261,7 @@ async def test_process_models_success(mocker: MockerFixture):
 
     mock_ecmwf_instance.process.assert_called_once()
 
-def test_process_model_run_prediction_model_not_found():
+def test_process_model_run_prediction_model_not_found(mock_herbie_instance):
     """Test process_model_run when prediction model is not found."""
     stations = [WeatherStation(code="001", name="Station1", lat=10.0, long=20.0)]
     mock_repo = MockModelRunRepository()

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -208,7 +208,7 @@ def main():
     except Exception as exception:
         # Exit non 0 - failure.
         logger.error("An error occurred while processing ECMWF model.", exc_info=exception)
-        rc_message = f':poop: Encountered error retrieving {sys.argv[1]} model data from Env Canada'
+        rc_message = f':poop: Encountered error retrieving model data from ECMWF'
         send_rocketchat_notification(rc_message, exception)
         sys.exit(os.EX_SOFTWARE)
 

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -208,7 +208,7 @@ def main():
     except Exception as exception:
         # Exit non 0 - failure.
         logger.error("An error occurred while processing ECMWF model.", exc_info=exception)
-        rc_message = f':poop: Encountered error retrieving model data from ECMWF'
+        rc_message = ':poop: Encountered error retrieving model data from ECMWF'
         send_rocketchat_notification(rc_message, exception)
         sys.exit(os.EX_SOFTWARE)
 


### PR DESCRIPTION
- optimize tests, cutting test run time by over 50%
       -  ~10.5 to ~4 mins for `api`
       -  ~5 to ~2 mins for `wps_shared`
- Adds skip markers to tests used for initial validation of FireCalc and REDapp.
- Updates GitHub workflow configurations to use a `wps-api-base` image and removes redundant setup steps.
- Consolidates and simplifies installation steps
- Notes: 
    - uses `pytest-cov` instead of `coverage` now. Enables branch coverage for accurate coverage and reports show partial branch coverage which is why there's a ~4% decrease in cov.
    - will need to adjust required checks to remove the `strategy` based required ones.

# Test Links:
[Landing Page](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4501-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
