### PR TITLE
Remove caching of oc tools

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -23,6 +23,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: Clean up - dev (OCP4)
         shell: bash
@@ -59,6 +60,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: Clean up dev database
         shell: bash

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,6 +22,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: Deploy PostGIS instance
         shell: bash
@@ -48,6 +49,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: Build wps-web Image
         shell: bash
@@ -71,6 +73,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: Build wps-api Image
         shell: bash
@@ -112,6 +115,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: Build wps-jobs Image
         shell: bash
@@ -135,6 +139,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: Configure
         shell: bash
@@ -168,6 +173,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: Deploy API to Dev
         shell: bash
@@ -322,6 +328,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: NATS Message Queue
         shell: bash
@@ -383,6 +390,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
 
       - name: C-Haines Cronjob
         shell: bash

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -30,6 +30,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.14"
+          skip_cache: true
       - name: Provision to production
         run: |
           echo Login


### PR DESCRIPTION
Disable caching for the OpenShift tools installer because it fails and takes a long time trying.

It takes ~2 mins for the default cache attempt, and 5 seconds to forgo caching:
Before: https://github.com/bcgov/wps/actions/runs/15334468614/job/43149160201
After: https://github.com/bcgov/wps/actions/runs/15334920251/job/43150075989?pr=4544

# Test Links:
[Landing Page](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4544-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
