### PR TITLE
ASA Go - Allow no zone/centre selection

### DIFF
--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -168,6 +168,7 @@ const App = () => {
           <ASAGoMap
             selectedFireShape={selectedFireShape}
             setSelectedFireShape={setSelectedFireShape}
+            setSelectedFireCenter={setFireCenter}
             advisoryThreshold={ADVISORY_THRESHOLD}
             date={dateOfInterest}
             setDate={setDateOfInterest}

--- a/mobile/asa-go/src/components/FireCenterDropdown.tsx
+++ b/mobile/asa-go/src/components/FireCenterDropdown.tsx
@@ -1,6 +1,5 @@
-import { MenuItem, Select } from "@mui/material";
+import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
 import { FireCenter, FireShape } from "api/fbaAPI";
-import { isEqual, isNil } from "lodash";
 import React from "react";
 
 interface FireCenterDropdownProps {
@@ -20,25 +19,29 @@ const FireCenterDropdown = ({
   setSelectedFireCenter,
   setSelectedFireShape,
 }: FireCenterDropdownProps) => {
-  const handleClick = (value: FireCenter) => {
-    if (!isEqual(selectedFireCenter, value)) {
-      setSelectedFireShape(undefined);
-      setSelectedFireCenter(value);
-    }
+  const handleChange = (event: SelectChangeEvent<string>): void => {
+    const selectedName = event.target.value;
+    const selected = fireCenterOptions.find((fc) => fc.name === selectedName);
+    setSelectedFireShape(undefined);
+    setSelectedFireCenter(selected ?? undefined);
   };
 
-  if (isNil(selectedFireCenter) && fireCenterOptions.length) {
-    setSelectedFireCenter(fireCenterOptions[0]);
-  }
-
   return (
-    <Select data-testid="fire-center-dropdown" value={selectedFireCenter?.name ?? ""}>
+    <Select
+      data-testid="fire-center-dropdown"
+      value={selectedFireCenter?.name ?? ""}
+      onChange={handleChange}
+      displayEmpty
+      renderValue={(selected) =>
+        selected ? (
+          selected
+        ) : (
+          <span style={{ color: "#aaa" }}>Select Fire Center</span>
+        )
+      }
+    >
       {fireCenterOptions.map((option) => (
-        <MenuItem
-          key={option.name}
-          value={option.name}
-          onClick={() => handleClick(option)}
-        >
+        <MenuItem key={option.name} value={option.name}>
           {option.name}
         </MenuItem>
       ))}

--- a/mobile/asa-go/src/components/FireCenterDropdown.tsx
+++ b/mobile/asa-go/src/components/FireCenterDropdown.tsx
@@ -26,15 +26,15 @@ const FireCenterDropdown = ({
     setSelectedFireCenter(selected ?? undefined);
   };
 
-  const getSelectedDisplay = (selected: string) => {
-    if (selected === "") {
+  const getSelectedDisplay = (selected: FireCenter | undefined) => {
+    if (!selected) {
       return (
         <Typography sx={{ color: "text.disabled" }}>
           Select Fire Center
         </Typography>
       );
     }
-    return selected;
+    return selected.name;
   };
 
   return (
@@ -43,7 +43,7 @@ const FireCenterDropdown = ({
       value={selectedFireCenter?.name ?? ""}
       onChange={handleChange}
       displayEmpty
-      renderValue={(selected) => getSelectedDisplay(selected)}
+      renderValue={() => getSelectedDisplay(selectedFireCenter)}
     >
       {fireCenterOptions.map((option) => (
         <MenuItem key={option.name} value={option.name}>

--- a/mobile/asa-go/src/components/FireCenterDropdown.tsx
+++ b/mobile/asa-go/src/components/FireCenterDropdown.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
+import { MenuItem, Select, SelectChangeEvent, Typography } from "@mui/material";
 import { FireCenter, FireShape } from "api/fbaAPI";
 import React from "react";
 
@@ -26,19 +26,24 @@ const FireCenterDropdown = ({
     setSelectedFireCenter(selected ?? undefined);
   };
 
+  const getSelectedDisplay = (selected: string) => {
+    if (selected === "") {
+      return (
+        <Typography sx={{ color: "text.disabled" }}>
+          Select Fire Center
+        </Typography>
+      );
+    }
+    return selected;
+  };
+
   return (
     <Select
       data-testid="fire-center-dropdown"
       value={selectedFireCenter?.name ?? ""}
       onChange={handleChange}
       displayEmpty
-      renderValue={(selected) =>
-        selected ? (
-          selected
-        ) : (
-          <span style={{ color: "#aaa" }}>Select Fire Center</span>
-        )
-      }
+      renderValue={(selected) => getSelectedDisplay(selected)}
     >
       {fireCenterOptions.map((option) => (
         <MenuItem key={option.name} value={option.name}>

--- a/mobile/asa-go/src/components/fireCenterDropdown.test.tsx
+++ b/mobile/asa-go/src/components/fireCenterDropdown.test.tsx
@@ -35,7 +35,7 @@ describe("FireCenterDropdown", () => {
     expect(element).toHaveTextContent("Center A");
   });
 
-  it("calls setSelectedFireCenter with first option if none selected", () => {
+  it("does not call setSelectedFireCenter if no option is selected", () => {
     render(
       <FireCenterDropdown
         fireCenterOptions={fireCenters}
@@ -45,7 +45,7 @@ describe("FireCenterDropdown", () => {
       />
     );
 
-    expect(setSelectedFireCenter).toHaveBeenCalledWith(fireCenters[0]);
+    expect(setSelectedFireCenter).not.toHaveBeenCalled();
   });
 
   it("changes selection and resets fire shape", async () => {
@@ -69,7 +69,7 @@ describe("FireCenterDropdown", () => {
     expect(setSelectedFireCenter).toHaveBeenCalledWith(fireCenters[1]);
   });
 
-  it("does not crash with empty options", () => {
+  it("has instructional default text if no fire centre is selected", () => {
     render(
       <FireCenterDropdown
         fireCenterOptions={[]}
@@ -79,6 +79,8 @@ describe("FireCenterDropdown", () => {
       />
     );
     // Expect empty select to render with a zero width space.
-    expect(screen.getByRole("combobox")).toHaveTextContent("\u200B");
+    expect(screen.getByRole("combobox")).toHaveTextContent(
+      "Select Fire Center"
+    );
   });
 });

--- a/mobile/asa-go/src/components/map/ASAGoMap.tsx
+++ b/mobile/asa-go/src/components/map/ASAGoMap.tsx
@@ -33,7 +33,7 @@ import { Filesystem } from "@capacitor/filesystem";
 import GpsOffIcon from "@mui/icons-material/GpsOff";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
 import { Box } from "@mui/material";
-import { FireShape } from "api/fbaAPI";
+import { FireCenter, FireShape } from "api/fbaAPI";
 import { cloneDeep, isNull, isUndefined } from "lodash";
 import { DateTime } from "luxon";
 import { Map, MapBrowserEvent, Overlay, View } from "ol";
@@ -67,6 +67,9 @@ export interface ASAGoMapProps {
   setSelectedFireShape: React.Dispatch<
     React.SetStateAction<FireShape | undefined>
   >;
+  setSelectedFireCenter: React.Dispatch<
+    React.SetStateAction<FireCenter | undefined>
+  >;
   advisoryThreshold: number;
   date: DateTime;
   setDate: React.Dispatch<React.SetStateAction<DateTime>>;
@@ -77,6 +80,7 @@ const ASAGoMap = ({
   testId,
   selectedFireShape,
   setSelectedFireShape,
+  setSelectedFireCenter,
   advisoryThreshold,
   date,
   setDate,
@@ -304,6 +308,7 @@ const ASAGoMap = ({
       fireZoneFileLayer.getFeatures(event.pixel).then((features) => {
         if (!features.length) {
           popup.setPosition(undefined);
+          setSelectedFireCenter(undefined);
           setSelectedFireShape(undefined);
           return;
         }

--- a/mobile/asa-go/src/components/map/asaGoMap.test.tsx
+++ b/mobile/asa-go/src/components/map/asaGoMap.test.tsx
@@ -46,6 +46,7 @@ describe("ASAGoMap", () => {
     testId: "asa-go-map",
     selectedFireShape: undefined,
     setSelectedFireShape: vi.fn(),
+    setSelectedFireCenter: vi.fn(),
     advisoryThreshold: 0,
     date: DateTime.fromISO("2024-12-15"),
     setDate: vi.fn(),

--- a/mobile/asa-go/src/components/profile/FireZoneUnitSummary.tsx
+++ b/mobile/asa-go/src/components/profile/FireZoneUnitSummary.tsx
@@ -16,7 +16,6 @@ interface FireZoneUnitSummaryProps {
 }
 
 const FireZoneUnitSummary = ({
-  //   fireZoneTPIStats,
   selectedFireCenter,
   selectedFireZoneUnit,
 }: FireZoneUnitSummaryProps) => {

--- a/mobile/asa-go/src/components/profile/Profile.test.tsx
+++ b/mobile/asa-go/src/components/profile/Profile.test.tsx
@@ -170,7 +170,9 @@ describe("Profile", () => {
   });
 
   it("should render FireZoneUnitTabs with correct advisory threshold", () => {
-    renderWithProvider(<Profile {...defaultProps} />);
+    renderWithProvider(
+      <Profile {...defaultProps} selectedFireCenter={mockFireCenter} />
+    );
 
     const tabs = screen.getByTestId("fire-zone-unit-tabs");
     expect(tabs).toBeInTheDocument();
@@ -179,12 +181,11 @@ describe("Profile", () => {
     expect(threshold).toHaveTextContent(`${defaultProps.advisoryThreshold}`);
   });
 
-  it("should render FireZoneUnitSummary", () => {
+  it("should render a default message if no fire centre is selected", () => {
     renderWithProvider(<Profile {...defaultProps} />);
 
-    const summary = screen.getByTestId("fire-zone-unit-summary");
+    const summary = screen.getByTestId("default-message");
     expect(summary).toBeInTheDocument();
-    expect(summary).toHaveTextContent("No fire zone selected");
   });
 
   it("should render FireZoneUnitSummary with selected fire zone", () => {

--- a/mobile/asa-go/src/components/profile/Profile.tsx
+++ b/mobile/asa-go/src/components/profile/Profile.tsx
@@ -1,6 +1,7 @@
 import { FireCenter, FireShape } from "@/api/fbaAPI";
 import FireCenterDropdown from "@/components/FireCenterDropdown";
 import FireZoneUnitSummary from "@/components/profile/FireZoneUnitSummary";
+import { DefaultText } from "@/components/report/DefaultText";
 import FireZoneUnitTabs from "@/components/report/FireZoneUnitTabs";
 import TodayTomorrowSwitch from "@/components/TodayTomorrowSwitch";
 import { selectFireCenters } from "@/store";
@@ -96,6 +97,7 @@ const Profile = ({
           Profile
         </Typography>
       </Box>
+
       <Box
         id="profile-content-container"
         sx={{
@@ -106,17 +108,21 @@ const Profile = ({
           overflowY: "hidden",
         }}
       >
-        <FireZoneUnitTabs
-          advisoryThreshold={advisoryThreshold}
-          selectedFireCenter={selectedFireCenter}
-          selectedFireZoneUnit={selectedFireZoneUnit}
-          setSelectedFireZoneUnit={setSelectedFireZoneUnit}
-        >
-          <FireZoneUnitSummary
+        {!selectedFireCenter ? (
+          <DefaultText />
+        ) : (
+          <FireZoneUnitTabs
+            advisoryThreshold={advisoryThreshold}
             selectedFireCenter={selectedFireCenter}
             selectedFireZoneUnit={selectedFireZoneUnit}
-          />
-        </FireZoneUnitTabs>
+            setSelectedFireZoneUnit={setSelectedFireZoneUnit}
+          >
+            <FireZoneUnitSummary
+              selectedFireCenter={selectedFireCenter}
+              selectedFireZoneUnit={selectedFireZoneUnit}
+            />
+          </FireZoneUnitTabs>
+        )}
       </Box>
     </Box>
   );

--- a/mobile/asa-go/src/components/report/AdvisoryText.tsx
+++ b/mobile/asa-go/src/components/report/AdvisoryText.tsx
@@ -4,6 +4,7 @@ import {
   FireZoneFuelStats,
   FireZoneHFIStats,
 } from "@/api/fbaAPI";
+import DefaultText from "@/components/report/DefaultText";
 import { selectFilteredFireCentreHFIFuelStats } from "@/slices/fireCentreHFIFuelStatsSlice";
 import { selectProvincialSummary } from "@/slices/provincialSummarySlice";
 import { selectForDate, selectRunDatetime } from "@/slices/runParameterSlice";
@@ -25,7 +26,7 @@ import { DateTime } from "luxon";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 
-const SerifTypography = styled(Typography)({
+export const SerifTypography = styled(Typography)({
   fontSize: "1.2rem",
   fontFamily: '"Courier", "Monospace"',
 }) as typeof Typography;
@@ -217,9 +218,7 @@ const AdvisoryText = ({
     return (
       <>
         {isNil(selectedFireCenter) ? (
-          <SerifTypography data-testid="default-message">
-            Please select a fire center.
-          </SerifTypography>
+          <DefaultText />
         ) : (
           <SerifTypography data-testid="no-data-message">
             No advisory data available for the selected date.

--- a/mobile/asa-go/src/components/report/DefaultText.tsx
+++ b/mobile/asa-go/src/components/report/DefaultText.tsx
@@ -1,0 +1,9 @@
+import { SerifTypography } from "@/components/report/AdvisoryText";
+
+export const DefaultText = () => (
+  <SerifTypography data-testid="default-message">
+    Please select a fire center.
+  </SerifTypography>
+);
+
+export default DefaultText;


### PR DESCRIPTION
- Don't auto select the first fire zone/centre on initial load
- Allow user to select no zone by touching outside of BC
- Adds default text to the `Profile` tab 'Please select a fire centre"

# Test Links:
[Landing Page](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4715-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
