### PR TITLE
Refactor authentication to use asa_authentication_required

### DIFF
--- a/api/app/routers/fba.py
+++ b/api/app/routers/fba.py
@@ -17,7 +17,7 @@ from app.auto_spatial_advisory.zone_stats import (
     get_fuel_type_area_stats,
     get_zone_wind_stats_for_source_id,
 )
-from wps_shared.auth import audit, asa_authentication_required
+from wps_shared.auth import audit, asa_authentication_required, audit_asa
 from wps_shared.db.crud.auto_spatial_advisory import (
     get_all_hfi_thresholds_by_id,
     get_all_sfms_fuel_type_records,
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/fba",
-    dependencies=[Depends(asa_authentication_required), Depends(audit)],
+    dependencies=[Depends(asa_authentication_required), Depends(audit_asa)],
 )
 
 

--- a/api/app/routers/fba.py
+++ b/api/app/routers/fba.py
@@ -17,7 +17,7 @@ from app.auto_spatial_advisory.zone_stats import (
     get_fuel_type_area_stats,
     get_zone_wind_stats_for_source_id,
 )
-from wps_shared.auth import audit, authentication_required
+from wps_shared.auth import audit, asa_authentication_required
 from wps_shared.db.crud.auto_spatial_advisory import (
     get_all_hfi_thresholds_by_id,
     get_all_sfms_fuel_type_records,
@@ -53,12 +53,12 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/fba",
-    dependencies=[Depends(authentication_required), Depends(audit)],
+    dependencies=[Depends(asa_authentication_required), Depends(audit)],
 )
 
 
 @router.get("/fire-centers", response_model=FireCenterListResponse)
-async def get_all_fire_centers(_=Depends(authentication_required)):
+async def get_all_fire_centers(_=Depends(asa_authentication_required)):
     """Returns fire centers for all active stations."""
     logger.info("/fba/fire-centers/")
     async with ClientSession() as session:
@@ -72,7 +72,10 @@ async def get_all_fire_centers(_=Depends(authentication_required)):
     response_model=FireShapeAreaListResponse,
 )
 async def get_shapes(
-    run_type: RunType, run_datetime: datetime, for_date: date, _=Depends(authentication_required)
+    run_type: RunType,
+    run_datetime: datetime,
+    for_date: date,
+    _=Depends(asa_authentication_required),
 ):
     """Return area of each zone unit shape, and percentage of area of zone unit shape with high hfi."""
     async with get_async_read_session_scope() as session:
@@ -104,7 +107,10 @@ async def get_shapes(
     response_model=ProvincialSummaryResponse,
 )
 async def get_provincial_summary(
-    run_type: RunType, run_datetime: datetime, for_date: date, _=Depends(authentication_required)
+    run_type: RunType,
+    run_datetime: datetime,
+    for_date: date,
+    _=Depends(asa_authentication_required),
 ):
     """Return all Fire Centres with their fire shapes and the HFI status of those shapes."""
     logger.info("/fba/provincial_summary/")
