### PR TITLE
VSC Settings

### DIFF
--- a/.vscode/wps.code-workspace
+++ b/.vscode/wps.code-workspace
@@ -30,7 +30,6 @@
 		"[python]": {
 			"editor.defaultFormatter": "charliermarsh.ruff",
 		},
-		"ruff.lineLength": 100,
 		"autoDocstring.docstringFormat": "sphinx-notypes",
 		"autoDocstring.startOnNewLine": true,
 		// JavaScript/TypeScript

--- a/.vscode/wps.code-workspace
+++ b/.vscode/wps.code-workspace
@@ -34,10 +34,6 @@
 			]
 		},
 		"ruff.lineLength": 100,
-		"ruff.lint.ignore": [
-			"E712",
-			"F401"
-		],
 		"autoDocstring.docstringFormat": "sphinx-notypes",
 		"autoDocstring.startOnNewLine": true,
 		// JavaScript/TypeScript

--- a/.vscode/wps.code-workspace
+++ b/.vscode/wps.code-workspace
@@ -11,8 +11,14 @@
 		}
 	],
 	"settings": {
-		"autoDocstring.docstringFormat": "sphinx-notypes",
-		"autoDocstring.startOnNewLine": true,
+		// General
+		"editor.codeActionsOnSave": {
+			"source.fixAll": "explicit"
+		},
+		"editor.formatOnSave": true,
+		"editor.rulers": [
+			100
+		],
 		"files.exclude": {
 			".github": false,
 			"**/.pytest_cache": true,
@@ -20,44 +26,49 @@
 			"**/python_cache": true,
 			"**/.venv": true
 		},
-		"editor.codeActionsOnSave": {
-			"source.fixAll": "explicit"
+		// Python
+		"[python]": {
+			"editor.defaultFormatter": "charliermarsh.ruff",
+			"editor.rulers": [
+				100
+			]
 		},
-		"editor.formatOnSave": true,
+		"ruff.lineLength": 100,
+		"ruff.lint.ignore": [
+			"E712",
+			"F401"
+		],
+		"autoDocstring.docstringFormat": "sphinx-notypes",
+		"autoDocstring.startOnNewLine": true,
+		// JavaScript/TypeScript
 		"eslint.format.enable": true,
+		"eslint.run": "onSave",
 		"eslint.validate": [
 			"javascript",
 			"javascriptreact",
 			"typescript",
-			"typescriptreact",
+			"typescriptreact"
 		],
-		"eslint.run": "onSave",
-		"editor.rulers": [
-			100
-		],
-		"[python]": {
-			"editor.defaultFormatter": "charliermarsh.ruff",
-			"editor.rulers": [
-				120,
-				100
-			]
-		},
+		"typescript.preferences.importModuleSpecifier": "non-relative",
+		// HTML
 		"[html]": {
 			"editor.formatOnSave": false
 		},
+		// YAML
 		"[yaml]": {
 			"editor.defaultFormatter": "esbenp.prettier-vscode",
 			"editor.insertSpaces": true,
 			"editor.tabSize": 2,
-			"editor.formatOnSave": true,
+			"editor.formatOnSave": true
 		},
+		// JSON/JSONC
 		"[json]": {
 			"editor.defaultFormatter": "vscode.json-language-features"
 		},
 		"[jsonc]": {
 			"editor.defaultFormatter": "vscode.json-language-features"
 		},
-		"typescript.preferences.importModuleSpecifier": "non-relative",
+		// Spell checker
 		"cSpell.words": [
 			"actuals",
 			"aiobotocore",

--- a/.vscode/wps.code-workspace
+++ b/.vscode/wps.code-workspace
@@ -29,9 +29,6 @@
 		// Python
 		"[python]": {
 			"editor.defaultFormatter": "charliermarsh.ruff",
-			"editor.rulers": [
-				100
-			]
 		},
 		"ruff.lineLength": 100,
 		"autoDocstring.docstringFormat": "sphinx-notypes",
@@ -57,7 +54,7 @@
 			"editor.tabSize": 2,
 			"editor.formatOnSave": true
 		},
-		// JSON/JSONC
+		// JSON
 		"[json]": {
 			"editor.defaultFormatter": "vscode.json-language-features"
 		},

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -98,3 +98,4 @@ lint.per-file-ignores = { "alembic/versions/00df3c7b5cba_rethink_classification.
     "E402",
     "F811",
 ] }
+lint.ignore = ["E712", "F401"]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -68,34 +68,3 @@ pytest-cov = "^6.0.0"
 [build-system]
 requires = ["poetry>=1.1.11"]
 build-backend = "poetry.masonry.api"
-
-[tool.ruff]
-exclude = ["app/tests/fba_calc/test_fba_error_redapp.py"]
-lint.per-file-ignores = { "alembic/versions/00df3c7b5cba_rethink_classification.py" = [
-    "E501",
-], "alembic/versions/39806f02cdec_wfwx_update_date_part_of_unique_.py" = [
-    "E501",
-], "alembic/versions/56916d46d8cb_high_hfi_area.py" = [
-    "E501",
-], "alembic/versions/ac65354014bd_remove_bear_lake_station.py" = [
-    "E501",
-], "app/auto_spatial_advisory/db/database/tileserver.py" = [
-    "E501",
-], "app/tests/fba_calc/test_fba_error.py" = [
-    "E501",
-], "app/tests/hfi/test_hfi.py" = [
-    "F811",
-], "app/auto_spatial_advisory/nats_consumer.py" = [
-    "F811",
-], "app/tests/hfi/test_pdf_formatter.py" = [
-    "F811",
-], "app/tests/hfi/test_pdf_generator.py" = [
-    "F811",
-], "app/tests/weather_models/test_env_canada_gdps.py" = [
-    "F811",
-], "app/db/models/__init__.py" = [
-    "F401",
-    "E402",
-    "F811",
-] }
-lint.ignore = ["E712", "F401"]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -98,5 +98,3 @@ lint.per-file-ignores = { "alembic/versions/00df3c7b5cba_rethink_classification.
     "E402",
     "F811",
 ] }
