### PR TITLE
ECMWF Precip Bug

### DIFF
--- a/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/ecmwf_prediction_processor.py
@@ -4,12 +4,20 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 
 from wps_shared.db.crud.model_run_repository import ModelRunRepository
-from wps_shared.db.models.weather_models import ModelRunPrediction, PredictionModelRunTimestamp, WeatherStationModelPrediction
+from wps_shared.db.models.weather_models import (
+    ModelRunPrediction,
+    PredictionModelRunTimestamp,
+    WeatherStationModelPrediction,
+)
 from wps_shared.schemas.stations import WeatherStation
 
 from wps_jobs.weather_model_jobs import ModelEnum
 from wps_jobs.weather_model_jobs.machine_learning import StationMachineLearning
-from wps_jobs.weather_model_jobs.utils.interpolate import SCALAR_MODEL_VALUE_KEYS_FOR_INTERPOLATION, construct_interpolated_noon_prediction, interpolate_between_two_points
+from wps_jobs.weather_model_jobs.utils.interpolate import (
+    SCALAR_MODEL_VALUE_KEYS_FOR_INTERPOLATION,
+    construct_interpolated_noon_prediction,
+    interpolate_between_two_points,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +29,12 @@ class ECMWFPredictionProcessor:
         self.station_predictions: Dict[int, List[ModelRunPrediction]] = defaultdict(list)
 
     def process(self):
-        for model_run, model in self.model_run_repository.get_prediction_model_run_timestamp_records(complete=True, interpolated=False, model_type=ModelEnum.ECMWF):
+        for (
+            model_run,
+            model,
+        ) in self.model_run_repository.get_prediction_model_run_timestamp_records(
+            complete=True, interpolated=False, model_type=ModelEnum.ECMWF
+        ):
             logger.info("model %s", model)
             logger.info("model_run %s", model_run)
             # Process the model run.
@@ -34,11 +47,20 @@ class ECMWFPredictionProcessor:
         logger.info("Interpolating values for model run: %s", model_run)
         # Iterate through stations.
         for index, station in enumerate(self.stations):
-            logger.info("Interpolating model run %s (%s/%s) for %s:%s", model_run.id, index, len(self.stations), station.code, station.name)
+            logger.info(
+                "Interpolating model run %s (%s/%s) for %s:%s",
+                model_run.id,
+                index,
+                len(self.stations),
+                station.code,
+                station.name,
+            )
             # Process this model run for station.
             self._process_model_run_for_station(model_run, station)
 
-    def _process_model_run_for_station(self, model_run: PredictionModelRunTimestamp, station: WeatherStation):
+    def _process_model_run_for_station(
+        self, model_run: PredictionModelRunTimestamp, station: WeatherStation
+    ):
         """Process the model run for the provided station."""
         # Extract the coordinate.
         coordinate = [station.long, station.lat]
@@ -52,18 +74,30 @@ class ECMWFPredictionProcessor:
         machine.learn()
 
         # Get all the predictions associated to this particular model run.
-        model_run_predictions: List[ModelRunPrediction] = self.model_run_repository.get_model_run_predictions_for_station(station.code, model_run)
+        model_run_predictions: List[ModelRunPrediction] = (
+            self.model_run_repository.get_model_run_predictions_for_station(station.code, model_run)
+        )
 
         # Iterate through all the predictions.
         prev_prediction: ModelRunPrediction | None = None
 
         for prediction in model_run_predictions:
-            if prev_prediction is not None and self._should_interpolate(prev_prediction, prediction):
+            if prev_prediction is not None and self._should_interpolate(
+                prev_prediction, prediction
+            ):
                 # create and store interpolated 20z prediction
-                noon_prediction = construct_interpolated_noon_prediction(prev_prediction, prediction, SCALAR_MODEL_VALUE_KEYS_FOR_INTERPOLATION)
-                noon_station_prediction = self.initialize_station_prediction(prev_prediction, noon_prediction)
-                noon_station_prediction = self._apply_interpolated_bias_adjustments(noon_station_prediction, prev_prediction, prediction, machine)
-                self.model_run_repository.store_weather_station_model_prediction(noon_station_prediction)
+                noon_prediction = construct_interpolated_noon_prediction(
+                    prev_prediction, prediction, SCALAR_MODEL_VALUE_KEYS_FOR_INTERPOLATION
+                )
+                noon_station_prediction = self.initialize_station_prediction(
+                    prev_prediction, noon_prediction
+                )
+                noon_station_prediction = self._apply_interpolated_bias_adjustments(
+                    noon_station_prediction, prev_prediction, prediction, machine
+                )
+                self.model_run_repository.store_weather_station_model_prediction(
+                    noon_station_prediction
+                )
 
             # always process the current prediction
             station_prediction = self.initialize_station_prediction(prev_prediction, prediction)
@@ -72,13 +106,19 @@ class ECMWFPredictionProcessor:
 
             prev_prediction = prediction
 
-    def _should_interpolate(self, prev_prediction: ModelRunPrediction, prediction: ModelRunPrediction) -> bool:
+    def _should_interpolate(
+        self, prev_prediction: ModelRunPrediction, prediction: ModelRunPrediction
+    ) -> bool:
         """Check if we should interpolate between the two predictions."""
         prev_timestamp: datetime = prev_prediction.prediction_timestamp
         next_timestamp: datetime = prediction.prediction_timestamp
-        assert next_timestamp > prev_timestamp, "Next timestamp must be greater than previous timestamp"
+        assert next_timestamp > prev_timestamp, (
+            "Next timestamp must be greater than previous timestamp"
+        )
         # Assert the hour difference is 24 or less
-        assert (next_timestamp - prev_timestamp).total_seconds() <= 24 * 3600, "Timestamps must be no more than 24 hours apart"
+        assert (next_timestamp - prev_timestamp).total_seconds() <= 24 * 3600, (
+            "Timestamps must be no more than 24 hours apart"
+        )
         # Check if datetimes are on the same day
         if prev_timestamp.date() == next_timestamp.date():
             # Timestamps on the same day but surround 20:00 UTC should be interpolated
@@ -87,30 +127,44 @@ class ECMWFPredictionProcessor:
         # datetimes are on different days, interpolate if previous is before 20:00 UTC
         return prev_timestamp.hour < 20
 
-    def _weather_station_prediction_initializer(self, prediction: ModelRunPrediction) -> WeatherStationModelPrediction:
+    def _weather_station_prediction_initializer(
+        self, prediction: ModelRunPrediction
+    ) -> WeatherStationModelPrediction:
         """Initialize a WeatherStationModelPrediction object."""
 
         station_prediction = self.model_run_repository.get_weather_station_model_prediction(
-            prediction.station_code, prediction.prediction_model_run_timestamp_id, prediction.prediction_timestamp
+            prediction.station_code,
+            prediction.prediction_model_run_timestamp_id,
+            prediction.prediction_timestamp,
         )
 
         if station_prediction is None:
             station_prediction = WeatherStationModelPrediction()
             station_prediction.station_code = prediction.station_code
-            station_prediction.prediction_model_run_timestamp_id = prediction.prediction_model_run_timestamp_id
+            station_prediction.prediction_model_run_timestamp_id = (
+                prediction.prediction_model_run_timestamp_id
+            )
             station_prediction.prediction_timestamp = prediction.prediction_timestamp
 
         return station_prediction
 
     def _apply_interpolated_bias_adjustments(
-        self, station_prediction: WeatherStationModelPrediction, prev_prediction: ModelRunPrediction, prediction: ModelRunPrediction, machine: StationMachineLearning
+        self,
+        station_prediction: WeatherStationModelPrediction,
+        prev_prediction: ModelRunPrediction,
+        prediction: ModelRunPrediction,
+        machine: StationMachineLearning,
     ):
         prev_prediction_datetime: datetime = prev_prediction.prediction_timestamp
         prediction_datetime: datetime = prediction.prediction_timestamp
         datetime_at_2000 = prev_prediction_datetime.replace(hour=20)
 
-        temp_before_2000 = machine.predict_temperature(station_prediction.tmp_tgl_2, prev_prediction_datetime)
-        temp_after_2000 = machine.predict_temperature(station_prediction.tmp_tgl_2, prediction_datetime)
+        temp_before_2000 = machine.predict_temperature(
+            station_prediction.tmp_tgl_2, prev_prediction_datetime
+        )
+        temp_after_2000 = machine.predict_temperature(
+            station_prediction.tmp_tgl_2, prediction_datetime
+        )
         station_prediction.bias_adjusted_temperature = self.interpolate_20_00_values(
             prev_prediction_datetime,
             prediction_datetime,
@@ -129,8 +183,12 @@ class ECMWFPredictionProcessor:
             datetime_at_2000,
         )
 
-        wind_speed_before_2000 = machine.predict_wind_speed(station_prediction.wind_tgl_10, prev_prediction_datetime)
-        wind_speed_after_2000 = machine.predict_wind_speed(station_prediction.wind_tgl_10, prediction_datetime)
+        wind_speed_before_2000 = machine.predict_wind_speed(
+            station_prediction.wind_tgl_10, prev_prediction_datetime
+        )
+        wind_speed_after_2000 = machine.predict_wind_speed(
+            station_prediction.wind_tgl_10, prediction_datetime
+        )
         station_prediction.bias_adjusted_wind_speed = self.interpolate_20_00_values(
             prev_prediction_datetime,
             prediction_datetime,
@@ -139,15 +197,19 @@ class ECMWFPredictionProcessor:
             datetime_at_2000,
         )
 
-        wind_direction_before_2000 = station_prediction.bias_adjusted_wdir = machine.predict_wind_direction(
-            station_prediction.wind_tgl_10,
-            station_prediction.wdir_tgl_10,
-            prev_prediction_datetime,
+        wind_direction_before_2000 = station_prediction.bias_adjusted_wdir = (
+            machine.predict_wind_direction(
+                station_prediction.wind_tgl_10,
+                station_prediction.wdir_tgl_10,
+                prev_prediction_datetime,
+            )
         )
-        wind_direction_after_2000 = station_prediction.bias_adjusted_wdir = machine.predict_wind_direction(
-            station_prediction.wind_tgl_10,
-            station_prediction.wdir_tgl_10,
-            prediction_datetime,
+        wind_direction_after_2000 = station_prediction.bias_adjusted_wdir = (
+            machine.predict_wind_direction(
+                station_prediction.wind_tgl_10,
+                station_prediction.wdir_tgl_10,
+                prediction_datetime,
+            )
         )
         station_prediction.bias_adjusted_wdir = self.interpolate_20_00_values(
             prev_prediction_datetime,
@@ -158,37 +220,62 @@ class ECMWFPredictionProcessor:
         )
 
         # Predict the 24h precipitation. No interpolation necessary due to the underlying model training.
-        station_prediction.bias_adjusted_precip_24h = machine.predict_precipitation(station_prediction.precip_24h, station_prediction.prediction_timestamp)
+        station_prediction.bias_adjusted_precip_24h = machine.predict_precipitation(
+            station_prediction.precip_24h, station_prediction.prediction_timestamp
+        )
         return station_prediction
 
-    def _apply_bias_adjustments(self, station_prediction: WeatherStationModelPrediction, machine: StationMachineLearning):
+    def _apply_bias_adjustments(
+        self, station_prediction: WeatherStationModelPrediction, machine: StationMachineLearning
+    ):
         """Create a WeatherStationModelPrediction from the ModelRunPrediction data."""
-        station_prediction.bias_adjusted_temperature = machine.predict_temperature(station_prediction.tmp_tgl_2, station_prediction.prediction_timestamp)
-        station_prediction.bias_adjusted_rh = machine.predict_rh(station_prediction.rh_tgl_2, station_prediction.prediction_timestamp)
-        station_prediction.bias_adjusted_wind_speed = machine.predict_wind_speed(station_prediction.wind_tgl_10, station_prediction.prediction_timestamp)
+        station_prediction.bias_adjusted_temperature = machine.predict_temperature(
+            station_prediction.tmp_tgl_2, station_prediction.prediction_timestamp
+        )
+        station_prediction.bias_adjusted_rh = machine.predict_rh(
+            station_prediction.rh_tgl_2, station_prediction.prediction_timestamp
+        )
+        station_prediction.bias_adjusted_wind_speed = machine.predict_wind_speed(
+            station_prediction.wind_tgl_10, station_prediction.prediction_timestamp
+        )
         station_prediction.bias_adjusted_wdir = machine.predict_wind_direction(
             station_prediction.wind_tgl_10,
             station_prediction.wdir_tgl_10,
             station_prediction.prediction_timestamp,
         )
-        station_prediction.bias_adjusted_precip_24h = machine.predict_precipitation(station_prediction.precip_24h, station_prediction.prediction_timestamp)
+        station_prediction.bias_adjusted_precip_24h = machine.predict_precipitation(
+            station_prediction.precip_24h, station_prediction.prediction_timestamp
+        )
         return station_prediction
 
-    def initialize_station_prediction(self, prev_prediction: ModelRunPrediction, prediction: ModelRunPrediction) -> WeatherStationModelPrediction:
+    def initialize_station_prediction(
+        self, prev_prediction: ModelRunPrediction, prediction: ModelRunPrediction
+    ) -> WeatherStationModelPrediction:
         """Initialize a WeatherStationModelPrediction object with the provided prediction data."""
         station_prediction = self._weather_station_prediction_initializer(prediction)
         station_prediction.tmp_tgl_2 = prediction.get_temp()
         station_prediction.rh_tgl_2 = prediction.get_rh()
         station_prediction.apcp_sfc_0 = prediction.get_precip()
 
-        station_prediction.precip_24h = self._calculate_past_24_hour_precip(prediction, station_prediction)
-        station_prediction.delta_precip = self._calculate_delta_precip(prev_prediction, station_prediction)
+        station_prediction.precip_24h = self._calculate_past_24_hour_precip(
+            prediction, station_prediction
+        )
+        station_prediction.delta_precip = self._calculate_delta_precip(
+            prev_prediction, station_prediction
+        )
 
         station_prediction.wind_tgl_10 = prediction.get_wind_speed()
         station_prediction.wdir_tgl_10 = prediction.get_wind_direction()
         return station_prediction
 
-    def interpolate_20_00_values(self, prev_datetime: datetime, next_datetime: datetime, prev_value: float, next_value: float, target_datetime: datetime) -> float | None:
+    def interpolate_20_00_values(
+        self,
+        prev_datetime: datetime,
+        next_datetime: datetime,
+        prev_value: float,
+        next_value: float,
+        target_datetime: datetime,
+    ) -> float | None:
         """Interpolate the value at 2000 UTC using the previous and next values."""
         assert target_datetime.hour == 20, "Target datetime must be at 20:00 UTC"
         assert prev_datetime < target_datetime, "Previous datetime must be before target datetime"
@@ -202,30 +289,47 @@ class ECMWFPredictionProcessor:
             int(target_datetime.timestamp()),
         )
 
-    def _calculate_past_24_hour_precip(self, prediction: ModelRunPrediction, station_prediction: WeatherStationModelPrediction):
+    def _calculate_past_24_hour_precip(
+        self, prediction: ModelRunPrediction, station_prediction: WeatherStationModelPrediction
+    ):
         """Calculate the predicted precipitation over the previous 24 hours within the specified model run.
         If the model run does not contain a prediction timestamp for 24 hours prior to the current prediction,
         return the predicted precipitation from the previous run of the same model for the same time frame."""
         start_prediction_timestamp: datetime = prediction.prediction_timestamp - timedelta(days=1)
         # Check if a prediction exists for this model run 24 hours in the past
-        previous_prediction_from_same_model_run = self.model_run_repository.get_weather_station_model_prediction(
-            prediction.station_code, prediction.prediction_model_run_timestamp_id, start_prediction_timestamp
+        previous_prediction_from_same_model_run = (
+            self.model_run_repository.get_weather_station_model_prediction(
+                prediction.station_code,
+                prediction.prediction_model_run_timestamp_id,
+                start_prediction_timestamp,
+            )
         )
         # If a prediction from 24 hours ago from the same model run exists, return the difference in cumulative precipitation
         # between now and then as our total for the past 24 hours. We can end up with very very small negative numbers due
         # to floating point math, so return absolute value to avoid displaying -0.0.
         if previous_prediction_from_same_model_run is not None:
-            return abs(station_prediction.apcp_sfc_0 - previous_prediction_from_same_model_run.apcp_sfc_0)
+            return abs(
+                station_prediction.apcp_sfc_0 - previous_prediction_from_same_model_run.apcp_sfc_0
+            )
 
         # We're within 24 hours of the start of a model run so we don't have cumulative precipitation for a full 24h.
         # We use actual precipitation from our hourly_actuals table to make up the missing hours.
         prediction_timestamp: datetime = station_prediction.prediction_timestamp
         # Create new datetime with time of 00:00 hours as the end time.
-        end_prediction_timestamp = datetime(year=prediction_timestamp.year, month=prediction_timestamp.month, day=prediction_timestamp.day, tzinfo=timezone.utc)
-        actual_precip = self.model_run_repository.get_accumulated_precipitation(prediction.station_code, start_prediction_timestamp, end_prediction_timestamp)
+        end_prediction_timestamp = datetime(
+            year=prediction_timestamp.year,
+            month=prediction_timestamp.month,
+            day=prediction_timestamp.day,
+            tzinfo=timezone.utc,
+        )
+        actual_precip = self.model_run_repository.get_accumulated_precipitation(
+            prediction.station_code, start_prediction_timestamp, end_prediction_timestamp
+        )
         return actual_precip + station_prediction.apcp_sfc_0
 
-    def _calculate_delta_precip(self, prev_prediction: ModelRunPrediction, station_prediction: WeatherStationModelPrediction):
+    def _calculate_delta_precip(
+        self, prev_prediction: ModelRunPrediction, station_prediction: WeatherStationModelPrediction
+    ):
         """Calculate the station_prediction's delta_precip based on the previous precip
         prediction for the station
         """

--- a/wps_shared/wps_shared/db/crud/model_run_repository.py
+++ b/wps_shared/wps_shared/db/crud/model_run_repository.py
@@ -5,7 +5,13 @@ from sqlalchemy.orm import Session
 from sqlalchemy import select
 from sqlalchemy.sql import func
 from wps_shared.db.models.observations import HourlyActual
-from wps_shared.db.models.weather_models import ModelRunPrediction, PredictionModel, PredictionModelRunTimestamp, ProcessedModelRunUrl, WeatherStationModelPrediction
+from wps_shared.db.models.weather_models import (
+    ModelRunPrediction,
+    PredictionModel,
+    PredictionModelRunTimestamp,
+    ProcessedModelRunUrl,
+    WeatherStationModelPrediction,
+)
 from wps_shared.utils.time import get_utc_now
 from wps_shared.weather_models import ModelEnum, ProjectionEnum
 
@@ -17,23 +23,36 @@ class ModelRunRepository:
         """Initialize the repository with a database session."""
         self.session = session
 
-    def get_prediction_run(self, prediction_model_id: int, prediction_run_timestamp: datetime) -> PredictionModelRunTimestamp:
+    def get_prediction_run(
+        self, prediction_model_id: int, prediction_run_timestamp: datetime
+    ) -> PredictionModelRunTimestamp:
         """load the model run from the database (.e.g. for 2020 07 07 12h00)."""
         logger.info("get prediction run for %s", prediction_run_timestamp)
         return (
             self.session.query(PredictionModelRunTimestamp)
             .filter(PredictionModelRunTimestamp.prediction_model_id == prediction_model_id)
-            .filter(PredictionModelRunTimestamp.prediction_run_timestamp == prediction_run_timestamp)
+            .filter(
+                PredictionModelRunTimestamp.prediction_run_timestamp == prediction_run_timestamp
+            )
             .first()
         )
 
-    def get_prediction_model(self, model_enum: ModelEnum, projection: ProjectionEnum) -> PredictionModel:
+    def get_prediction_model(
+        self, model_enum: ModelEnum, projection: ProjectionEnum
+    ) -> PredictionModel:
         """Get the prediction model corresponding to a particular abbreviation and projection."""
-        return self.session.query(PredictionModel).filter(PredictionModel.abbreviation == model_enum.value).filter(PredictionModel.projection == projection.value).first()
+        return (
+            self.session.query(PredictionModel)
+            .filter(PredictionModel.abbreviation == model_enum.value)
+            .filter(PredictionModel.projection == projection.value)
+            .first()
+        )
 
     def get_processed_url(self, url: str) -> ProcessedModelRunUrl:
         """Get record corresponding to a processed file."""
-        processed_url = self.session.query(ProcessedModelRunUrl).filter(ProcessedModelRunUrl.url == url).first()
+        processed_url = (
+            self.session.query(ProcessedModelRunUrl).filter(ProcessedModelRunUrl.url == url).first()
+        )
         return processed_url
 
     def mark_url_as_processed(self, url: str):
@@ -50,7 +69,11 @@ class ModelRunRepository:
 
     def get_processed_url_count(self, urls: List[str]) -> int:
         """Return the number of matching urls"""
-        return self.session.query(ProcessedModelRunUrl).filter(ProcessedModelRunUrl.url.in_(urls)).count()
+        return (
+            self.session.query(ProcessedModelRunUrl)
+            .filter(ProcessedModelRunUrl.url.in_(urls))
+            .count()
+        )
 
     def check_if_model_run_complete(self, urls: List[str]) -> bool:
         """Check if a particular model run is complete"""
@@ -59,25 +82,44 @@ class ModelRunRepository:
         logger.info("we have processed %s/%s files", actual_count, expected_count)
         return actual_count == expected_count and actual_count > 0
 
-    def create_prediction_run(self, prediction_model_id: int, prediction_run_timestamp: datetime) -> PredictionModelRunTimestamp:
+    def create_prediction_run(
+        self, prediction_model_id: int, prediction_run_timestamp: datetime
+    ) -> PredictionModelRunTimestamp:
         """Create a model prediction run for a particular model."""
-        prediction_run = PredictionModelRunTimestamp(prediction_model_id=prediction_model_id, prediction_run_timestamp=prediction_run_timestamp, complete=False, interpolated=False)
+        prediction_run = PredictionModelRunTimestamp(
+            prediction_model_id=prediction_model_id,
+            prediction_run_timestamp=prediction_run_timestamp,
+            complete=False,
+            interpolated=False,
+        )
         self.session.add(prediction_run)
         self.session.commit()
         return prediction_run
 
-    def get_or_create_prediction_run(self, prediction_model: PredictionModel, prediction_run_timestamp: datetime) -> PredictionModelRunTimestamp:
+    def get_or_create_prediction_run(
+        self, prediction_model: PredictionModel, prediction_run_timestamp: datetime
+    ) -> PredictionModelRunTimestamp:
         """Get a model prediction run for a particular model, creating one if it doesn't already exist."""
         prediction_run = self.get_prediction_run(prediction_model.id, prediction_run_timestamp)
         if not prediction_run:
-            logger.info("Creating prediction run %s for %s", prediction_model.abbreviation, prediction_run_timestamp)
-            prediction_run = self.create_prediction_run(prediction_model.id, prediction_run_timestamp)
+            logger.info(
+                "Creating prediction run %s for %s",
+                prediction_model.abbreviation,
+                prediction_run_timestamp,
+            )
+            prediction_run = self.create_prediction_run(
+                prediction_model.id, prediction_run_timestamp
+            )
         return prediction_run
 
-    def mark_prediction_model_run_processed(self, model: ModelEnum, projection: ProjectionEnum, model_run_datetime: datetime):
+    def mark_prediction_model_run_processed(
+        self, model: ModelEnum, projection: ProjectionEnum, model_run_datetime: datetime
+    ):
         """Mark a prediction model run as processed (complete)"""
         prediction_model = self.get_prediction_model(model, projection)
-        logger.info("prediction_model:%s, prediction_run_timestamp:%s", prediction_model, model_run_datetime)
+        logger.info(
+            "prediction_model:%s, prediction_run_timestamp:%s", prediction_model, model_run_datetime
+        )
         prediction_run = self.get_prediction_run(prediction_model.id, model_run_datetime)
         logger.info("prediction run: %s", prediction_run)
         prediction_run.complete = True
@@ -89,7 +131,12 @@ class ModelRunRepository:
         self.session.add(prediction)
         self.session.commit()
 
-    def get_model_run_prediction(self, prediction_run: PredictionModelRunTimestamp, prediction_timestamp: datetime, station_code: int) -> ModelRunPrediction:
+    def get_model_run_prediction(
+        self,
+        prediction_run: PredictionModelRunTimestamp,
+        prediction_timestamp: datetime,
+        station_code: int,
+    ) -> ModelRunPrediction:
         prediction = (
             self.session.query(ModelRunPrediction)
             .filter(ModelRunPrediction.prediction_model_run_timestamp_id == prediction_run.id)
@@ -105,7 +152,10 @@ class ModelRunRepository:
         """Get prediction model run timestamps (filter on complete and interpolated if provided.)"""
         query = (
             self.session.query(PredictionModelRunTimestamp, PredictionModel)
-            .join(PredictionModelRunTimestamp, PredictionModelRunTimestamp.prediction_model_id == PredictionModel.id)
+            .join(
+                PredictionModelRunTimestamp,
+                PredictionModelRunTimestamp.prediction_model_id == PredictionModel.id,
+            )
             .filter(PredictionModel.abbreviation == model_type.value)
             .filter(PredictionModelRunTimestamp.interpolated == interpolated)
             .filter(PredictionModelRunTimestamp.complete == complete)
@@ -113,27 +163,41 @@ class ModelRunRepository:
         )
         return query.all()
 
-    def get_weather_station_model_prediction(self, station_code: int, prediction_model_run_timestamp_id: int, prediction_timestamp: datetime) -> WeatherStationModelPrediction:
+    def get_weather_station_model_prediction(
+        self,
+        station_code: int,
+        prediction_model_run_timestamp_id: int,
+        prediction_timestamp: datetime,
+    ) -> WeatherStationModelPrediction:
         """Get the model prediction for a weather station given a model run and a timestamp."""
         return (
             self.session.query(WeatherStationModelPrediction)
             .filter(WeatherStationModelPrediction.station_code == station_code)
-            .filter(WeatherStationModelPrediction.prediction_model_run_timestamp_id == prediction_model_run_timestamp_id)
+            .filter(
+                WeatherStationModelPrediction.prediction_model_run_timestamp_id
+                == prediction_model_run_timestamp_id
+            )
             .filter(WeatherStationModelPrediction.prediction_timestamp == prediction_timestamp)
             .first()
         )
 
-    def get_accumulated_precipitation(self, station_code: int, start_datetime: datetime, end_datetime: datetime):
+    def get_accumulated_precipitation(
+        self, station_code: int, start_datetime: datetime, end_datetime: datetime
+    ):
         """Get the accumulated precipitation for a station by datetime range."""
         stmt = select(func.sum(HourlyActual.precipitation)).where(
-            HourlyActual.station_code == station_code, HourlyActual.weather_date > start_datetime, HourlyActual.weather_date <= end_datetime
+            HourlyActual.station_code == station_code,
+            HourlyActual.weather_date > start_datetime,
+            HourlyActual.weather_date <= end_datetime,
         )
         result = self.session.scalars(stmt).first()
         if result is None:
             return 0
         return result
 
-    def get_model_run_predictions_for_station(self, station_code: int, prediction_run: PredictionModelRunTimestamp) -> List[ModelRunPrediction]:
+    def get_model_run_predictions_for_station(
+        self, station_code: int, prediction_run: PredictionModelRunTimestamp
+    ) -> List[ModelRunPrediction]:
         """Get all the predictions for a provided model run"""
         logger.info("Getting model predictions for grid %s", prediction_run)
         return (
@@ -148,6 +212,8 @@ class ModelRunRepository:
         """Store the model run prediction in the database."""
         prediction.update_date = get_utc_now()
         self.session.add(prediction)
+        # we need to flush so that added prediction are available for later queries, especially 24 hour precip
+        self.session.flush()
 
     def mark_model_run_interpolated(self, model_run: PredictionModelRunTimestamp):
         """Having completely processed a model run, we can mark it has having been interpolated."""

--- a/wps_shared/wps_shared/tests/db/test_model_run_repository.py
+++ b/wps_shared/wps_shared/tests/db/test_model_run_repository.py
@@ -47,8 +47,8 @@ def db_session(postgres_container):
     ProcessedModelRunUrl.__table__.create(engine, checkfirst=True)
     ModelRunPrediction.__table__.create(engine, checkfirst=True)
     WeatherStationModelPrediction.__table__.create(engine, checkfirst=True)
-    Session = sessionmaker(bind=engine, autoflush=False)
-    session = Session()
+    session_ = sessionmaker(bind=engine, autoflush=False)
+    session = session_()
 
     # Make sure model exists
     stmt = insert(PredictionModel).values(

--- a/wps_shared/wps_shared/tests/db/test_model_run_repository.py
+++ b/wps_shared/wps_shared/tests/db/test_model_run_repository.py
@@ -106,7 +106,7 @@ def test_get_prediction_model(repository: ModelRunRepository, db_session: Sessio
 
 
 def test_get_processed_file_record(repository: ModelRunRepository, db_session: Session):
-    url = "http://example.com/file"
+    url = "https://example.com/file"
 
     # Insert a mock record
     mock_processed_file = ProcessedModelRunUrl(
@@ -365,7 +365,7 @@ def test_get_prediction_model(repository: ModelRunRepository, db_session: Sessio
 
 
 def test_mark_url_as_processed_new_url(repository: ModelRunRepository, db_session: Session):
-    url = "http://example.com/new_file"
+    url = "https://example.com/new_file"
 
     # Ensure the URL does not exist initially
     existing_url = repository.get_processed_url(url)
@@ -389,17 +389,17 @@ def test_mark_url_as_processed_new_url(repository: ModelRunRepository, db_sessio
         (
             [
                 ProcessedModelRunUrl(
-                    url="http://example.com/file1",
+                    url="https://example.com/file1",
                     create_date=TEST_DATETIME,
                     update_date=TEST_DATETIME,
                 ),
                 ProcessedModelRunUrl(
-                    url="http://example.com/file2",
+                    url="https://example.com/file2",
                     create_date=TEST_DATETIME,
                     update_date=TEST_DATETIME,
                 ),
                 ProcessedModelRunUrl(
-                    url="http://example.com/file3",
+                    url="https://example.com/file3",
                     create_date=TEST_DATETIME,
                     update_date=TEST_DATETIME,
                 ),
@@ -411,19 +411,19 @@ def test_mark_url_as_processed_new_url(repository: ModelRunRepository, db_sessio
         (
             [
                 ProcessedModelRunUrl(
-                    url="http://example.com/file1",
+                    url="https://example.com/file1",
                     create_date=TEST_DATETIME,
                     update_date=TEST_DATETIME,
                 ),
                 ProcessedModelRunUrl(
-                    url="http://example.com/file2",
+                    url="https://example.com/file2",
                     create_date=TEST_DATETIME,
                     update_date=TEST_DATETIME,
                 ),
             ],
             [
                 ProcessedModelRunUrl(
-                    url="http://example.com/file3",
+                    url="https://example.com/file3",
                     create_date=TEST_DATETIME,
                     update_date=TEST_DATETIME,
                 )


### PR DESCRIPTION
- Flushes after storage of `weather_model_run_prediction` since we need to retrieve the last stored record for precip calcs

# Test Links:
[Landing Page](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4577-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