@@ -137,7 +143,11 @@ async def get_provincial_summary(
     response_model=dict[str, dict[int, FireZoneHFIStats]],
 )
 async def get_hfi_fuels_data_for_fire_centre(
-    run_type: RunType, for_date: date, run_datetime: datetime, fire_centre_name: str
+    run_type: RunType,
+    for_date: date,
+    run_datetime: datetime,
+    fire_centre_name: str,
+    _=Depends(asa_authentication_required),
 ):
     """
     Fetch fuel type and critical hours data for all fire zones in a fire centre for a given date
@@ -231,7 +241,9 @@ async def get_hfi_fuels_data_for_fire_centre(
 
 
 @router.get("/latest-sfms-run-datetime/{for_date}", response_model=LatestSFMSRunParameterResponse)
-async def get_latest_sfms_run_datetime_for_date(for_date: date):
+async def get_latest_sfms_run_datetime_for_date(
+    for_date: date, _=Depends(asa_authentication_required)
+):
     async with get_async_read_session_scope() as session:
         latest_run_parameter = await get_most_recent_run_datetime_for_date(session, for_date)
         if latest_run_parameter is None:
@@ -246,7 +258,7 @@ async def get_latest_sfms_run_datetime_for_date(for_date: date):
 
 @router.get("/sfms-run-datetimes/{run_type}/{for_date}", response_model=List[datetime])
 async def get_run_datetimes_for_date_and_runtype(
-    run_type: RunType, for_date: date, _=Depends(authentication_required)
+    run_type: RunType, for_date: date, _=Depends(asa_authentication_required)
 ):
     """Return list of datetimes for which SFMS has run, given a specific for_date and run_type.
     Datetimes should be ordered with most recent first."""
@@ -281,7 +293,7 @@ async def get_fire_centre_tpi_stats(
     run_type: RunType,
     run_datetime: datetime,
     for_date: date,
-    _=Depends(authentication_required),
+    _=Depends(asa_authentication_required),
 ):
     """Return the elevation TPI statistics for each advisory threshold for a fire centre"""
     logger.info("/fba/fire-centre-tpi-stats/")

--- a/api/app/tests/conftest.py
+++ b/api/app/tests/conftest.py
@@ -8,6 +8,7 @@ from wps_shared.tests.conftest import (
     mock_get_pst_today_start_and_end,
     mock_session,
     mock_jwt_decode,
+    mock_test_idir_jwt_decode,
     mock_sentry,
     mock_requests_session,
     mock_client_session,

--- a/api/app/tests/fba/test_fba_endpoint.py
+++ b/api/app/tests/fba/test_fba_endpoint.py
@@ -456,6 +456,7 @@ FBA_ENDPOINTS = [
 @patch("app.routers.fba.get_fuel_type_raster_by_year", mock_get_fuel_type_raster_by_year)
 @patch("app.routers.fba.get_fire_centre_tpi_fuel_areas", mock_get_fire_centre_tpi_fuel_areas)
 @patch("app.routers.fba.get_centre_tpi_stats", mock_get_centre_tpi_stats)
+@patch("app.routers.fba.get_run_datetimes", mock_get_sfms_run_datetimes)
 @patch("app.routers.fba.get_sfms_bounds", mock_get_sfms_bounds)
 def test_fba_endpoints_allowed_for_test_idir(client, endpoint):
     headers = {"Authorization": "Bearer token"}

--- a/api/app/tests/fba/test_fba_endpoint.py
+++ b/api/app/tests/fba/test_fba_endpoint.py
@@ -19,7 +19,7 @@ from wps_shared.db.models.auto_spatial_advisory import (
 )
 from wps_shared.db.models.fuel_type_raster import FuelTypeRaster
 from wps_shared.schemas.fba import HfiThreshold
-from wps_shared.tests.common import MockTestIDIRJWTDecode, default_mock_client_get
+from wps_shared.tests.common import default_mock_client_get
 
 mock_fire_centre_name = "PGFireCentre"
 
@@ -196,6 +196,7 @@ def test_fba_endpoint_fire_centers(status, expected_fire_centers, monkeypatch):
     assert response.json() == expected_response
 
 
+@pytest.mark.usefixtures("mock_client_session")
 @pytest.mark.parametrize(
     "endpoint",
     [
@@ -442,16 +443,6 @@ FBA_ENDPOINTS = [
 ]
 
 
-@pytest.fixture()
-def mock_test_idir_jwt_decode(monkeypatch):
-    """Mock pyjwt's decode method"""
-
-    def mock_function(*args, **kwargs):
-        return MockTestIDIRJWTDecode()
-
-    monkeypatch.setattr("jwt.decode", mock_function)
-
-
 @pytest.mark.usefixtures("mock_test_idir_jwt_decode")
 @pytest.mark.parametrize("endpoint", FBA_ENDPOINTS)
 @patch("app.routers.fba.get_auth_header", mock_get_auth_header)
@@ -465,6 +456,7 @@ def mock_test_idir_jwt_decode(monkeypatch):
 @patch("app.routers.fba.get_fuel_type_raster_by_year", mock_get_fuel_type_raster_by_year)
 @patch("app.routers.fba.get_fire_centre_tpi_fuel_areas", mock_get_fire_centre_tpi_fuel_areas)
 @patch("app.routers.fba.get_centre_tpi_stats", mock_get_centre_tpi_stats)
+@patch("app.routers.fba.get_sfms_bounds", mock_get_sfms_bounds)
 def test_fba_endpoints_allowed_for_test_idir(client, endpoint):
     headers = {"Authorization": "Bearer token"}
     response = client.get(endpoint, headers=headers)

