### PR TITLE
ASA Go - Small screen layout

### DIFF
--- a/mobile/asa-go/src/components/profile/ElevationStatus.tsx
+++ b/mobile/asa-go/src/components/profile/ElevationStatus.tsx
@@ -47,7 +47,6 @@ const ElevationStatus = ({ tpiStats }: ElevationStatusProps) => {
               color: "#003366",
               fontWeight: "bold",
               textAlign: "left",
-              width: "50%",
             }}
           >
             Topographic Position:
@@ -59,7 +58,6 @@ const ElevationStatus = ({ tpiStats }: ElevationStatusProps) => {
               color: "#003366",
               fontWeight: "bold",
               textAlign: "right",
-              width: "65%",
             }}
           >
             Portion under advisory:

--- a/mobile/asa-go/src/components/profile/FuelSummary.tsx
+++ b/mobile/asa-go/src/components/profile/FuelSummary.tsx
@@ -174,6 +174,9 @@ const FuelSummary = ({
             "& .fuel-summary-header": {
               background: "#F1F1F1",
             },
+            "& .MuiDataGrid-sortIcon": {
+              display: "none",
+            },
           }}
         ></DataGridPro>
       )}


### PR DESCRIPTION
Small screens like the iPhone SE 2nd gen showed some layout issues on the Profile tab
closes #4807 

<img width="325" height="667" alt="image" src="https://github.com/user-attachments/assets/440205c4-db4b-4746-aa57-a2ab35db6ee2" />

<img width="461" height="717" alt="image" src="https://github.com/user-attachments/assets/643a9b0f-3644-4a2d-815a-b080d422e4f5" />

