### PR TITLE
Add 'openshift: true' to PostgreSQL spec in crunchy templates

### DIFF
--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -75,6 +75,7 @@ objects:
     spec:
       postgresVersion: 16
       postGISVersion: "3.3"
+      openshift: true
       metadata:
         name: ${CRUNCHY_NAME}-${SUFFIX}
         labels:

--- a/openshift/templates/crunchy_standby.yaml
+++ b/openshift/templates/crunchy_standby.yaml
@@ -70,6 +70,7 @@ objects:
     spec:
       postgresVersion: 16
       postGISVersion: "3.3"
+      openshift: true
       metadata:
         name: ${CRUNCHY_NAME}-${DATE}-${SUFFIX}
         labels:


### PR DESCRIPTION
Include the 'openshift: true' configuration in the PostgreSQL specification within the crunchy templates to support OpenShift deployments.

This tells crunchy to run pods with the security context openshift expects