### PR TITLE
Refine Provincial Fuel Thresholds

### DIFF
--- a/api/app/auto_spatial_advisory/zone_stats.py
+++ b/api/app/auto_spatial_advisory/zone_stats.py
@@ -54,11 +54,11 @@ def get_fuel_type_area_stats(grass_curing_date: date,
                              fuel_type_id: int,
                              area: float,
                              fuel_area: float):
-    # area is stored in square metres in DB. For user convenience, convert to hectares
-    # 1 ha = 10,000 sq.m.
-    area = area / 10000
-    fuel_area = fuel_area / 10000
-    fuel_type_obj: DBSFMSFuelType = next((ft[0] for ft in sfms_fuel_types if ft[0].id == fuel_type_id), None)
+    area = area
+    fuel_area = fuel_area
+    fuel_type_obj: DBSFMSFuelType = next(
+        (ft for ft in sfms_fuel_types if ft.id == fuel_type_id), None
+    )
     percent_curing = get_optional_percent_curing(grass_curing_date, fuel_type_obj)
     fuel_type_code_details = fuel_type_obj.fuel_type_code + (f" (≥{percent_conifer} PC)" if percent_conifer is not None else "")
     return ClassifiedHfiThresholdFuelTypeArea(

--- a/api/app/tests/auto_spatial_advisory/test_zone_stats.py
+++ b/api/app/tests/auto_spatial_advisory/test_zone_stats.py
@@ -69,8 +69,8 @@ def test_get_fuel_type_area_stats():
     area=50000
     fuel_area=60000
     res = get_fuel_type_area_stats(date(2024, 11, 1), [(grass_fuel_type, non_grass_fuel_type)], HfiThreshold(id=1, description="4000 < hfi < 10000", name="advisory"), None, critical_hour_start=8, critical_hour_end=12, fuel_type_id=12, area=area, fuel_area=fuel_area)
-    assert res.area == area / 10000
-    assert res.fuel_area == fuel_area / 10000
+    assert res.area == area
+    assert res.fuel_area == fuel_area
     assert res.percent_curing == 60
 
 
@@ -78,8 +78,8 @@ def test_get_fuel_type_area_stats_non_grass():
     area=50000
     fuel_area=60000
     res = get_fuel_type_area_stats(date(2024, 11, 1), [(non_grass_fuel_type, grass_fuel_type)], HfiThreshold(id=1, description="4000 < hfi < 10000", name="advisory"), None, critical_hour_start=8, critical_hour_end=12, fuel_type_id=14, area=area, fuel_area=fuel_area)
-    assert res.area == area / 10000
-    assert res.fuel_area == fuel_area / 10000
+    assert res.area == area
+    assert res.fuel_area == fuel_area
     assert res.percent_curing is None
 
 
@@ -88,8 +88,8 @@ def test_get_fuel_type_area_stats_percent_conifer():
     fuel_area=60000
     percent_conifer = 1
     res = get_fuel_type_area_stats(date(2024, 11, 1), [(non_grass_fuel_type, grass_fuel_type)], HfiThreshold(id=1, description="4000 < hfi < 10000", name="advisory"), percent_conifer, critical_hour_start=8, critical_hour_end=12, fuel_type_id=14, area=area, fuel_area=fuel_area)
-    assert res.area == area / 10000
-    assert res.fuel_area == fuel_area / 10000
+    assert res.area == area
+    assert res.fuel_area == fuel_area
     assert res.percent_curing is None
     assert res.fuel_type.fuel_type_code == f"M-1/M-2 (≥{percent_conifer} PC)"
 

--- a/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
+++ b/web/src/features/fba/components/infoPanel/FireZoneUnitTabs.tsx
@@ -125,6 +125,7 @@ const FireZoneUnitTabs = ({
                           minHeight: '30px'
                         }}
                         label={zone.fire_shape_name.split('-')[0]}
+                        aria-label={`zone-${key}-tab`}
                       />
                     </Tooltip>
                   )