-line-length = 185
-lint.ignore = ["E712", "F401"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,34 @@
+target-version = "py312"
+line-length = 100
+
+exclude = ["api/app/tests/fba_calc/test_fba_error_redapp.py"]
+
+[lint]
+ignore = ["E712", "F401"]
+per-file-ignores = { "api/alembic/versions/00df3c7b5cba_rethink_classification.py" = [
+    "E501",
+], "api/alembic/versions/39806f02cdec_wfwx_update_date_part_of_unique_.py" = [
+    "E501",
+], "api/alembic/versions/56916d46d8cb_high_hfi_area.py" = [
+    "E501",
+], "api/alembic/versions/ac65354014bd_remove_bear_lake_station.py" = [
+    "E501",
+], "api/app/auto_spatial_advisory/db/database/tileserver.py" = [
+    "E501",
+], "api/app/tests/fba_calc/test_fba_error.py" = [
+    "E501",
+], "api/app/tests/hfi/test_hfi.py" = [
+    "F811",
+], "api/app/auto_spatial_advisory/nats_consumer.py" = [
+    "F811",
+], "api/app/tests/hfi/test_pdf_formatter.py" = [
+    "F811",
+], "api/app/tests/hfi/test_pdf_generator.py" = [
+    "F811",
+], "api/app/tests/weather_models/test_env_canada_gdps.py" = [
+    "F811",
+], "api/app/db/models/__init__.py" = [
+    "F401",
+    "E402",
+    "F811",
+] }

--- a/wps_jobs/pyproject.toml
+++ b/wps_jobs/pyproject.toml
@@ -33,3 +33,6 @@ pytest-xdist = "^3.6.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+lint.ignore = ["E712", "F401"]

--- a/wps_jobs/pyproject.toml
+++ b/wps_jobs/pyproject.toml
@@ -33,6 +33,3 @@ pytest-xdist = "^3.6.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.ruff]
-lint.ignore = ["E712", "F401"]

--- a/wps_jobs/pyproject.toml
+++ b/wps_jobs/pyproject.toml
@@ -33,7 +33,3 @@ pytest-xdist = "^3.6.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.ruff]
-line-length = 185
-lint.ignore = ["E712", "F401"]

--- a/wps_shared/pyproject.toml
+++ b/wps_shared/pyproject.toml
@@ -36,3 +36,6 @@ pytest-cov = "^6.1.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+lint.ignore = ["E712", "F401"]

--- a/wps_shared/pyproject.toml
+++ b/wps_shared/pyproject.toml
@@ -36,6 +36,3 @@ pytest-cov = "^6.1.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.ruff]
-lint.ignore = ["E712", "F401"]

--- a/wps_shared/pyproject.toml
+++ b/wps_shared/pyproject.toml
@@ -30,13 +30,9 @@ pytest = "^7.2.1"
 pytest-mock = "^3"
 coverage = "^7.6.4"
 ruff = "^0.11.5"
-testcontainers = {extras = ["postgres"], version = "^4.10.0"}
+testcontainers = { extras = ["postgres"], version = "^4.10.0" }
 pytest-cov = "^6.1.1"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.ruff]
-line-length = 185
-lint.ignore = ["E712", "F401"]


### PR DESCRIPTION
- use `ruff.toml` file so we can just have ruff settings in a single place. Without it I believe we would still need `lint.ignore` rules in each pyproject.toml
   - set ruff line-length project wide to 100
- minor re-org of vscode settings 
# Test Links:
[Landing Page](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4520-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
