### PR TITLE
Repopulate fuel type raster id

### DIFF
--- a/api/alembic/versions/9298059a1912_populate_missing_fuel_type_raster_ids.py
+++ b/api/alembic/versions/9298059a1912_populate_missing_fuel_type_raster_ids.py
@@ -1,0 +1,191 @@
+"""Populate missing fuel type raster ids
+
+Revision ID: 9298059a1912
+Revises: 305e64ecce19
+Create Date: 2025-07-03 11:20:23.050042
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm.session import Session
+
+
+# revision identifiers, used by Alembic.
+revision = '9298059a1912'
+down_revision = '305e64ecce19'
+branch_labels = None
+depends_on = None
+
+
+FUEL_GRID_2021 = 2021
+FUEL_GRID_2024 = 2024
+FUEL_GRID_2021_YEARS = [2022, 2023]
+FUEL_GRID_2024_YEARS = [2024, 2025]
+
+fuel_type_raster_table = sa.Table(
+    "fuel_type_raster",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer),
+    sa.Column("version", sa.Integer),
+    sa.Column("year", sa.Integer),
+)
+
+run_parameters_table = sa.Table(
+    "run_parameters", sa.MetaData(), sa.Column("id", sa.Integer), sa.Column("for_date", sa.Date)
+)
+
+advisory_fuel_stats_table = sa.Table(
+    "advisory_fuel_stats",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer),
+    sa.Column("run_parameters", sa.Integer),
+    sa.Column("fuel_type_raster_id", sa.Integer),
+)
+
+advisory_fuel_types_table = sa.Table(
+    "advisory_fuel_types",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer),
+    sa.Column("fuel_type_id", sa.Integer),
+    sa.Column("fuel_type_raster_id", sa.Integer),
+)
+
+advisory_hfi_percent_conifer_table = sa.Table(
+    "advisory_hfi_percent_conifer",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer),
+    sa.Column("run_parameters", sa.Integer),
+    sa.Column("fuel_type_raster_id", sa.Integer),
+)
+
+advisory_shape_fuels_table = sa.Table(
+    "advisory_shape_fuels",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer),
+    sa.Column("fuel_type_raster_id", sa.Integer),
+)
+
+critical_hours_table = sa.Table(
+    "critical_hours",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer),
+    sa.Column("run_parameters", sa.Integer),
+    sa.Column("fuel_type_raster_id", sa.Integer),
+)
+
+tpi_fuel_area_table = sa.Table(
+    "tpi_fuel_area",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer),
+    sa.Column("fuel_type_raster_id", sa.Integer),
+)
+
+
+def get_fuel_type_raster(session: Session, year: int):
+    stmt = (
+        fuel_type_raster_table.select()
+        .where(fuel_type_raster_table.c.year == year)
+        .order_by(fuel_type_raster_table.c.version.desc())
+    )
+    result = session.execute(stmt)
+    return result.first()
+
+
+def get_run_parameter_ids(session: Session, years: list[int]) -> list[int]:
+    stmt = (
+        run_parameters_table.select()
+        .where(sa.func.date_part("year", run_parameters_table.c.for_date).in_(years))
+        .order_by(run_parameters_table.c.id)
+    )
+    rows = session.execute(stmt).fetchall()
+    ids = [row.id for row in rows]
+    return ids
+
+
+def update_fk_for_advisory_fuel_stats_table(
+    session: Session, fuel_type_raster_id: int, run_parameter_ids: list[int]
+) -> None:
+    stmt = (
+        advisory_fuel_stats_table.update()
+        .where(advisory_fuel_stats_table.c.run_parameters.in_(run_parameter_ids))
+        .values(fuel_type_raster_id=fuel_type_raster_id)
+    )
+    session.execute(stmt)
+
+
+def update_fk_for_advisory_fuel_types_table(session: Session, fuel_type_raster_id: int) -> None:
+    stmt = advisory_fuel_types_table.update().values(fuel_type_raster_id=fuel_type_raster_id)
+    session.execute(stmt)
+
+
+def update_fk_for_advisory_hfi_percent_conifer(
+    session: Session, fuel_type_raster_id: int, run_parameter_ids: list[int]
+) -> None:
+    stmt = (
+        advisory_hfi_percent_conifer_table.update()
+        .where(advisory_hfi_percent_conifer_table.c.run_parameters.in_(run_parameter_ids))
+        .values(fuel_type_raster_id=fuel_type_raster_id)
+    )
+    session.execute(stmt)
+
+
+def update_fk_for_advisory_shape_fuels_table(session: Session, fuel_type_raster_id: int) -> None:
+    stmt = advisory_shape_fuels_table.update().values(fuel_type_raster_id=fuel_type_raster_id)
+    session.execute(stmt)
+
+
+def update_fk_for_critical_hours_table(
+    session: Session, fuel_type_raster_id: int, run_parameter_ids: list[int]
+) -> None:
+    stmt = (
+        critical_hours_table.update()
+        .where(critical_hours_table.c.run_parameters.in_(run_parameter_ids))
+        .values(fuel_type_raster_id=fuel_type_raster_id)
+    )
+    session.execute(stmt)
+
+
+def update_fk_for_tpi_fuel_area_table(session: Session, fuel_type_raster_id: int) -> None:
+    stmt = tpi_fuel_area_table.update().values(fuel_type_raster_id=fuel_type_raster_id)
+    session.execute(stmt)
+
+
+def populate_for_years_and_fuel_grid(
+    session: Session, fuel_grid_year: int, years: list[int]
+) -> None:
+    fuel_type_raster = get_fuel_type_raster(session, fuel_grid_year)
+    fuel_type_raster_id = fuel_type_raster.id
+    run_parameter_ids = get_run_parameter_ids(session, years)
+    update_fk_for_advisory_fuel_stats_table(session, fuel_type_raster_id, run_parameter_ids)
+    update_fk_for_advisory_fuel_types_table(session, fuel_type_raster_id)
+    update_fk_for_advisory_hfi_percent_conifer(session, fuel_type_raster_id, run_parameter_ids)
+    update_fk_for_advisory_shape_fuels_table(session, fuel_type_raster_id)
+    update_fk_for_critical_hours_table(session, fuel_type_raster_id, run_parameter_ids)
+    update_fk_for_tpi_fuel_area_table(session, fuel_type_raster_id)
+
+
+def depopulate_for_years(session: Session, years: list[int]) -> None:
+    fuel_type_raster_id = None
+    run_parameter_ids = get_run_parameter_ids(session, years)
+    update_fk_for_advisory_fuel_stats_table(session, fuel_type_raster_id, run_parameter_ids)
+    update_fk_for_advisory_fuel_types_table(session, fuel_type_raster_id)
+    update_fk_for_advisory_hfi_percent_conifer(session, fuel_type_raster_id, run_parameter_ids)
+    update_fk_for_advisory_shape_fuels_table(session, fuel_type_raster_id)
+    update_fk_for_critical_hours_table(session, fuel_type_raster_id, run_parameter_ids)
+    update_fk_for_tpi_fuel_area_table(session, fuel_type_raster_id)
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    # Data processed in 2022 and 2023 used the fbp2021.tif fuel grid.
+    populate_for_years_and_fuel_grid(session, FUEL_GRID_2021, FUEL_GRID_2021_YEARS)
+    # Data processed in 2024 and 2025 used the fbp2024.tif fuel grid.
+    populate_for_years_and_fuel_grid(session, FUEL_GRID_2024, FUEL_GRID_2024_YEARS)
+
+
+def downgrade():
+    session = Session(bind=op.get_bind())
+    # Data processed in 2022 and 2023 used the fbp2021.tif fuel grid.
+    depopulate_for_years(session, FUEL_GRID_2021_YEARS)
+    # Data processed in 2024 and 2025 used the fbp2024.tif fuel grid.
+    depopulate_for_years(session, FUEL_GRID_2024_YEARS)

--- a/api/alembic/versions/9298059a1912_populate_missing_fuel_type_raster_ids.py
+++ b/api/alembic/versions/9298059a1912_populate_missing_fuel_type_raster_ids.py
@@ -42,13 +42,6 @@ advisory_fuel_stats_table = sa.Table(
     sa.Column("fuel_type_raster_id", sa.Integer),
 )
 
-advisory_fuel_types_table = sa.Table(
-    "advisory_fuel_types",
-    sa.MetaData(),
-    sa.Column("id", sa.Integer),
-    sa.Column("fuel_type_id", sa.Integer),
-    sa.Column("fuel_type_raster_id", sa.Integer),
-)
 
 advisory_hfi_percent_conifer_table = sa.Table(
     "advisory_hfi_percent_conifer",
@@ -58,25 +51,12 @@ advisory_hfi_percent_conifer_table = sa.Table(
     sa.Column("fuel_type_raster_id", sa.Integer),
 )
 
-advisory_shape_fuels_table = sa.Table(
-    "advisory_shape_fuels",
-    sa.MetaData(),
-    sa.Column("id", sa.Integer),
-    sa.Column("fuel_type_raster_id", sa.Integer),
-)
 
 critical_hours_table = sa.Table(
     "critical_hours",
     sa.MetaData(),
     sa.Column("id", sa.Integer),
     sa.Column("run_parameters", sa.Integer),
-    sa.Column("fuel_type_raster_id", sa.Integer),
-)
-
-tpi_fuel_area_table = sa.Table(
-    "tpi_fuel_area",
-    sa.MetaData(),
-    sa.Column("id", sa.Integer),
     sa.Column("fuel_type_raster_id", sa.Integer),
 )
 
@@ -113,11 +93,6 @@ def update_fk_for_advisory_fuel_stats_table(
     session.execute(stmt)
 
 
-def update_fk_for_advisory_fuel_types_table(session: Session, fuel_type_raster_id: int) -> None:
-    stmt = advisory_fuel_types_table.update().values(fuel_type_raster_id=fuel_type_raster_id)
-    session.execute(stmt)
-
-
 def update_fk_for_advisory_hfi_percent_conifer(
     session: Session, fuel_type_raster_id: int, run_parameter_ids: list[int]
 ) -> None:
@@ -126,11 +101,6 @@ def update_fk_for_advisory_hfi_percent_conifer(
         .where(advisory_hfi_percent_conifer_table.c.run_parameters.in_(run_parameter_ids))
         .values(fuel_type_raster_id=fuel_type_raster_id)
     )
-    session.execute(stmt)
-
-
-def update_fk_for_advisory_shape_fuels_table(session: Session, fuel_type_raster_id: int) -> None:
-    stmt = advisory_shape_fuels_table.update().values(fuel_type_raster_id=fuel_type_raster_id)
     session.execute(stmt)
 
 
@@ -145,11 +115,6 @@ def update_fk_for_critical_hours_table(
     session.execute(stmt)
 
 
-def update_fk_for_tpi_fuel_area_table(session: Session, fuel_type_raster_id: int) -> None:
-    stmt = tpi_fuel_area_table.update().values(fuel_type_raster_id=fuel_type_raster_id)
-    session.execute(stmt)
-
-
 def populate_for_years_and_fuel_grid(
     session: Session, fuel_grid_year: int, years: list[int]
 ) -> None:
@@ -157,22 +122,16 @@ def populate_for_years_and_fuel_grid(
     fuel_type_raster_id = fuel_type_raster.id
     run_parameter_ids = get_run_parameter_ids(session, years)
     update_fk_for_advisory_fuel_stats_table(session, fuel_type_raster_id, run_parameter_ids)
-    update_fk_for_advisory_fuel_types_table(session, fuel_type_raster_id)
     update_fk_for_advisory_hfi_percent_conifer(session, fuel_type_raster_id, run_parameter_ids)
-    update_fk_for_advisory_shape_fuels_table(session, fuel_type_raster_id)
     update_fk_for_critical_hours_table(session, fuel_type_raster_id, run_parameter_ids)
-    update_fk_for_tpi_fuel_area_table(session, fuel_type_raster_id)
 
 
 def depopulate_for_years(session: Session, years: list[int]) -> None:
     fuel_type_raster_id = None
     run_parameter_ids = get_run_parameter_ids(session, years)
     update_fk_for_advisory_fuel_stats_table(session, fuel_type_raster_id, run_parameter_ids)
-    update_fk_for_advisory_fuel_types_table(session, fuel_type_raster_id)
     update_fk_for_advisory_hfi_percent_conifer(session, fuel_type_raster_id, run_parameter_ids)
-    update_fk_for_advisory_shape_fuels_table(session, fuel_type_raster_id)
     update_fk_for_critical_hours_table(session, fuel_type_raster_id, run_parameter_ids)
-    update_fk_for_tpi_fuel_area_table(session, fuel_type_raster_id)
 
 
 def upgrade():


### PR DESCRIPTION
This is a copy/paste of a previous migration which updates the `fuel_type_raster_id` foreign key based on the `for_date` of associated `run_parameters`.
# Test Links:
[Landing Page](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4656-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
