### PR TITLE
Add cache busting for stale JS chunks on preload error

### DIFF
--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -36,5 +36,9 @@ const render = () => {
   )
 }
 
-render()
+// cache bust any stale js chunks
+window.addEventListener('vite:preloadError', event => {
+  window.location.reload()
+})
 
+render()


### PR DESCRIPTION
Implement a listener for preload errors that reloads the page to ensure fresh JavaScript chunks are loaded.

https://vite.dev/guide/build.html#load-error-handling