--- a/api/app/tests/fba/test_fba_endpoint.py
+++ b/api/app/tests/fba/test_fba_endpoint.py
@@ -19,7 +19,7 @@ from wps_shared.db.models.auto_spatial_advisory import (
 )
 from wps_shared.db.models.fuel_type_raster import FuelTypeRaster
 from wps_shared.schemas.fba import HfiThreshold
-from wps_shared.tests.common import default_mock_client_get
+from wps_shared.tests.common import MockTestIDIRJWTDecode, default_mock_client_get
 
 mock_fire_centre_name = "PGFireCentre"
 
@@ -440,28 +440,6 @@ FBA_ENDPOINTS = [
     "/api/fba/sfms-run-datetimes/forecast/2022-09-27",
     "/api/fba/sfms-run-bounds",
 ]
-
-
-class MockTestIDIRJWTDecode:
-    """Mock pyjwt module with test idir"""
-
-    def __init__(self):
-        self.decoded_token = {
-            "idir_username": "test_username",
-            "email": "test@email.com",
-            "idir_user_guid": "4F488A419BD843C4ABF631094C6F04A2",
-        }
-
-    def __getitem__(self, key):
-        return self.decoded_token[key]
-
-    def get(self, key, _):
-        "Returns the mock decoded token"
-        return self.decoded_token.get(key, {})
-
-    def decode(self):
-        "Returns the mock decoded token"
-        return self.decoded_token
 
 
 @pytest.fixture()

--- a/api/app/tests/test_auth.py
+++ b/api/app/tests/test_auth.py
@@ -9,11 +9,41 @@ from app.tests import load_json_file
 @pytest.mark.parametrize(
     "token, status, endpoint, verb, payload",
     [
-        ("Basic token", 401, "/api/weather_models/GDPS/predictions/summaries/", "post", "test_auth_stations_payload.json"),
-        ("just_token", 401, "/api/weather_models/GDPS/predictions/summaries/", "post", "test_auth_stations_payload.json"),
-        ("Bearer token", 401, "/api/weather_models/GDPS/predictions/summaries/", "post", "test_auth_stations_payload.json"),
-        ("just_token", 401, "/api/weather_models/GDPS/predictions/most_recent/", "post", "test_auth_stations_payload.json"),
-        ("Bearer token", 401, "/api/weather_models/GDPS/predictions/most_recent/", "post", "test_auth_stations_payload.json"),
+        (
+            "Basic token",
+            401,
+            "/api/weather_models/GDPS/predictions/summaries/",
+            "post",
+            "test_auth_stations_payload.json",
+        ),
+        (
+            "just_token",
+            401,
+            "/api/weather_models/GDPS/predictions/summaries/",
+            "post",
+            "test_auth_stations_payload.json",
+        ),
+        (
+            "Bearer token",
+            401,
+            "/api/weather_models/GDPS/predictions/summaries/",
+            "post",
+            "test_auth_stations_payload.json",
+        ),
+        (
+            "just_token",
+            401,
+            "/api/weather_models/GDPS/predictions/most_recent/",
+            "post",
+            "test_auth_stations_payload.json",
+        ),
+        (
+            "Bearer token",
+            401,
+            "/api/weather_models/GDPS/predictions/most_recent/",
+            "post",
+            "test_auth_stations_payload.json",
+        ),
         ("just_token", 401, "/api/stations/details/", "get", "test_auth_stations_payload.json"),
     ],
 )