--- a/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
+++ b/web/src/features/fba/components/infoPanel/advisoryText.test.tsx
@@ -37,6 +37,11 @@ const buildTestStore = (
   return testStore
 }
 
+const preCoreSeasonForDate = DateTime.fromObject({ year: 2025, month: 5, day: 31 })
+const firstCoreSeasonDate = DateTime.fromObject({ year: 2025, month: 6, day: 1 })
+const lastCoreSeasonDate = DateTime.fromObject({ year: 2025, month: 9, day: 30 })
+const postCoreSeasonDate = DateTime.fromObject({ year: 2025, month: 10, day: 1 })
+
 const issueDate = DateTime.now()
 const forDate = DateTime.now()
 const advisoryThreshold = 20
@@ -143,8 +148,8 @@ const initialHFIFuelStats = {
             start_time: 9,
             end_time: 13
           },
-          area: 4000,
-          fuel_area: 8000
+          area: 4000000000,
+          fuel_area: 8000000000
         }
       ],
       min_wind_stats: [
@@ -187,8 +192,8 @@ describe('AdvisoryText', () => {
     expect(screen.queryByTestId('advisory-message-proportion')).toBeInTheDocument()
     expect(screen.queryByTestId('advisory-message-warning')).toBeInTheDocument()
     expect(screen.queryByTestId('advisory-message-wind-speed')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('advisory-message-early-low-wind')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('advisory-message-overnight')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('advisory-message-slash')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('overnight-burning-text')).not.toBeInTheDocument()
   }
 
   it('should render the advisory text container', () => {
@@ -240,6 +245,56 @@ describe('AdvisoryText', () => {
     expect(message).toBeInTheDocument()
     const bulletinIssueDate = queryByTestId('bulletin-issue-date')
     expect(bulletinIssueDate).not.toBeInTheDocument()
+  })
+
+  it('should include fuel stats when their fuel area is above the 100 * 2000m * 2000m threshold', async () => {
+    const store = getInitialStore()
+    render(
+      <Provider store={store}>
+        <AdvisoryText
+          issueDate={issueDate}
+          forDate={forDate}
+          advisoryThreshold={advisoryThreshold}
+          selectedFireCenter={mockFireCenter}
+          selectedFireZoneUnit={mockFireZoneUnit}
+        />
+      </Provider>
+    )
+    assertInitialState()
+    store.dispatch(getFireCentreHFIFuelStatsSuccess(initialHFIFuelStats))
+    await waitFor(() => expect(screen.queryByTestId('advisory-message-warning')).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.queryByTestId('advisory-message-warning')).toHaveTextContent(
+        initialHFIFuelStats['Cariboo Fire Centre'][20].fuel_area_stats[0].fuel_type.fuel_type_code
+      )
+    )
+  })
+
+  it('should not include fuel stats when their fuel area is below the 100 * 2000m * 2000m threshold', async () => {
+    const store = getInitialStore()
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <AdvisoryText
+          issueDate={issueDate}
+          forDate={forDate}
+          advisoryThreshold={advisoryThreshold}
+          selectedFireCenter={mockFireCenter}
+          selectedFireZoneUnit={mockFireZoneUnit}
+        />
+      </Provider>
+    )
+    assertInitialState()
+    let smallAreaStats = cloneDeep(initialHFIFuelStats)
+    smallAreaStats['Cariboo Fire Centre'][20].fuel_area_stats[0].area = 10
+    smallAreaStats['Cariboo Fire Centre'][20].fuel_area_stats[0].fuel_area = 100
+    store.dispatch(getFireCentreHFIFuelStatsSuccess(smallAreaStats))
+
+    await waitFor(() => expect(screen.queryByTestId('advisory-message-warning')).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.queryByTestId('advisory-message-warning')).not.toHaveTextContent(
+        initialHFIFuelStats['Cariboo Fire Centre'][20].fuel_area_stats[0].fuel_type.fuel_type_code
+      )
+    )
   })
 
   it('should render forDate as mmm/dd when different than issue date', () => {
@@ -328,8 +383,6 @@ describe('AdvisoryText', () => {
       `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL)} for today.`
     )
     expect(screen.queryByTestId('advisory-message-wind-speed')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('advisory-message-early-low-wind')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('advisory-message-overnight')).not.toBeInTheDocument()
   })
 
   it('should render advisory status', () => {
@@ -359,8 +412,6 @@ describe('AdvisoryText', () => {
       `Issued on ${issueDate?.toLocaleString(DateTime.DATETIME_FULL)} for today.`
     )
     expect(screen.queryByTestId('advisory-message-wind-speed')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('advisory-message-early-low-wind')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('advisory-message-overnight')).not.toBeInTheDocument()
   })
 
   it('should render wind speed text and early fire behaviour text when fire zone unit is selected, based on wind speed & critical hours data', async () => {
@@ -377,9 +428,7 @@ describe('AdvisoryText', () => {
       </Provider>
     )
     assertInitialState()
-
     store.dispatch(getFireCentreHFIFuelStatsSuccess(initialHFIFuelStats))
-
     await waitFor(() => expect(screen.queryByTestId('advisory-message-wind-speed')).toBeInTheDocument())
     await waitFor(() => expect(screen.queryByTestId('early-advisory-text')).toBeInTheDocument())
     await waitFor(() => expect(screen.queryByTestId('overnight-burning-text')).not.toBeInTheDocument())
@@ -404,7 +453,6 @@ describe('AdvisoryText', () => {
     overnightStats['Cariboo Fire Centre'][20].fuel_area_stats[0].critical_hours.end_time = 5
 
     store.dispatch(getFireCentreHFIFuelStatsSuccess(overnightStats))
-
     await waitFor(() => expect(screen.queryByTestId('early-advisory-text')).toBeInTheDocument())
     await waitFor(() => expect(screen.queryByTestId('overnight-burning-text')).toBeInTheDocument())
     await waitFor(() =>
@@ -434,9 +482,8 @@ describe('AdvisoryText', () => {
     overnightStats['Cariboo Fire Centre'][20].fuel_area_stats[0].critical_hours.start_time = 13
 
     store.dispatch(getFireCentreHFIFuelStatsSuccess(overnightStats))
-
-    await waitFor(() => expect(screen.queryByTestId('early-advisory-text')).not.toBeInTheDocument())
-    await waitFor(() => expect(screen.queryByTestId('overnight-burning-text')).toBeInTheDocument())
+    await waitFor(async () => expect(screen.queryByTestId('early-advisory-text')).not.toBeInTheDocument())
+    await waitFor(async () => expect(screen.queryByTestId('overnight-burning-text')).toBeInTheDocument())
     await waitFor(() =>
       expect(screen.queryByTestId('overnight-burning-text')).toHaveTextContent(
         'Be prepared for fire behaviour to remain elevated into the overnight hours.'
@@ -498,6 +545,46 @@ describe('AdvisoryText', () => {
     const criticalHoursMessage = queryByTestId('advisory-message-no-critical-hours')
     expect(advisoryMessage).toBeInTheDocument()
     expect(criticalHoursMessage).toBeInTheDocument()
+  })
+
+  it('should not render slash warning when critical hours duration is less than 12 hours', async () => {
+    const store = getInitialStore()
+    render(
+      <Provider store={store}>
+        <AdvisoryText
+          issueDate={issueDate}
+          forDate={forDate}
+          advisoryThreshold={advisoryThreshold}
+          selectedFireCenter={mockFireCenter}
+          selectedFireZoneUnit={mockFireZoneUnit}
+        />
+      </Provider>
+    )
+    assertInitialState()
+    store.dispatch(getFireCentreHFIFuelStatsSuccess(initialHFIFuelStats))
+    await waitFor(() => expect(screen.queryByTestId('advisory-message-slash')).not.toBeInTheDocument())
+  })
+
+  it('should render slash warning when critical hours duration is greater than 12 hours', async () => {
+    const store = getInitialStore()
+    render(
+      <Provider store={store}>
+        <AdvisoryText
+          issueDate={issueDate}
+          forDate={forDate}
+          advisoryThreshold={advisoryThreshold}
+          selectedFireCenter={mockFireCenter}
+          selectedFireZoneUnit={mockFireZoneUnit}
+        />
+      </Provider>
+    )
+    assertInitialState()
+
+    let newHFIFuelStats = cloneDeep(initialHFIFuelStats)
+    newHFIFuelStats['Cariboo Fire Centre'][20].fuel_area_stats[0].critical_hours.end_time = 22
+
+    store.dispatch(getFireCentreHFIFuelStatsSuccess(newHFIFuelStats))
+    await waitFor(() => expect(screen.queryByTestId('advisory-message-slash')).toBeInTheDocument())
   })
 })
 
@@ -616,8 +703,8 @@ const fireZoneFuelStats: FireZoneHFIStats = {
         start_time: 10.0,
         end_time: 21.0
       },
-      area: 90,
-      fuel_area: 100
+      area: 300,
+      fuel_area: 1000
     },
     {
       fuel_type: {
@@ -642,10 +729,25 @@ const fireZoneFuelStats: FireZoneHFIStats = {
 }
 
 describe('getTopFuelsByArea', () => {
-  it('should return the top fuels by area, correctly handling both advisory and warning hfi pixels', () => {
-    const result = getTopFuelsByArea(fireZoneFuelStats)
+  it('should return the top fuels by area before start of core season, correctly handling both advisory and warning hfi pixels', () => {
+    const result = getTopFuelsByArea(fireZoneFuelStats, preCoreSeasonForDate)
+    // should return the fuel records that cumulatively sum to > 75% of the total hfi area
+    expect(result).toEqual(fireZoneFuelStats.fuel_area_stats.slice(0, 3))
+  })
+  it('should return the top fuels by area from start of core season, correctly handling both advisory and warning hfi pixels', () => {
+    const result = getTopFuelsByArea(fireZoneFuelStats, firstCoreSeasonDate)
+    // should return the fuel records that cumulatively sum to > 75% of the total hfi area
+    expect(result).toEqual([...fireZoneFuelStats.fuel_area_stats.slice(0, 2)])
+  })
+  it('should return the top fuels by area until end of core season, correctly handling both advisory and warning hfi pixels', () => {
+    const result = getTopFuelsByArea(fireZoneFuelStats, lastCoreSeasonDate)
     // should return the fuel records that cumulatively sum to > 75% of the total hfi area
     expect(result).toEqual(fireZoneFuelStats.fuel_area_stats.slice(0, 2))
+  })
+  it('should return the top fuels by area after end of core season, correctly handling both advisory and warning hfi pixels', () => {
+    const result = getTopFuelsByArea(fireZoneFuelStats, postCoreSeasonDate)
+    // should return the fuel records that cumulatively sum to > 75% of the total hfi area
+    expect(result).toEqual(fireZoneFuelStats.fuel_area_stats.slice(0, 3))
   })
 })
 
@@ -653,7 +755,7 @@ describe('getTopFuelsByProportion', () => {
   it('should return the top fuels by proportion of their fuel area', () => {
     const result = getTopFuelsByProportion(fireZoneFuelStats.fuel_area_stats)
     // should return the fuel records that cumulatively sum to > 90% of their own fuel area
-    expect(result).toEqual(fireZoneFuelStats.fuel_area_stats.slice(0, 3))
+    expect(result).toEqual(fireZoneFuelStats.fuel_area_stats.slice(0, 2))
   })
 })
 

--- a/web/src/features/fba/criticalHoursStartEndTime.test.ts
+++ b/web/src/features/fba/criticalHoursStartEndTime.test.ts
@@ -99,19 +99,19 @@ const noHoursM1M2: FireZoneFuelStats = {
 describe('getMinStartAndMaxEndTime', () => {
   it('handles normal same-day critical hours', () => {
     const result = getMinStartAndMaxEndTime([sameDayC2])
-    expect(result).toEqual({ minStartTime: 10, maxEndTime: 21 })
+    expect(result).toEqual({ minStartTime: 10, maxEndTime: 21, duration: 11 })
   })
   it('handles full day/time critical hours', () => {
     const result = getMinStartAndMaxEndTime([fullDayC2])
-    expect(result).toEqual({ minStartTime: 7, maxEndTime: 7 })
+    expect(result).toEqual({ minStartTime: 7, maxEndTime: 7, duration: 24 })
   })
   it('handles stats containing both same day and next day critical hours', () => {
     const result = getMinStartAndMaxEndTime([sameDayC2, fullDayC2])
-    expect(result).toEqual({ minStartTime: 7, maxEndTime: 7 })
+    expect(result).toEqual({ minStartTime: 7, maxEndTime: 7, duration: 24 })
   })
   it('handles stats containing both same day and next day critical hours, as well as no critical hours', () => {
     const result = getMinStartAndMaxEndTime([sameDayC2, nextDayM1M2, nextDayS1, noHoursM1M2])
-    expect(result).toEqual({ minStartTime: 10, maxEndTime: 6 })
+    expect(result).toEqual({ minStartTime: 10, maxEndTime: 6, duration: 20 })
   })
 })
 

--- a/web/src/features/fba/criticalHoursStartEndTime.ts
+++ b/web/src/features/fba/criticalHoursStartEndTime.ts
@@ -15,9 +15,11 @@ export const getMinStartAndMaxEndTime = (
 ): {
   minStartTime: number | undefined
   maxEndTime: number | undefined
+  duration: number | undefined
 } => {
   let minStartTime: number | undefined = undefined
   let maxEndTime: number | undefined = undefined
+  let duration: number | undefined = undefined
 
   for (const fuel of fuels) {
     let { start_time, end_time } = fuel.critical_hours
@@ -42,11 +44,16 @@ export const getMinStartAndMaxEndTime = (
       }
     }
   }
+
+  if (!isNil(minStartTime) && !isNil(maxEndTime)) {
+    duration = maxEndTime - minStartTime
+  }
+
   if (!isNil(maxEndTime)) {
     maxEndTime = maxEndTime % 24 // normalize back to 24 hour clock
   }
 
-  return { minStartTime, maxEndTime }
+  return { minStartTime, maxEndTime, duration }
 }
 
 export const criticalHoursExtendToNextDay = (startTime: number, endTime: number): boolean => {

--- a/web/src/features/fba/slices/fireCentreHFIFuelStatsSlice.test.ts
+++ b/web/src/features/fba/slices/fireCentreHFIFuelStatsSlice.test.ts
@@ -1,0 +1,80 @@
+import { FireCentreHFIStats } from '@/api/fbaAPI'
+import fireCentreHFIFuelStatsReducer, { getFireCentreHFIFuelStatsFailed, getFireCentreHFIFuelStatsSuccess, initialState} from '@/features/fba/slices/fireCentreHFIFuelStatsSlice'
+
+const fireCentreHfiStats: FireCentreHFIStats = {
+  'Cariboo Fire Centre': {
+    '20': {
+      fuel_area_stats: [
+        {
+          fuel_type: {
+            fuel_type_id: 2,
+            fuel_type_code: 'C-2',
+            description: 'Boreal Spruce'
+          },
+          threshold: {
+            id: 1,
+            name: 'advisory',
+            description: '4000 < hfi < 10000'
+          },
+          critical_hours: {
+            start_time: 9,
+            end_time: 13
+          },
+          area: 4000000000,
+          fuel_area: 8000000000
+        },
+        {
+          fuel_type: {
+            fuel_type_id: 2,
+            fuel_type_code: 'S-1',
+            description: 'Slash'
+          },
+          threshold: {
+            id: 1,
+            name: 'advisory',
+            description: '4000 < hfi < 10000'
+          },
+          critical_hours: {
+            start_time: 9,
+            end_time: 13
+          },
+          area: 4000000000,
+          fuel_area: 8000000000
+        }
+      ],
+      min_wind_stats: [
+        {
+          threshold: {
+            id: 1,
+            name: 'advisory',
+            description: '4000 < hfi < 10000'
+          },
+          min_wind_speed: 1
+        },
+        {
+          threshold: {
+            id: 2,
+            name: 'warning',
+            description: 'hfi > 1000'
+          },
+          min_wind_speed: 1
+        }
+      ]
+    }
+  }
+}
+
+describe('fireCentreHFIFuelStatsSlice', () => {
+  describe('reducer', () => {
+    it('should have the correct initial state', () => {
+      expect(fireCentreHFIFuelStatsReducer(undefined, { type: '' })).toEqual(initialState)
+    })
+    it('should set a value for error state when getFireCentreHFIFuelStatsFailed is called', () => {
+      expect(fireCentreHFIFuelStatsReducer(initialState, getFireCentreHFIFuelStatsFailed("error")).error).not.toBeNull()
+    })
+    it('should set a value for fireCentreHFIFuelStats when getFireCentreHFIFuelStatsSuccess is called', () => {
+      const result = fireCentreHFIFuelStatsReducer(initialState, getFireCentreHFIFuelStatsSuccess(fireCentreHfiStats))
+      expect(result.fireCentreHFIFuelStats).toEqual(fireCentreHfiStats)
+    })
+  })
+})

--- a/wps_shared/wps_shared/db/crud/auto_spatial_advisory.py
+++ b/wps_shared/wps_shared/db/crud/auto_spatial_advisory.py
@@ -181,7 +181,7 @@ async def get_all_sfms_fuel_type_records(session: AsyncSession) -> List[SFMSFuel
     """
     stmt = select(SFMSFuelType)
     result = await session.execute(stmt)
-    return result.all()
+    return result.scalars().all()
 
 
 async def get_sfms_mixed_fuel_type(session: AsyncSession) -> SFMSFuelType:
@@ -613,7 +613,7 @@ async def get_fuel_types_code_dict(db_session: AsyncSession):
     sfms_fuel_types = await get_all_sfms_fuel_type_records(db_session)
     fuel_types_dict = {}
     for fuel_type in sfms_fuel_types:
-        fuel_types_dict[fuel_type[0].fuel_type_code] = fuel_type[0].id
+        fuel_types_dict[fuel_type.fuel_type_code] = fuel_type.id
     return fuel_types_dict
 
 
@@ -627,5 +627,5 @@ async def get_fuel_types_id_dict(db_session: AsyncSession):
     sfms_fuel_types = await get_all_sfms_fuel_type_records(db_session)
     fuel_types_dict = {}
     for fuel_type in sfms_fuel_types:
-        fuel_types_dict[fuel_type[0].fuel_type_id] = fuel_type[0].id
+        fuel_types_dict[fuel_type.fuel_type_id] = fuel_type.id
     return fuel_types_dict

--- a/wps_shared/wps_shared/db/models/weather_models.py
+++ b/wps_shared/wps_shared/db/models/weather_models.py
@@ -133,7 +133,7 @@ class PredictionModelGridSubset(Base):
         return ("id: {self.id}, prediction_model_id: {self.prediction_model_id}").format(self=self)
 
 
-# Explict creation of index due to issue with alembic + geoalchemy.
+# Explicit creation of index due to issue with alembic + geoalchemy.
 Index("idx_prediction_model_grid_subsets_geom", PredictionModelGridSubset.geom, postgresql_using="gist")
 
 


### PR DESCRIPTION
- filters out low prevalence fuel types from the top fuels (except for slash fuel types and C-5)
- slash fuel types are not used for the critical hours text from June 1 to September 30
- adds message about slash fuel types when critical hours for top fuels exceeds 12 hours

Closes #4507 