### PR TITLE
Cache HFI layer selection

### DIFF
--- a/web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/src/features/fba/components/map/FBAMap.tsx
@@ -161,7 +161,7 @@ const FBAMap = (props: FBAMapProps) => {
   useEffect(() => {
     const hfiLayerEnabled = localStorage.getItem(hfiLayerName)
     setShowHFI(hfiLayerEnabled === 'true')
-  })
+  }, [])
 
   useEffect(() => {
     if (map) {

--- a/web/src/features/fba/components/map/Legend.tsx
+++ b/web/src/features/fba/components/map/Legend.tsx
@@ -7,6 +7,8 @@ import {
   HFI_ADVISORY,
   HFI_WARNING
 } from 'features/fba/components/map/featureStylers'
+import { isEqual } from 'lodash'
+import { hfiLayerName, zoneStatusLayerName } from '@/features/fba/components/map/FBAMap'
 
 const LegendGrid = styled(Grid)({
   display: 'flex',
@@ -100,18 +102,15 @@ interface LegendProps {
   setShowHFI: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-const Legend = ({
-  onToggleLayer,
-  showShapeStatus,
-  setShowShapeStatus,
-  showHFI,
-  setShowHFI
-}: LegendProps) => {
+const Legend = ({ onToggleLayer, showShapeStatus, setShowShapeStatus, showHFI, setShowHFI }: LegendProps) => {
   const handleLayerChange = (
     layerName: string,
     isVisible: boolean,
     setShowLayer: React.Dispatch<React.SetStateAction<boolean>>
   ) => {
+    if (isEqual(layerName, hfiLayerName)) {
+      localStorage.setItem(hfiLayerName, `${!isVisible}`)
+    }
     setShowLayer(!isVisible)
     onToggleLayer(layerName, !isVisible)
   }
@@ -133,13 +132,13 @@ const Legend = ({
       <LegendItem
         label="Zone Unit Status"
         checked={showShapeStatus}
-        onChange={() => handleLayerChange('fireShapeVector', showShapeStatus, setShowShapeStatus)}
+        onChange={() => handleLayerChange(zoneStatusLayerName, showShapeStatus, setShowShapeStatus)}
         subItems={zoneStatusSubItems}
       />
       <LegendItem
         label="HFI Potential (kW/m)"
         checked={showHFI}
-        onChange={() => handleLayerChange('hfiVector', showHFI, setShowHFI)}
+        onChange={() => handleLayerChange(hfiLayerName, showHFI, setShowHFI)}
         subItems={hfiSubItems}
       />
     </LegendGrid>


### PR DESCRIPTION
Implement caching for the HFI layer selection state using local storage, allowing users to retain their preferences across sessions. Update related components to utilize the cached value.

Closes #4538

# Test Links:
[Landing Page](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4549-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