@@ -49,7 +79,9 @@ def test_authenticated_requests(status, endpoint, verb, utc_time, spy_access_log
     client = TestClient(app.main.app)
     response = None
     if verb == "post":
-        response = client.post(endpoint, headers={"Authorization": "Bearer token"}, json={"stations": [838]})
+        response = client.post(
+            endpoint, headers={"Authorization": "Bearer token"}, json={"stations": [838]}
+        )
     if verb == "get":
         response = client.get(endpoint, headers={"Authorization": "Bearer token"})
 

--- a/api/app/tests/test_auth.py
+++ b/api/app/tests/test_auth.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from datetime import datetime, timezone
 import pytest
 from fastapi.routing import APIRoute
+from wps_shared.auth import authentication_required
 import app.main
 from app.tests import load_json_file
 
@@ -102,8 +103,7 @@ def get_non_fba_routes(app):
         if isinstance(route, APIRoute) and not is_fba_route(route):
             # Only include routes that require authentication (i.e., have dependencies)
             if any(
-                "authentication_required" in str(dep.dependency)
-                for dep in route.dependant.dependencies
+                dep.dependency is authentication_required for dep in route.dependant.dependencies
             ):
                 for method in route.methods:
                     if method in {"GET", "POST"}:

--- a/api/app/tests/utils/mock_jwt_decode_role.py
+++ b/api/app/tests/utils/mock_jwt_decode_role.py
@@ -1,13 +1,12 @@
 class MockJWTDecodeWithRole:
-    """ Mock pyjwt module with role """
+    """Mock pyjwt module with role"""
 
     def __init__(self, role):
         self.decoded_token = {
             "idir_username": "test_username",
+            "idir_user_guid": "test-guid",
             "email": "test@email.com",
-            "client_roles": [
-                role
-            ]
+            "client_roles": [role],
         }
 
     def __getitem__(self, key):

--- a/wps_shared/wps_shared/auth.py
+++ b/wps_shared/wps_shared/auth.py
@@ -8,6 +8,7 @@ from jwt import InvalidTokenError
 from sentry_sdk import set_user
 from wps_shared import config
 from wps_shared.db.crud.api_access_audits import create_api_access_audit_log
+from wps_shared.tests.common import ASA_TEST_IDIR_GUID
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ async def default_authenticate(request: Request, token=Depends(authenticate)):
     Only allows non-mobile test IDIRs
     """
     guid = token.get("idir_user_guid", None)
-    if str(guid).upper() == "4F488A419BD843C4ABF631094C6F04A2":
+    if str(guid).upper() == ASA_TEST_IDIR_GUID:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     return token
 
@@ -77,7 +78,7 @@ async def audit(request: Request, token=Depends(permissive_oauth2_scheme)):
         decoded_token = await authenticate(token)
         # Apply the same test IDIR check as default_authenticate
         guid = decoded_token.get("idir_user_guid", None)
-        if str(guid).upper() == "4F488A419BD843C4ABF631094C6F04A2":
+        if str(guid).upper() == ASA_TEST_IDIR_GUID:
             decoded_token = {}
     except Exception:
         decoded_token = {}

--- a/wps_shared/wps_shared/auth.py
+++ b/wps_shared/wps_shared/auth.py
@@ -57,8 +57,9 @@ async def default_authenticate(request: Request, token=Depends(authenticate)):
     Only allows non-mobile test IDIRs
     """
     guid = token.get("idir_user_guid", None)
-    if guid is None or str(guid).upper() == "4F488A419BD843C4ABF631094C6F04A2":
+    if str(guid).upper() == "4F488A419BD843C4ABF631094C6F04A2":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return token
 
 
 async def audit(request: Request, token=Depends(default_authenticate)):

--- a/wps_shared/wps_shared/auth.py
+++ b/wps_shared/wps_shared/auth.py
@@ -8,12 +8,13 @@ from jwt import InvalidTokenError
 from sentry_sdk import set_user
 from wps_shared import config
 from wps_shared.db.crud.api_access_audits import create_api_access_audit_log
-from wps_shared.tests.common import ASA_TEST_IDIR_GUID
 
 logger = logging.getLogger(__name__)
 
 # Parse request header and pass the token
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
+
+ASA_TEST_IDIR_GUID = "4F488A419BD843C4ABF631094C6F04A2"
 
 
 async def permissive_oauth2_scheme(request: Request):

--- a/wps_shared/wps_shared/auth.py
+++ b/wps_shared/wps_shared/auth.py
@@ -71,6 +71,15 @@ async def audit(request: Request, token=Depends(default_authenticate)):
     return token
 
 
+async def audit_asa(request: Request, token=Depends(authenticate)):
+    """Audits attempted requests based on bearer token."""
+    path = request.url.path
+    username = token.get("idir_username", None)
+
+    create_api_access_audit_log(username, bool(token), path)
+    return token
+
+
 async def authentication_required(token=Depends(default_authenticate)):
     """Raises HTTPException with status code 401 if authentication fails."""
     if not token:

--- a/wps_shared/wps_shared/tests/common.py
+++ b/wps_shared/wps_shared/tests/common.py
@@ -1,5 +1,5 @@
-""" Mock modules/classes
-"""
+"""Mock modules/classes"""
+
 import logging
 import os
 import json
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class MockJWTDecode:
-    """ Mock pyjwt module """
+    """Mock pyjwt module"""
 
     def __init__(self):
         self.decoded_token = {"idir_username": "test_username", "email": "test@email.com"}
@@ -28,29 +28,51 @@ class MockJWTDecode:
         return self.decoded_token
 
 
+class MockTestIDIRJWTDecode:
+    """Mock pyjwt module with test idir"""
+
+    def __init__(self):
+        self.decoded_token = {
+            "idir_username": "test_username",
+            "email": "test@email.com",
+            "idir_user_guid": "4F488A419BD843C4ABF631094C6F04A2",
+        }
+
+    def __getitem__(self, key):
+        return self.decoded_token[key]
+
+    def get(self, key, _):
+        "Returns the mock decoded token"
+        return self.decoded_token.get(key, {})
+
+    def decode(self):
+        "Returns the mock decoded token"
+        return self.decoded_token
+
+
 class MockClientSession:
-    """ Stubbed asyncronous context manager. """
+    """Stubbed asyncronous context manager."""
 
     def __init__(self, json=None, text=None):
-        """ Initialize client response """
+        """Initialize client response"""
         self._json = json
         self._text = text
 
     async def __aenter__(self):
-        """ Enter context - return the appropriate response object depending on the url """
+        """Enter context - return the appropriate response object depending on the url"""
         if self._json:
             return MockAsyncResponse(json=self._json)
         return MockAsyncResponse(text=self._text)
 
     async def __aexit__(self, *error_info):
-        """ Clean up anything you need to clean up """
+        """Clean up anything you need to clean up"""
 
 
 class MockResponse:
-    """ Stubbed response object. """
+    """Stubbed response object."""
 
     def __init__(self, text: str = None, json: dict = None, status_code=200, content=None):
-        """ Initialize client response """
+        """Initialize client response"""
 
         self.text = text
         self.content = content
@@ -58,16 +80,15 @@ class MockResponse:
         self.status_code = status_code
 
     def json(self) -> dict:
-        """ Return json response """
+        """Return json response"""
         return self._json
 
 
 class MockAsyncResponse:
-    """ Stubbed async response object.
-    """
+    """Stubbed async response object."""
 
     def __init__(self, text: str = None, json: dict = None, status_code=200):
-        """ Initialize client response """
+        """Initialize client response"""
         self._text = text
         self._json = json
         # NOTE: there is no status_code response!
@@ -75,74 +96,72 @@ class MockAsyncResponse:
         self.status = status_code
 
     async def text(self) -> str:
-        """ Return text response """
+        """Return text response"""
 
         return self._text
 
     async def json(self) -> dict:
-        """ Return json response """
+        """Return json response"""
         return self._json
 
 
 class DefaultMockAioSession:
-    """ Mock aiobotocore.session.AioSession """
+    """Mock aiobotocore.session.AioSession"""
 
     @asynccontextmanager
     async def create_client(self, *args, **kwargs):
-        """ Mock create client """
+        """Mock create client"""
         yield DefaultMockAioBaseClient()
 
 
 class DefaultMockAioBaseClient:
-    """ Stubbed AioBaseClient object
-    """
+    """Stubbed AioBaseClient object"""
 
     def __init__(self, *args, **kwargs):
-        """ you can set the values below for some default behaviour """
+        """you can set the values below for some default behaviour"""
         self.mock_generate_presigned_url: Optional[str] = None
         self.mock_list_objects_v2_lookup: dict = {}
 
     async def list_objects_v2(self, *args, **kwargs) -> dict:
-        """ mock list objects """
-        if kwargs.get('Prefix') in self.mock_list_objects_v2_lookup:
-            return self.mock_list_objects_v2_lookup[kwargs.get('Prefix')]
+        """mock list objects"""
+        if kwargs.get("Prefix") in self.mock_list_objects_v2_lookup:
+            return self.mock_list_objects_v2_lookup[kwargs.get("Prefix")]
         raise NotImplementedError(f"no lookup for {kwargs.get('Prefix')}")
 
     async def put_object(self, *args, **kwargs) -> dict:
-        """ mock put object """
+        """mock put object"""
 
     async def generate_presigned_url(self, *args, **kwargs) -> str:
-        """ mock presigned url """
+        """mock presigned url"""
         return self.mock_generate_presigned_url
 
     async def __aenter__(self):
-        """ Enter context """
+        """Enter context"""
 
     async def __aexit__(self, *error_info):
-        """ Clean up anything you need to clean up """
+        """Clean up anything you need to clean up"""
 
     async def close(self, *args, **kwargs):
         """Close all http connections."""
 
 
 def default_aiobotocore_get_session():
-    """ Default session stub """
+    """Default session stub"""
     return DefaultMockAioSession()
 
 
 def is_json(filename):
-    """ Check if file is a json file (look if the extension is .json) """
+    """Check if file is a json file (look if the extension is .json)"""
     extension = os.path.splitext(filename)[1]
-    return extension == '.json'
+    return extension == ".json"
 
 
 def get_mock_client_session(url: str, params: dict = None) -> MockClientSession:
-    """ Returns a mocked client session, looking for fixtures based on the url and params provided.
-    """
+    """Returns a mocked client session, looking for fixtures based on the url and params provided."""
     # Get the fixture filename
     fixture_finder = FixtureFinder()
-    filename = fixture_finder.get_fixture_path(url, 'get', params)
-    logger.info('using mock client session to load %s, injecting %s', url, filename)
+    filename = fixture_finder.get_fixture_path(url, "get", params)
+    logger.info("using mock client session to load %s, injecting %s", url, filename)
     with open(filename, encoding="utf-8") as fixture_file:
         if is_json(filename):
             return MockClientSession(json=json.load(fixture_file))
@@ -150,16 +169,15 @@ def get_mock_client_session(url: str, params: dict = None) -> MockClientSession:
 
 
 def default_mock_client_get(*args, **kwargs) -> MockClientSession:
-    """ Return a mocked client session - this should be good for most request.
-    """
+    """Return a mocked client session - this should be good for most request."""
     url = args[1]
-    params = kwargs.get('params')
+    params = kwargs.get("params")
     return get_mock_client_session(url, params)
 
 
 def _get_fixture_response(fixture):
-    logger.debug('construct response with %s', fixture)
-    with open(fixture, 'rb') as fixture_file:
+    logger.debug("construct response with %s", fixture)
+    with open(fixture, "rb") as fixture_file:
         if is_json(fixture):
             # Return a response with the appropriate fixture
             return MockResponse(json=json.load(fixture_file))
@@ -169,35 +187,35 @@ def _get_fixture_response(fixture):
 
 
 def default_mock_requests_get(url, params=None, **kwargs) -> MockResponse:
-    """ Return a mocked request response """
+    """Return a mocked request response"""
     # Get the file location of the fixture
     fixture_finder = FixtureFinder()
-    filename = fixture_finder.get_fixture_path(url, 'get', params)
+    filename = fixture_finder.get_fixture_path(url, "get", params)
     # Construct the response
     return _get_fixture_response(filename)
 
 
 def default_mock_requests_post(url, data=None, json=None, params=None, **kwargs) -> MockResponse:
-    """ Return a mocked request response """
+    """Return a mocked request response"""
     # Get the file location of the fixture
     fixture_finder = FixtureFinder()
-    filename = fixture_finder.get_fixture_path(url, 'post', params, data)
+    filename = fixture_finder.get_fixture_path(url, "post", params, data)
     # Construct the response
     return _get_fixture_response(filename)
 
 
 def default_mock_requests_session_get(self, url, **kwargs) -> MockResponse:
-    """ Return a mocked request response from a request.Session object """
+    """Return a mocked request response from a request.Session object"""
     return default_mock_requests_get(url, **kwargs)
 
 
 def default_mock_requests_session_post(self, url, data=None, json=None, **kwargs) -> MockResponse:
-    """ Return a mocked request response from a request.Session object """
+    """Return a mocked request response from a request.Session object"""
     return default_mock_requests_post(url, data, json, **kwargs)
 
 
 def str2float(value: str):
-    """ Change a string into a floating point number, or a None """
-    if value == 'None':
+    """Change a string into a floating point number, or a None"""
+    if value == "None":
         return None
     return float(value)

--- a/wps_shared/wps_shared/tests/common.py
+++ b/wps_shared/wps_shared/tests/common.py
@@ -5,11 +5,10 @@ import os
 import json
 from typing import Optional
 from contextlib import asynccontextmanager
+from wps_shared.auth import ASA_TEST_IDIR_GUID
 from wps_shared.tests.fixtures.loader import FixtureFinder
 
 logger = logging.getLogger(__name__)
-
-ASA_TEST_IDIR_GUID = "4F488A419BD843C4ABF631094C6F04A2"
 
 
 class MockJWTDecode:

--- a/wps_shared/wps_shared/tests/common.py
+++ b/wps_shared/wps_shared/tests/common.py
@@ -16,7 +16,11 @@ class MockJWTDecode:
     """Mock pyjwt module"""
 
     def __init__(self):
-        self.decoded_token = {"idir_username": "test_username", "email": "test@email.com"}
+        self.decoded_token = {
+            "idir_username": "test_username",
+            "email": "test@email.com",
+            "idir_user_guid": "test-guid",
+        }
 
     def __getitem__(self, key):
         return self.decoded_token[key]

--- a/wps_shared/wps_shared/tests/common.py
+++ b/wps_shared/wps_shared/tests/common.py
@@ -9,6 +9,8 @@ from wps_shared.tests.fixtures.loader import FixtureFinder
 
 logger = logging.getLogger(__name__)
 
+ASA_TEST_IDIR_GUID = "4F488A419BD843C4ABF631094C6F04A2"
+
 
 class MockJWTDecode:
     """Mock pyjwt module"""
@@ -35,7 +37,7 @@ class MockTestIDIRJWTDecode:
         self.decoded_token = {
             "idir_username": "test_username",
             "email": "test@email.com",
-            "idir_user_guid": "4F488A419BD843C4ABF631094C6F04A2",
+            "idir_user_guid": ASA_TEST_IDIR_GUID,
         }
 
     def __getitem__(self, key):

--- a/wps_shared/wps_shared/tests/conftest.py
+++ b/wps_shared/wps_shared/tests/conftest.py
@@ -156,7 +156,7 @@ def mock_jwt_decode(monkeypatch):
     monkeypatch.setattr("jwt.decode", mock_function)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def mock_test_idir_jwt_decode(monkeypatch):
     """Mock pyjwt's decode method to always return the blocked guid."""
 

--- a/wps_shared/wps_shared/tests/conftest.py
+++ b/wps_shared/wps_shared/tests/conftest.py
@@ -15,6 +15,7 @@ import wps_shared.utils.time
 from wps_shared import auth
 from wps_shared.tests.common import (
     MockJWTDecode,
+    MockTestIDIRJWTDecode,
     default_aiobotocore_get_session,
     default_mock_requests_get,
     default_mock_requests_post,
@@ -51,7 +52,9 @@ def mock_env(monkeypatch):
     monkeypatch.setenv("PROJECT_NAMESPACE", "project_namespace")
     monkeypatch.setenv("STATUS_CHECKER_SECRET", "some_secret")
     monkeypatch.setenv("PATRONI_CLUSTER_NAME", "some_suffix")
-    monkeypatch.setenv("ROCKET_URL_POST_MESSAGE", "https://rc-notifications-test.ca/api/v1/chat.postMessage")
+    monkeypatch.setenv(
+        "ROCKET_URL_POST_MESSAGE", "https://rc-notifications-test.ca/api/v1/chat.postMessage"
+    )
     monkeypatch.setenv("ROCKET_AUTH_TOKEN", "sometoken")
     monkeypatch.setenv("ROCKET_USER_ID", "someid")
     monkeypatch.setenv("ROCKET_CHANNEL", "#channel")
@@ -110,7 +113,9 @@ def mock_get_now(monkeypatch):
     # The default value for WeatherDataRequest cannot be mocked out, as it
     # is declared prior to test mocks being loaded. We manipulate the class
     # directly in order to have the desire default be deterministic.
-    WeatherDataRequest.__fields__["time_of_interest"].default = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    WeatherDataRequest.__fields__["time_of_interest"].default = datetime.fromtimestamp(
+        timestamp, tz=timezone.utc
+    )
 
     def mock_utc_now():
         return datetime.fromtimestamp(timestamp, tz=timezone.utc)
@@ -147,6 +152,16 @@ def mock_jwt_decode(monkeypatch):
 
     def mock_function(*args, **kwargs):
         return MockJWTDecode()
+
+    monkeypatch.setattr("jwt.decode", mock_function)
+
+
+@pytest.fixture(autouse=True)
+def mock_test_idir_jwt_decode(monkeypatch):
+    """Mock pyjwt's decode method to always return the blocked guid."""
+
+    def mock_function(*args, **kwargs):
+        return MockTestIDIRJWTDecode()
 
     monkeypatch.setattr("jwt.decode", mock_function)
 


### PR DESCRIPTION
Refactors authenticate checks to return 401 everywhere the IDIR test account guid is found, except for FBA (ASA) routes.

# Test Links:
[Landing Page](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4768-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
