### PR TITLE
Remove unused prop from ElevationFlag component

### DIFF
--- a/mobile/asa-go/src/components/profile/ElevationStatus.tsx
+++ b/mobile/asa-go/src/components/profile/ElevationStatus.tsx
@@ -1,51 +1,65 @@
-import { useTheme } from '@mui/material/styles'
-import Typography from '@mui/material/Typography'
-import { Box, Grid2 as Grid } from '@mui/material'
-import { FireZoneTPIStats } from '@/api/fbaAPI'
-import Mountain from '@/images/mountain.png'
-import ElevationLabel from '@/components/profile/ElevationLabel'
-import ElevationFlag from '@/components/profile/ElevationFlag'
+import { useTheme } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { Box, Grid2 as Grid } from "@mui/material";
+import { FireZoneTPIStats } from "@/api/fbaAPI";
+import Mountain from "@/images/mountain.png";
+import ElevationLabel from "@/components/profile/ElevationLabel";
+import ElevationFlag from "@/components/profile/ElevationFlag";
 
 enum ElevationOption {
-  BOTTOM = 'Valley Bottom',
-  MID = 'Mid Slope',
-  UPPER = 'Upper Slope'
+  BOTTOM = "Valley Bottom",
+  MID = "Mid Slope",
+  UPPER = "Upper Slope",
 }
 
 interface ElevationStatusProps {
-  tpiStats: Required<FireZoneTPIStats>
+  tpiStats: Required<FireZoneTPIStats>;
 }
 
 const ElevationStatus = ({ tpiStats }: ElevationStatusProps) => {
-  const theme = useTheme()
+  const theme = useTheme();
   const mid_percent =
-    tpiStats.mid_slope_tpi === 0 ? 0 : Math.round((tpiStats.mid_slope_hfi / tpiStats.mid_slope_tpi) * 100)
+    tpiStats.mid_slope_tpi === 0
+      ? 0
+      : Math.round((tpiStats.mid_slope_hfi / tpiStats.mid_slope_tpi) * 100);
   const upper_percent =
-    tpiStats.upper_slope_tpi === 0 ? 0 : Math.round((tpiStats.upper_slope_hfi / tpiStats.upper_slope_tpi) * 100)
+    tpiStats.upper_slope_tpi === 0
+      ? 0
+      : Math.round((tpiStats.upper_slope_hfi / tpiStats.upper_slope_tpi) * 100);
   const bottom_percent =
-    tpiStats.valley_bottom_tpi === 0 ? 0 : Math.round((tpiStats.valley_bottom_hfi / tpiStats.valley_bottom_tpi) * 100)
+    tpiStats.valley_bottom_tpi === 0
+      ? 0
+      : Math.round(
+          (tpiStats.valley_bottom_hfi / tpiStats.valley_bottom_tpi) * 100
+        );
   return (
     <Grid container size={12} data-testid="elevation-status">
       <Grid container sx={{ height: theme.spacing(6) }} size={12}>
-        <Grid sx={{ paddingLeft: theme.spacing(0.5), paddingRight: theme.spacing(0.5) }} size={6}>
+        <Grid
+          sx={{
+            paddingLeft: theme.spacing(0.5),
+            paddingRight: theme.spacing(0.5),
+          }}
+          size={6}
+        >
           <Typography
             sx={{
-              color: '#003366',
-              fontWeight: 'bold',
-              textAlign: 'left',
-              width: '50%'
+              color: "#003366",
+              fontWeight: "bold",
+              textAlign: "left",
+              width: "50%",
             }}
           >
             Topographic Position:
           </Typography>
         </Grid>
-        <Grid sx={{ display: 'flex', justifyContent: 'flex-end' }} size={6}>
+        <Grid sx={{ display: "flex", justifyContent: "flex-end" }} size={6}>
           <Typography
             sx={{
-              color: '#003366',
-              fontWeight: 'bold',
-              textAlign: 'right',
-              width: '65%'
+              color: "#003366",
+              fontWeight: "bold",
+              textAlign: "right",
+              width: "65%",
             }}
           >
             Portion under advisory:
@@ -56,30 +70,37 @@ const ElevationStatus = ({ tpiStats }: ElevationStatusProps) => {
         <Box
           sx={{
             background: `url(${Mountain})`,
-            backgroundRepeat: 'round',
-            display: 'flex',
-            width: '100%'
+            backgroundRepeat: "round",
+            display: "flex",
+            width: "100%",
           }}
           data-testid="tpi-mountain"
         >
-          <Grid sx={{ paddingLeft: theme.spacing(0.5), paddingRight: theme.spacing(0.5) }} container size={12}>
+          <Grid
+            sx={{
+              paddingLeft: theme.spacing(0.5),
+              paddingRight: theme.spacing(0.5),
+            }}
+            container
+            size={12}
+          >
             <Grid container sx={{ height: theme.spacing(8) }} size={12}>
               <ElevationLabel label={ElevationOption.UPPER} />
-              <ElevationFlag id="upper" percent={upper_percent} testId="upper-slope" />
+              <ElevationFlag percent={upper_percent} testId="upper-slope" />
             </Grid>
             <Grid container sx={{ height: theme.spacing(8) }} size={12}>
               <ElevationLabel label={ElevationOption.MID} />
-              <ElevationFlag id="mid" percent={mid_percent} testId="mid-slope" />
+              <ElevationFlag percent={mid_percent} testId="mid-slope" />
             </Grid>
             <Grid container sx={{ height: theme.spacing(8) }} size={12}>
               <ElevationLabel label={ElevationOption.BOTTOM} />
-              <ElevationFlag id="lower" percent={bottom_percent} testId="valley-bottom" />
+              <ElevationFlag percent={bottom_percent} testId="valley-bottom" />
             </Grid>
           </Grid>
         </Box>
       </Grid>
     </Grid>
-  )
-}
+  );
+};
 
-export default ElevationStatus
+export default ElevationStatus;


### PR DESCRIPTION
Eliminate the unused `id` prop from the `ElevationFlag` component that is no longer used.
# Test Links:
[Landing Page](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4716-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
