### PR TITLE
Fix fuel raster job

### DIFF
--- a/openshift/templates/fuel_raster_processor_job.yaml
+++ b/openshift/templates/fuel_raster_processor_job.yaml
@@ -22,6 +22,9 @@ parameters:
     value: e1e498-tools
   - name: CRUNCHYDB_USER
     required: true
+  - name: IMAGE_REGISTRY
+    required: true
+    value: image-registry.openshift-image-registry.svc:5000
 objects:
   - kind: Job
     apiVersion: batch/v1

--- a/openshift/templates/fuel_raster_processor_job.yaml
+++ b/openshift/templates/fuel_raster_processor_job.yaml
@@ -70,22 +70,22 @@ objects:
                     configMapKeyRef:
                       name: ${GLOBAL_NAME}
                       key: env.fuel_raster_name
-                - name: PG_USER
+                - name: POSTGRES_WRITE_USER
                   valueFrom:
                     secretKeyRef:
                       name: ${CRUNCHYDB_USER}
                       key: user
-                - name: PG_PASSWORD
+                - name: POSTGRES_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: ${CRUNCHYDB_USER}
                       key: password
-                - name: PG_HOSTNAME
+                - name: POSTGRES_WRITE_HOST
                   valueFrom:
                     secretKeyRef:
                       name: ${CRUNCHYDB_USER}
                       key: pgbouncer-host
-                - name: PG_PORT
+                - name: POSTGRES_PORT
                   valueFrom:
                     secretKeyRef:
                       name: ${CRUNCHYDB_USER}

--- a/openshift/templates/fuel_raster_processor_job.yaml
+++ b/openshift/templates/fuel_raster_processor_job.yaml
@@ -70,11 +70,6 @@ objects:
                     configMapKeyRef:
                       name: ${GLOBAL_NAME}
                       key: env.fuel_raster_name
-                - name: FUEL_RASTER_CONTENT_HASH
-                  valueFrom:
-                    configMapKeyRef:
-                      name: ${GLOBAL_NAME}
-                      key: env.fuel_raster_content_hash
                 - name: PG_USER
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Adds missing `IMAGE_REGISTRY` parameter to the job template.
# Test Links:
[Landing Page](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4581-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
