### PR TITLE
Fix Keycloak Swift Plugin test destination in CI workflow

### DIFF
--- a/.github/workflows/asa_go_integration.yml
+++ b/.github/workflows/asa_go_integration.yml
@@ -59,15 +59,17 @@ jobs:
         working-directory: ./mobile/keycloak
         if: steps.asa-go-keycloak-cache.outputs.cache-hit != 'true'
         run: yarn install
-      - name: Setup Xcode and check available platforms
+      - name: Setup iOS Simulator
         run: |
           sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-          xcodebuild -version
-          xcrun simctl list runtimes
-          xcrun simctl list devices available
+          xcrun simctl list runtimes | head -20
+          xcrun simctl list devices | head -20
+          # Try to create a simple simulator
+          xcrun simctl create TestDevice "iPhone 16" || xcrun simctl create TestDevice "iPhone 15" || true
+          xcrun simctl list devices | grep TestDevice || true
       - name: Test Keycloak Swift Plugin
         working-directory: ./mobile/keycloak
-        run: xcodebuild test -scheme "Keycloak" -destination "platform=macOS,variant=Mac Catalyst" -enableCodeCoverage YES build test
+        run: xcodebuild test -scheme "Keycloak" -destination "generic/platform=iOS Simulator" -enableCodeCoverage YES build test
       - name: Upload Swift plugin test coverage to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
Update the CI workflow to use a more general iOS Simulator destination for testing the Keycloak Swift Plugin.
# Test Links:
[Landing Page](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4789-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
