### PR TITLE
ASA bug - no fuel info/previous fuel grid

### DIFF
--- a/api/app/routers/fba.py
+++ b/api/app/routers/fba.py
@@ -179,14 +179,16 @@ async def get_hfi_fuels_data_for_fire_centre(
             if hfi_fuel_type_ids_for_zone is None or len(hfi_fuel_type_ids_for_zone) == 0:
                 # Handle the situation where data for the current year was actually processed with
                 # last year's fuel grid
-                fuel_type_raster = await get_fuel_type_raster_by_year(session, for_date.year - 1)
+                prev_fuel_type_raster = await get_fuel_type_raster_by_year(
+                    session, for_date.year - 1
+                )
                 hfi_fuel_type_ids_for_zone = await get_precomputed_stats_for_shape(
                     session,
                     run_type=RunTypeEnum(run_type.value),
                     for_date=for_date,
                     run_datetime=run_datetime,
                     source_identifier=zone_source_id,
-                    fuel_type_raster_id=fuel_type_raster.id,
+                    fuel_type_raster_id=prev_fuel_type_raster.id,
                 )
 
             zone_fuel_stats = []


### PR DESCRIPTION
- Fixes bug where the `fuel_type_raster` variable was getting overwritten in some cases. Result was subsequent queries were also trying to use the fuel grid from 1 year previous

# Test Links:
[Landing Page](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4679-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
