### PR TITLE
Ensure unique mask IDs for flag components

### DIFF
--- a/mobile/asa-go/src/components/profile/ElevationFlag.test.tsx
+++ b/mobile/asa-go/src/components/profile/ElevationFlag.test.tsx
@@ -25,34 +25,46 @@ vi.mock("@/components/profile/FillableFlag", () => ({
 
 describe("ElevationFlag", () => {
   it("should render the flag component", () => {
-    render(<ElevationFlag id="upper" percent={75} testId="upper-slope" />);
+    const { container } = render(
+      <ElevationFlag percent={75} testId="upper-slope" />
+    );
 
-    const mockFlag = screen.getByTestId("mock-flag-upper");
+    const mockFlag = container.querySelector('[data-percent="75"]');
     expect(mockFlag).toBeInTheDocument();
+    expect(mockFlag).toHaveAttribute("data-test-id", "upper-slope");
   });
 
   it("should pass correct props to FillableFlag", () => {
-    render(<ElevationFlag id="test-id" percent={50} testId="test-flag" />);
+    render(<ElevationFlag percent={50} testId="test-flag" />);
 
-    const mockFlag = screen.getByTestId("mock-flag-test-id");
+    const mockFlag = screen.getByText(/Mock Flag: 50%/);
     expect(mockFlag).toHaveAttribute("data-percent", "50");
     expect(mockFlag).toHaveAttribute("data-test-id", "test-flag");
   });
 
-  it("should pass maskId prop correctly", () => {
-    const testIds = ["upper", "mid", "lower"];
+  it("should generate random maskId correctly", () => {
+    const { container: container1 } = render(<ElevationFlag percent={25} />);
+    const { container: container2 } = render(<ElevationFlag percent={25} />);
 
-    testIds.forEach((id) => {
-      const { container } = render(<ElevationFlag id={id} percent={25} />);
-      const mockFlag = container.querySelector(
-        `[data-testid="mock-flag-${id}"]`
-      );
-      expect(mockFlag).toBeInTheDocument();
-    });
+    // Both should have mock flags with different maskIds since they're random
+    const mockFlag1 = container1.querySelector(
+      '[data-testid^="mock-flag-elevation-flag-"]'
+    );
+    const mockFlag2 = container2.querySelector(
+      '[data-testid^="mock-flag-elevation-flag-"]'
+    );
+
+    expect(mockFlag1).toBeInTheDocument();
+    expect(mockFlag2).toBeInTheDocument();
+
+    // The maskIds should be different (random)
+    const maskId1 = mockFlag1?.getAttribute("data-testid");
+    const maskId2 = mockFlag2?.getAttribute("data-testid");
+    expect(maskId1).not.toBe(maskId2);
   });
 
   it("should have correct Grid styling", () => {
-    const { container } = render(<ElevationFlag id="test" percent={50} />);
+    const { container } = render(<ElevationFlag percent={50} />);
 
     // The Grid should have specific styling
     const gridElement = container.firstChild;
@@ -64,11 +76,13 @@ describe("ElevationFlag", () => {
 
     percentages.forEach((percent) => {
       const { container } = render(
-        <ElevationFlag id="test" percent={percent} />
+        <ElevationFlag testId="test" percent={percent} />
       );
+      // Since maskId is now random, we need to find the element differently
       const mockFlag = container.querySelector(
-        '[data-testid="mock-flag-test"]'
+        '[data-testid^="mock-flag-elevation-flag-"]'
       );
+      expect(mockFlag).toBeInTheDocument();
       expect(mockFlag).toHaveAttribute("data-percent", percent.toString());
     });
   });

--- a/mobile/asa-go/src/components/profile/ElevationFlag.tsx
+++ b/mobile/asa-go/src/components/profile/ElevationFlag.tsx
@@ -3,18 +3,23 @@ import { Grid2 as Grid } from "@mui/material";
 import React from "react";
 
 interface ElevationFlagProps {
-  id: string;
   percent: number;
   testId?: string;
 }
 
-const ElevationFlag = ({ id, percent, testId }: ElevationFlagProps) => {
+const ElevationFlag = ({ percent, testId }: ElevationFlagProps) => {
+  const uniqueId = `${Date.now()}-${Math.random().toString(36)}`;
+
   return (
     <Grid
       size={6}
       sx={{ alignItems: "center", display: "flex", justifyContent: "flex-end" }}
     >
-      <Flag maskId={id} percent={percent} testId={testId} />
+      <Flag
+        maskId={`elevation-flag-${uniqueId}`}
+        percent={percent}
+        testId={testId}
+      />
     </Grid>
   );
 };


### PR DESCRIPTION
Modify the ElevationFlag component to generate unique mask IDs, preventing stale renders of flag SVGs. Update tests to reflect changes in prop handling and ensure correct rendering.

Closes #4711
# Test Links:
[Landing Page](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4712-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
