### PR TITLE
Bump crunchydb mem limit above default range limit

### DIFF
--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -91,6 +91,8 @@ objects:
             requests:
               cpu: ${CPU_REQUEST}
               memory: ${MEMORY_REQUEST}
+            limits:
+              memory: 32Gi
           dataVolumeClaimSpec:
             accessModes:
               - "ReadWriteOnce"

--- a/openshift/templates/deploy.yaml
+++ b/openshift/templates/deploy.yaml
@@ -450,7 +450,6 @@ objects:
                 initialDelaySeconds: 30
                 periodSeconds: 120
                 timeoutSeconds: 20
-
       targetRef:
         apiVersion: "apps/v1"
         kind: Deployment

--- a/openshift/templates/deploy.yaml
+++ b/openshift/templates/deploy.yaml
@@ -450,17 +450,24 @@ objects:
                 initialDelaySeconds: 30
                 periodSeconds: 120
                 timeoutSeconds: 20
-  - apiVersion: autoscaling.k8s.io/v1
-    kind: VerticalPodAutoscaler
-    metadata:
-      name: vpa-recommender-${SUFFIX}
-    spec:
+
       targetRef:
         apiVersion: "apps/v1"
         kind: Deployment
         name: ${APP_NAME}-${SUFFIX}
       updatePolicy:
         updateMode: "Off"
+  - apiVersion: v1
+    kind: LimitRange
+    metadata:
+      name: default-limits
+    spec:
+      limits:
+        - type: Container
+          default:
+            memory: 12Gi
+          max:
+            memory: 32Gi
   - apiVersion: v1
     kind: Service
     metadata:

--- a/openshift/templates/deploy.yaml
+++ b/openshift/templates/deploy.yaml
@@ -457,17 +457,6 @@ objects:
       updatePolicy:
         updateMode: "Off"
   - apiVersion: v1
-    kind: LimitRange
-    metadata:
-      name: default-limits
-    spec:
-      limits:
-        - type: Container
-          default:
-            memory: 12Gi
-          max:
-            memory: 32Gi
-  - apiVersion: v1
     kind: Service
     metadata:
       labels:


### PR DESCRIPTION
- Remove unused VPA
- Add mem limit of 32GB to supercede LimitRange  of 16GB according to: https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/automation-and-resiliency/openshift-project-resource-quotas/#limitrange
# Test Links:
[Landing Page](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4750-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
