### PR TITLE
Herbie/ECMWF job logic

### DIFF
--- a/wps_jobs/tests/weather_models/test_ecmwf.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf.py
@@ -1,13 +1,11 @@
-from datetime import datetime
 import os
-import sys
 import pytest
 from aiohttp import ClientSession
 from pytest_mock import MockerFixture
 from unittest.mock import MagicMock
 from wps_shared.tests.common import default_mock_client_get
 import wps_jobs.weather_model_jobs.ecmwf
-from wps_jobs.weather_model_jobs import ModelEnum, ProjectionEnum
+from wps_jobs.weather_model_jobs import ModelEnum
 from wps_shared.schemas.stations import WeatherStation
 from wps_shared.db.crud.model_run_repository import ModelRunRepository
 from wps_shared.db.models.weather_models import PredictionModelRunTimestamp

--- a/wps_jobs/tests/weather_models/test_ecmwf.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf.py
@@ -267,27 +267,3 @@ def test_process_model_run_prediction_model_complete(mock_herbie_instance, compl
     assert ecmwf.files_downloaded == 0
     assert ecmwf.files_processed == 0
     assert ecmwf.exception_count == 0
-
-
-def test_get_model_run_urls(mock_herbie_instance):
-    """Test get_model_run_urls to ensure it returns the correct URLs."""
-    mock_herbie_instance.grib = "/mock/path/to/file.grib"
-
-    urls = wps_jobs.weather_model_jobs.ecmwf.get_model_run_urls(datetime(2023, 1, 1, 0, 0))
-
-    # Ensure the number of URLs matches the forecast hours
-    expected_forecast_hours = len(list(get_ecmwf_forecast_hours()))
-    assert len(urls) == expected_forecast_hours
-
-    # Ensure all URLs are the mocked grib file path
-    assert all(url == "/mock/path/to/file.grib" for url in urls)
-
-
-def test_get_model_run_urls_no_grib(mock_herbie_instance):
-    """Test get_model_run_urls when no grib files are found."""
-    mock_herbie_instance.grib = None  # Simulate no grib file found
-
-    urls = wps_jobs.weather_model_jobs.ecmwf.get_model_run_urls(datetime(2023, 1, 1, 0, 0))
-
-    # Ensure no URLs are returned
-    assert len(urls) == 0

--- a/wps_jobs/tests/weather_models/test_ecmwf.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf.py
@@ -99,7 +99,7 @@ def test_ecmwf_process_model_complete(complete, expected_processed, expected_com
     mock_repository = MagicMock(spec=ModelRunRepository)
     mock_repository.get_or_create_prediction_run.return_value.complete = complete
     mock_repository.check_if_model_run_complete.return_value = complete
-    mock_repository.get_processed_url.return_value = False
+    mock_repository.get_processed_url.return_value = None
 
     ecmwf = ECMWF("/tmp", stations, mock_repository)
     ecmwf.process_model_run(0)

--- a/wps_jobs/tests/weather_models/test_ecmwf.py
+++ b/wps_jobs/tests/weather_models/test_ecmwf.py
@@ -53,7 +53,6 @@ def mock_herbie_instance(mocker: MockerFixture):
     yield mock_herbie_instance
 
 
-
 def test_get_model_run_hours():
     hours = list(get_model_run_hours(ModelEnum.ECMWF))
     assert hours == [0, 12]
@@ -77,6 +76,7 @@ def test_get_stations_dataframe():
     assert df.iloc[0]["latitude"] == 11.0
     assert df.iloc[0]["longitude"] == 21.0
 
+
 def test_ecmwf_process_model_run_no_url(mock_herbie_instance):
     mock_herbie_instance.grib = None
     stations = [WeatherStation(code="001", name="Station1", lat=10.0, long=20.0)]
@@ -86,37 +86,23 @@ def test_ecmwf_process_model_run_no_url(mock_herbie_instance):
     assert ecmwf.files_downloaded == 0
     assert ecmwf.files_processed == 0
 
+
 @pytest.mark.parametrize(
     "complete, expected_processed, expected_complete_check, expected_complete",
-    [
-        (False, 65, 1, 1),
-        (True, 0, 0, 0)
-    ],
+    [(False, 65, 1, 1), (True, 0, 0, 0)],
 )
 def test_ecmwf_process_model_complete(complete, expected_processed, expected_complete_check, expected_complete, mock_herbie_instance, mocker: MockerFixture):
-    mocker.patch(
-        "wps_jobs.weather_model_jobs.ecmwf.get_ecmwf_transformer",
-        return_value=MagicMock()
-    )
-    mocker.patch(
-        "wps_jobs.weather_model_jobs.ecmwf.get_stations_dataframe",
-        return_value=MagicMock()
-    )
-    mocker.patch.object(
-        ECMWFModelProcessor,
-        "process_grib_data",
-        return_value=MagicMock()
-    )
+    mocker.patch("wps_jobs.weather_model_jobs.ecmwf.get_ecmwf_transformer", return_value=MagicMock())
+    mocker.patch("wps_jobs.weather_model_jobs.ecmwf.get_stations_dataframe", return_value=MagicMock())
+    mocker.patch.object(ECMWFModelProcessor, "process_grib_data", return_value=MagicMock())
     # Mock ECMWF.store_processed_result to do nothing
-    mocker.patch.object(
-        ECMWF,
-        "store_processed_result",
-        return_value=None
-    )
+    mocker.patch.object(ECMWF, "store_processed_result", return_value=None)
     stations = [WeatherStation(code="001", name="Station1", lat=10.0, long=20.0)]
     mock_repository = MagicMock(spec=ModelRunRepository)
-    mock_repository.get_or_create_prediction_run = MagicMock(return_value=MagicMock(complete=complete))
-    mock_repository.check_if_model_run_complete = MagicMock(return_value=True)
+    mock_repository.get_or_create_prediction_run.return_value.complete = complete
+    mock_repository.check_if_model_run_complete.return_value = complete
+    mock_repository.get_processed_url.return_value = False
+
     ecmwf = ECMWF("/tmp", stations, mock_repository)
     ecmwf.process_model_run(0)
 
@@ -124,9 +110,7 @@ def test_ecmwf_process_model_complete(complete, expected_processed, expected_com
     assert ecmwf.files_downloaded == expected_processed
     assert ecmwf.files_processed == expected_processed
     assert mock_repository.mark_url_as_processed.call_count == expected_processed
-    assert mock_repository.check_if_model_run_complete.call_count == expected_complete_check
     assert mock_repository.mark_prediction_model_run_processed.call_count == expected_complete
-
 
 
 def test_ecmwf_process(mock_herbie_instance):
@@ -141,25 +125,9 @@ def test_ecmwf_process(mock_herbie_instance):
     assert ecmwf.files_processed == 130
 
 
-def test_ecmwf_process_model_run_prediction_not_found(mock_herbie_instance, monkeypatch):
-    def mock_get_transformer(_, __):
-        raise Exception()
-
-    monkeypatch.setattr(wps_jobs.weather_model_jobs.ecmwf, "get_ecmwf_transformer", mock_get_transformer)
-
-    stations = [WeatherStation(code="001", name="Station1", lat=10.0, long=20.0)]
-    ecmwf = ECMWF("/tmp", stations, MockModelRunRepository())
-
-    ecmwf.process()
-    # For each hour (0 and 12) get all the forecast hours (2 * (len(range(0, 145, 3)) + len(range(150, 241, 6)))
-    assert ecmwf.exception_count == 130
-
 @pytest.mark.parametrize(
     "prediction_exists",
-    [
-        (True),
-        (False)
-    ],
+    [(True), (False)],
 )
 def test_store_processed_result(prediction_exists):
     mock_repo = MagicMock(spec=ModelRunRepository)
@@ -194,31 +162,34 @@ def test_ecmwf_process_handles_exceptions(monkeypatch):
     stations = [WeatherStation(code="001", name="Station1", lat=10.0, long=20.0)]
     monkeypatch.setattr(wps_jobs.weather_model_jobs.ecmwf.ECMWF, "process_model_run", lambda: Exception("Mocked exception"))
 
-
     ecmwf = ECMWF("/tmp", stations, mock_repo)
     ecmwf.process()
 
     assert ecmwf.exception_count > 0
 
+
 def test_main_success(mocker: MockerFixture, monkeypatch):
     """Test the main function when it runs successfully."""
+
     async def mock_process_models():
         pass
+
     monkeypatch.setattr(ClientSession, "get", default_mock_client_get)
     monkeypatch.setattr(wps_jobs.weather_model_jobs.ecmwf, "process_models", mock_process_models)
     rocket_chat_spy = mocker.spy(wps_jobs.weather_model_jobs.ecmwf, "send_rocketchat_notification")
 
     with pytest.raises(SystemExit) as excinfo:
         wps_jobs.weather_model_jobs.ecmwf.main()
-    
-     # Assert that we exited with an error code.
+
+    # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_OK
     # Assert that rocket chat was called.
     assert rocket_chat_spy.call_count == 0
 
 
 def test_main_fail(mocker: MockerFixture, monkeypatch):
-    """ Run the main method, check that message is sent to rocket chat, and exit code is EX_SOFTWARE """
+    """Run the main method, check that message is sent to rocket chat, and exit code is EX_SOFTWARE"""
+
     def mock_process_models():
         raise Exception()
 
@@ -232,6 +203,7 @@ def test_main_fail(mocker: MockerFixture, monkeypatch):
     assert excinfo.value.code == os.EX_SOFTWARE
     # Assert that rocket chat was called.
     assert rocket_chat_spy.call_count == 1
+
 
 @pytest.mark.anyio
 async def test_process_models_success(mocker: MockerFixture):
@@ -253,13 +225,13 @@ async def test_process_models_success(mocker: MockerFixture):
     mock_ecmwf_instance = mock_ecmwf.return_value
     mock_ecmwf_instance.files_processed = 10
 
-
     mock_temp_dir.return_value.__enter__.return_value = "/mock/temp/dir"
     mock_session_scope.return_value.__enter__.return_value = mock_repo
 
     await wps_jobs.weather_model_jobs.ecmwf.process_models()
 
     mock_ecmwf_instance.process.assert_called_once()
+
 
 def test_process_model_run_prediction_model_not_found(mock_herbie_instance):
     """Test process_model_run when prediction model is not found."""
@@ -275,12 +247,10 @@ def test_process_model_run_prediction_model_not_found(mock_herbie_instance):
     assert ecmwf.files_processed == 0
     assert ecmwf.exception_count == 0
 
+
 @pytest.mark.parametrize(
     "complete",
-    [
-        (True),
-        (False)
-    ],
+    [(True), (False)],
 )
 def test_process_model_run_prediction_model_complete(mock_herbie_instance, complete):
     """Test process_model_run when prediction model is not found."""
@@ -297,6 +267,7 @@ def test_process_model_run_prediction_model_complete(mock_herbie_instance, compl
     assert ecmwf.files_downloaded == 0
     assert ecmwf.files_processed == 0
     assert ecmwf.exception_count == 0
+
 
 def test_get_model_run_urls(mock_herbie_instance):
     """Test get_model_run_urls to ensure it returns the correct URLs."""

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -49,15 +49,6 @@ def get_ecmwf_forecast_hours():
         yield h
 
 
-def get_model_run_urls(model_datetime: datetime) -> List[str]:
-    urls = []
-    for fxx in get_ecmwf_forecast_hours():
-        H = Herbie(model_datetime.strftime("%Y-%m-%d %H"), model="ifs", product="oper", fxx=fxx, verbose=False)
-        if H.grib:
-            urls.append(H.grib)
-    return urls
-
-
 def get_stations_dataframe(transformer: Transformer, stations: List[WeatherStation]) -> pd.DataFrame:
     stations_df = pd.DataFrame([station.model_dump(include={"code", "name", "lat", "long"}) for station in stations]).rename(columns={"lat": "latitude", "long": "longitude"})
 

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -139,9 +139,9 @@ class ECMWF:
                     stations_df = get_stations_dataframe(transformer, self.stations)
                     process_result = self.ecmwf_processor.process_grib_data(H, model_info, stations_df)
                     self.store_processed_result(self.stations, prediction_run, process_result)
-                except Exception as e:
+                except Exception as exception:
                     self.exception_count += 1
-                    logger.error("unexpected exception processing %s", url, exc_info=e)
+                    logger.error("unexpected exception processing %s", url, exc_info=exception)
 
                 self.files_processed += 1
                 self.model_run_repository.mark_url_as_processed(url)
@@ -150,14 +150,6 @@ class ECMWF:
             if len(forecast_hours) == self.files_processed:
                 logger.info(f"{self.model_type} model run {model_run_hour:02d}:00 completed with SUCCESS")
                 self.model_run_repository.mark_prediction_model_run_processed(self.model_type, self.projection, model_datetime)
-
-    def _already_processed(self, url: str) -> bool:
-        """Check if the URL has already been processed."""
-        if self.model_run_repository.get_processed_url(self.session, url):
-            logger.info(f"file already processed -- {url}")
-            self.files_processed += 1
-            return True
-        return False
 
     def process(self):
         for hour in get_model_run_hours(self.model_type):

--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf.py
@@ -48,20 +48,15 @@ def get_ecmwf_forecast_hours():
     for h in range(150, 241, 6):
         yield h
 
+
 def get_model_run_urls(model_datetime: datetime) -> List[str]:
     urls = []
     for fxx in get_ecmwf_forecast_hours():
-        H = Herbie(
-            model_datetime.strftime("%Y-%m-%d %H"),
-            model="ifs",
-            product="oper",
-            priority="aws",
-            fxx=fxx,
-            verbose=False
-        )
+        H = Herbie(model_datetime.strftime("%Y-%m-%d %H"), model="ifs", product="oper", fxx=fxx, verbose=False)
         if H.grib:
             urls.append(H.grib)
     return urls
+
 
 def get_stations_dataframe(transformer: Transformer, stations: List[WeatherStation]) -> pd.DataFrame:
     stations_df = pd.DataFrame([station.model_dump(include={"code", "name", "lat", "long"}) for station in stations]).rename(columns={"lat": "latitude", "long": "longitude"})
@@ -105,7 +100,6 @@ class ECMWF:
         logger.info("Processing {} model run {:02d}".format(self.model_type, model_run_hour))
 
         model_datetime = self.now.replace(hour=model_run_hour, minute=0, second=0, microsecond=0)
-        all_model_run_urls = get_model_run_urls(model_datetime)
 
         self.prediction_model = self.model_run_repository.get_prediction_model(self.model_type, self.projection)
         if not self.prediction_model:
@@ -123,30 +117,56 @@ class ECMWF:
                 projection=self.projection,
             )
 
-            with tempfile.TemporaryDirectory() as temp_dir:
-                H = Herbie(model_datetime.strftime("%Y-%m-%d %H"), model="ifs", product="oper", priority="aws", fxx=prediction_hour, save_dir=temp_dir, verbose=False)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            forecast_hours = list(get_ecmwf_forecast_hours())
+
+            for prediction_hour in forecast_hours:
+                H = Herbie(
+                    model_datetime.strftime("%Y-%m-%d %H"),
+                    model="ifs",
+                    product="oper",
+                    priority="aws",
+                    fxx=prediction_hour,
+                    save_dir=temp_dir,
+                    verbose=False,
+                )
+
                 url = H.grib
                 if not url:
-                    logger.info(f"grib file not found for {model_info.prediction_timestamp} ")
-                    continue
+                    logger.info(f"GRIB file not found for {model_datetime} - hour {prediction_hour}. Exiting model run. ")
+                    return
 
                 self.files_downloaded += 1
+
+                if self.model_run_repository.get_processed_url(url):
+                    logger.info(f"file already processed -- {url}")
+                    self.files_processed += 1
+                    continue
 
                 try:
                     transformer = get_ecmwf_transformer(self.working_directory, H)
                     stations_df = get_stations_dataframe(transformer, self.stations)
                     process_result = self.ecmwf_processor.process_grib_data(H, model_info, stations_df)
                     self.store_processed_result(self.stations, prediction_run, process_result)
-                except Exception as exception:
+                except Exception as e:
                     self.exception_count += 1
-                    # We intentionally catch a broad exception, as we want to try and download as much
-                    # as we can.
-                    logger.error("unexpected exception processing %s", url, exc_info=exception)
+                    logger.error("unexpected exception processing %s", url, exc_info=e)
+
                 self.files_processed += 1
                 self.model_run_repository.mark_url_as_processed(url)
-        if self.model_run_repository.check_if_model_run_complete(all_model_run_urls):
-            logger.info("{} model run {:02d}:00 completed with SUCCESS".format(self.model_type, model_run_hour))
-            self.model_run_repository.mark_prediction_model_run_processed(self.model_type, self.projection, model_datetime)
+
+            # files_processed is incremented whether the file was processed previously or on this run, so we can use it to check if all files were processed.
+            if len(forecast_hours) == self.files_processed:
+                logger.info(f"{self.model_type} model run {model_run_hour:02d}:00 completed with SUCCESS")
+                self.model_run_repository.mark_prediction_model_run_processed(self.model_type, self.projection, model_datetime)
+
+    def _already_processed(self, url: str) -> bool:
+        """Check if the URL has already been processed."""
+        if self.model_run_repository.get_processed_url(self.session, url):
+            logger.info(f"file already processed -- {url}")
+            self.files_processed += 1
+            return True
+        return False
 
     def process(self):
         for hour in get_model_run_hours(self.model_type):
@@ -208,7 +228,7 @@ def main():
     except Exception as exception:
         # Exit non 0 - failure.
         logger.error("An error occurred while processing ECMWF model.", exc_info=exception)
-        rc_message = ':poop: Encountered error retrieving model data from ECMWF'
+        rc_message = ":poop: Encountered error retrieving model data from ECMWF"
         send_rocketchat_notification(rc_message, exception)
         sys.exit(os.EX_SOFTWARE)
 


### PR DESCRIPTION
- Will check if a url has already been processed, so it doesn't try to process it again
- If a url isn't found for a model run, we'll just stop processing the model run and try again later
- Changes logic for determining if a model run was completely processed
# Test Links:
[Landing Page](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4510-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
