### PR TITLE
Add logging for critical hours saving and error handling

### DIFF
--- a/api/app/auto_spatial_advisory/critical_hours.py
+++ b/api/app/auto_spatial_advisory/critical_hours.py
@@ -146,6 +146,9 @@ async def save_critical_hours(
             fuel_type_raster_id=fuel_type_raster_id,
         )
         critical_hours_to_save.append(critical_hours_record)
+    logger.info(
+        f"Saving {len(critical_hours_to_save)} critical hours for run parameter {run_parameters_id}"
+    )
     await save_all_critical_hours(db_session, critical_hours_to_save)
 
 
@@ -545,41 +548,46 @@ async def calculate_critical_hours(run_type: RunType, run_datetime: datetime, fo
     )
     perf_start = perf_counter()
 
-    async with get_async_write_session_scope() as db_session:
-        run_parameters_id = await get_run_parameters_id(
-            db_session, RunType(run_type), run_datetime, for_date
+    try:
+        async with get_async_write_session_scope() as db_session:
+            run_parameters_id = await get_run_parameters_id(
+                db_session, RunType(run_type), run_datetime, for_date
+            )
+            stmt = select(CriticalHours).where(CriticalHours.run_parameters == run_parameters_id)
+            exists = (await db_session.execute(stmt)).scalars().first() is not None
+
+            if exists:
+                logger.info("Critical hours already processed.")
+                return
+
+            fuel_type_raster = await get_fuel_type_raster_by_year(db_session, for_date.year)
+            async with ClientSession() as client_session:
+                header = await wfwx_api.get_auth_header(client_session)
+                all_stations = await get_stations_asynchronously()
+                station_codes = list(station.code for station in all_stations)
+                stations = await wfwx_api.get_wfwx_stations_from_station_codes(
+                    client_session, header, station_codes
+                )
+                stations_by_zone: Dict[int, List[WFWXWeatherStation]] = defaultdict(list)
+                transformer = PointTransformer(4326, 3005)
+                for station in stations:
+                    (x, y) = transformer.transform_coordinate(station.lat, station.long)
+                    zone_id = await get_containing_zone(db_session, f"POINT({x} {y})", 3005)
+                    if zone_id is not None:
+                        stations_by_zone[zone_id[0]].append(station)
+
+                await calculate_critical_hours_by_zone(
+                    db_session,
+                    header,
+                    stations_by_zone,
+                    run_parameters_id,
+                    for_date,
+                    fuel_type_raster.id,
+                )
+    except Exception:
+        logger.error(
+            f"Fatal error calculating and storing critical hours for run parameters: {run_parameters_id}"
         )
-        stmt = select(CriticalHours).where(CriticalHours.run_parameters == run_parameters_id)
-        exists = (await db_session.execute(stmt)).scalars().first() is not None
-
-        if exists:
-            logger.info("Critical hours already processed.")
-            return
-
-        fuel_type_raster = await get_fuel_type_raster_by_year(db_session, for_date.year)
-        async with ClientSession() as client_session:
-            header = await wfwx_api.get_auth_header(client_session)
-            all_stations = await get_stations_asynchronously()
-            station_codes = list(station.code for station in all_stations)
-            stations = await wfwx_api.get_wfwx_stations_from_station_codes(
-                client_session, header, station_codes
-            )
-            stations_by_zone: Dict[int, List[WFWXWeatherStation]] = defaultdict(list)
-            transformer = PointTransformer(4326, 3005)
-            for station in stations:
-                (x, y) = transformer.transform_coordinate(station.lat, station.long)
-                zone_id = await get_containing_zone(db_session, f"POINT({x} {y})", 3005)
-                if zone_id is not None:
-                    stations_by_zone[zone_id[0]].append(station)
-
-            await calculate_critical_hours_by_zone(
-                db_session,
-                header,
-                stations_by_zone,
-                run_parameters_id,
-                for_date,
-                fuel_type_raster.id,
-            )
 
     perf_end = perf_counter()
     delta = perf_end - perf_start

--- a/api/app/auto_spatial_advisory/critical_hours.py
+++ b/api/app/auto_spatial_advisory/critical_hours.py
@@ -584,10 +584,12 @@ async def calculate_critical_hours(run_type: RunType, run_datetime: datetime, fo
                     for_date,
                     fuel_type_raster.id,
                 )
-    except Exception:
+    except Exception as e:
         logger.error(
-            f"Fatal error calculating and storing critical hours for run parameters: {run_parameters_id}"
+            f"Fatal error calculating and storing critical hours for run parameters: {run_parameters_id}",
+            exc_info=True,
         )
+        raise e
 
     perf_end = perf_counter()
     delta = perf_end - perf_start


### PR DESCRIPTION
Enhance the critical hours calculation process by adding logging for the number of critical hours being saved and implementing error handling to log fatal errors during the calculation and storage process.
# Test Links:
[Landing Page](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4761-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
