### PR TITLE
Split out read/write session for ModelValueProcessor

### DIFF
--- a/wps_jobs/wps_jobs/weather_model_jobs/noaa.py
+++ b/wps_jobs/wps_jobs/weather_model_jobs/noaa.py
@@ -9,6 +9,7 @@ import logging
 import tempfile
 from sqlalchemy.orm import Session
 from urllib.parse import parse_qs, urlsplit
+from wps_shared.db.database import get_read_session_scope, get_write_session_scope
 from wps_shared.db.crud.weather_models import (
     get_processed_file_record,
     get_prediction_model,
@@ -365,12 +366,12 @@ def process_models():
     # grab the start time.
     start_time = datetime.datetime.now()
 
-    with wps_shared.db.database.get_write_session_scope() as session:
-        noaa = NOAA(session, model_type)
+    with get_write_session_scope() as write_session, get_read_session_scope() as read_session:
+        noaa = NOAA(write_session, model_type)
         noaa.process()
 
         # interpolate and machine learn everything that needs interpolating.
-        model_value_processor = ModelValueProcessor(session)
+        model_value_processor = ModelValueProcessor(write_session, read_session)
         model_value_processor.process(model_type)
 
     # calculate the execution time.


### PR DESCRIPTION
- Uses a read only session for functions which return a scalar
- Uses a read only session for `StationMachineLearning` 
# Test Links:
[Landing Page](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4596-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
