### PR TITLE
Add push notification support

### DIFF
--- a/mobile/asa-go/ios/App/App/AppDelegate.swift
+++ b/mobile/asa-go/ios/App/App/AppDelegate.swift
@@ -11,6 +11,34 @@ class AppDelegate: UIResponder, UIApplicationDelegate, KeycloakAppDelegate {
 
     func application(
         _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+
+        let tokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        print("Device Token: \(tokenString)")
+
+        NotificationCenter.default.post(
+            name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+    }
+
+    func application(
+        _ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        NotificationCenter.default.post(
+            name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+    }
+
+    func application(
+        _ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        NotificationCenter.default.post(
+            name: Notification.Name.init("didReceiveRemoteNotification"), object: completionHandler,
+            userInfo: userInfo)
+    }
+
+    func application(
+        _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         // Override point for customization after application launch.

--- a/mobile/asa-go/ios/App/App/Info.plist
+++ b/mobile/asa-go/ios/App/App/Info.plist
@@ -18,18 +18,33 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ca.bc.gov.asago.auth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ca.bc.gov.asago</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>Your app requires access to the Documents folder for file management.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>This app needs location access to show your position and provide location-based fire advisory information.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>This app needs location access to show your position and provide location-based fire advisory information.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app needs location access to show your position and provide location-based fire advisory information.</string>
 	<key>UIBackgroundModes</key>
-	<array/>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -53,18 +68,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLName</key>
-			<string>ca.bc.gov.asago.auth</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>ca.bc.gov.asago</string>
-			</array>
-		</dict>
-	</array>
 </dict>
 </plist>

--- a/mobile/asa-go/ios/App/Podfile
+++ b/mobile/asa-go/ios/App/Podfile
@@ -17,6 +17,7 @@ def capacitor_pods
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorNetwork', :path => '../../node_modules/@capacitor/network'
+  pod 'CapacitorPushNotifications', :path => '../../node_modules/@capacitor/push-notifications'
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
   pod 'CapacitorEmailComposer', :path => '../../node_modules/capacitor-email-composer'

--- a/mobile/asa-go/ios/App/Podfile.lock
+++ b/mobile/asa-go/ios/App/Podfile.lock
@@ -14,7 +14,7 @@ PODS:
     - Capacitor
   - CapacitorFilesystem (7.0.0):
     - Capacitor
-  - CapacitorGeolocation (7.1.2):
+  - CapacitorGeolocation (7.1.4):
     - Capacitor
     - IONGeolocationLib (~> 1.0)
   - CapacitorHaptics (7.0.0):
@@ -23,7 +23,9 @@ PODS:
     - Capacitor
   - CapacitorNetwork (7.0.0):
     - Capacitor
-  - CapacitorSplashScreen (7.0.1):
+  - CapacitorPushNotifications (7.0.2):
+    - Capacitor
+  - CapacitorSplashScreen (7.0.2):
     - Capacitor
   - CapacitorStatusBar (7.0.0):
     - Capacitor
@@ -42,6 +44,7 @@ DEPENDENCIES:
   - "CapacitorHaptics (from `../../node_modules/@capacitor/haptics`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - "CapacitorNetwork (from `../../node_modules/@capacitor/network`)"
+  - "CapacitorPushNotifications (from `../../node_modules/@capacitor/push-notifications`)"
   - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
   - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
   - Keycloak (from `../../node_modules/keycloak`)
@@ -70,6 +73,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/keyboard"
   CapacitorNetwork:
     :path: "../../node_modules/@capacitor/network"
+  CapacitorPushNotifications:
+    :path: "../../node_modules/@capacitor/push-notifications"
   CapacitorSplashScreen:
     :path: "../../node_modules/@capacitor/splash-screen"
   CapacitorStatusBar:
@@ -84,15 +89,16 @@ SPEC CHECKSUMS:
   CapacitorCordova: 866217f32c1d25b326c568a10ea3ed0c36b13e29
   CapacitorEmailComposer: 5f0ae4bd516997aba61034ba4387f2a67947ce21
   CapacitorFilesystem: 2881ad012b5c8d0ffbfed1216aadfc2cca16d5b5
-  CapacitorGeolocation: 8c86a3afea574c84447c17905da96f2356ad913e
+  CapacitorGeolocation: 5583eb25815522c4b4cb38936ac7fea8a34996d9
   CapacitorHaptics: 1fba3e460e7614349c6d5f868b1fccdc5c87b66d
   CapacitorKeyboard: 2c26c6fccde35023c579fc37d4cae6326d5e6343
   CapacitorNetwork: cd17b98182841055ff58629213242a1f22f4a76b
-  CapacitorSplashScreen: 19cd3573e57507e02d6f34597a8c421e00931487
+  CapacitorPushNotifications: 6ffcf5df95f17d71a1b02893549bc4727f80540c
+  CapacitorSplashScreen: 8d6c8cb0542a8e81585c593815db8785ed8ce454
   CapacitorStatusBar: 438e90beeeefa8276b24e6c5991cb02dd13e51bf
   IONGeolocationLib: 81f33f88d025846946de2cf63b0c7628e7c6bc9d
   Keycloak: c39abe3ec71f672fbf306a7f37b85d3858ae7f00
 
-PODFILE CHECKSUM: f6bca02298de844371df6d72f4c8fdc0f670f010
+PODFILE CHECKSUM: 0bd0bc477491fc65e3564039eaa6c94b940a777b
 
 COCOAPODS: 1.16.2

--- a/mobile/asa-go/package.json
+++ b/mobile/asa-go/package.json
@@ -25,6 +25,7 @@
     "@capacitor/ios": "7.1.0",
     "@capacitor/keyboard": "7.0.0",
     "@capacitor/network": "^7.0.0",
+    "@capacitor/push-notifications": "^7.0.2",
     "@capacitor/splash-screen": "^7.0.1",
     "@capacitor/status-bar": "7.0.0",
     "@emotion/react": "^11.14.0",

--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -27,6 +27,7 @@ import { isNull, isUndefined } from "lodash";
 import { DateTime } from "luxon";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { PushNotifications } from "@capacitor/push-notifications";
 
 const ADVISORY_THRESHOLD = 20;
 
@@ -67,6 +68,33 @@ const App = () => {
       Network.removeAllListeners();
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const addListeners = async () => {
+      await PushNotifications.addListener("registration", (token) => {
+        console.info("Registration token: ", token.value);
+      });
+
+      await PushNotifications.addListener("registrationError", (err) => {
+        console.error("Registration error: ", err.error);
+      });
+    };
+    const registerNotifications = async () => {
+      let permStatus = await PushNotifications.checkPermissions();
+
+      if (permStatus.receive === "prompt") {
+        permStatus = await PushNotifications.requestPermissions();
+      }
+
+      if (permStatus.receive !== "granted") {
+        throw new Error("User denied permissions!");
+      }
+
+      await PushNotifications.register();
+    };
+    addListeners();
+    registerNotifications();
+  }, []);
 
   useEffect(() => {
     dispatch(fetchFireCenters());

--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -27,7 +27,7 @@ import { isNull, isUndefined } from "lodash";
 import { DateTime } from "luxon";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { PushNotifications } from "@capacitor/push-notifications";
+import { setupPushNotifications } from "@/notifications/setup";
 
 const ADVISORY_THRESHOLD = 20;
 
@@ -70,30 +70,7 @@ const App = () => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const addListeners = async () => {
-      await PushNotifications.addListener("registration", (token) => {
-        console.info("Registration token: ", token.value);
-      });
-
-      await PushNotifications.addListener("registrationError", (err) => {
-        console.error("Registration error: ", err.error);
-      });
-    };
-    const registerNotifications = async () => {
-      let permStatus = await PushNotifications.checkPermissions();
-
-      if (permStatus.receive === "prompt") {
-        permStatus = await PushNotifications.requestPermissions();
-      }
-
-      if (permStatus.receive !== "granted") {
-        throw new Error("User denied permissions!");
-      }
-
-      await PushNotifications.register();
-    };
-    addListeners();
-    registerNotifications();
+    setupPushNotifications();
   }, []);
 
   useEffect(() => {

--- a/mobile/asa-go/src/notifications/setup.test.ts
+++ b/mobile/asa-go/src/notifications/setup.test.ts
@@ -1,0 +1,73 @@
+import { setupPushNotifications } from "@/notifications/setup";
+import { PushNotifications } from "@capacitor/push-notifications";
+import { vi } from "vitest";
+
+describe("setup push notifications", () => {
+  vi.mock("@capacitor/push-notifications", () => ({
+    PushNotifications: {
+      register: vi.fn(),
+      checkPermissions: vi.fn(),
+      requestPermissions: vi.fn(),
+      addListener: vi.fn(),
+    },
+  }));
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(PushNotifications.checkPermissions).mockResolvedValue({
+      receive: "granted",
+    });
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: "granted",
+    });
+    vi.mocked(PushNotifications.register).mockResolvedValue();
+    vi.mocked(PushNotifications.addListener).mockResolvedValue({
+      remove: vi.fn(),
+    });
+  });
+
+  it("registers app for push notifications and checks for permissions", async () => {
+    await setupPushNotifications();
+
+    expect(PushNotifications.addListener).toHaveBeenCalledTimes(2);
+    expect(PushNotifications.addListener).toHaveBeenCalledWith(
+      "registration",
+      expect.any(Function)
+    );
+    expect(PushNotifications.addListener).toHaveBeenCalledWith(
+      "registrationError",
+      expect.any(Function)
+    );
+    expect(PushNotifications.checkPermissions).toHaveBeenCalled();
+    expect(PushNotifications.register).toHaveBeenCalled();
+  });
+
+  it("throws error when push notification permissions are denied", async () => {
+    vi.mocked(PushNotifications.checkPermissions).mockResolvedValue({
+      receive: "denied",
+    });
+
+    await expect(setupPushNotifications()).rejects.toThrow(
+      "User denied push notification permissions"
+    );
+
+    expect(PushNotifications.addListener).toHaveBeenCalledTimes(2);
+    expect(PushNotifications.checkPermissions).toHaveBeenCalled();
+    expect(PushNotifications.register).not.toHaveBeenCalled();
+  });
+
+  it("requests permissions when initially prompted", async () => {
+    vi.mocked(PushNotifications.checkPermissions).mockResolvedValue({
+      receive: "prompt",
+    });
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: "granted",
+    });
+
+    await setupPushNotifications();
+
+    expect(PushNotifications.checkPermissions).toHaveBeenCalled();
+    expect(PushNotifications.requestPermissions).toHaveBeenCalled();
+    expect(PushNotifications.register).toHaveBeenCalled();
+  });
+});

--- a/mobile/asa-go/src/notifications/setup.ts
+++ b/mobile/asa-go/src/notifications/setup.ts
@@ -1,0 +1,24 @@
+import { PushNotifications } from "@capacitor/push-notifications";
+
+export const setupPushNotifications = async () => {
+  await PushNotifications.addListener("registration", (token) => {
+    console.debug("Registration token: ", token.value);
+    console.info("Successfully registered for push notifications");
+  });
+
+  await PushNotifications.addListener("registrationError", (err) => {
+    console.error("Registration error: ", err.error);
+  });
+
+  let permStatus = await PushNotifications.checkPermissions();
+
+  if (permStatus.receive === "prompt") {
+    permStatus = await PushNotifications.requestPermissions();
+  }
+
+  if (permStatus.receive !== "granted") {
+    throw new Error("User denied push notification permissions");
+  }
+
+  await PushNotifications.register();
+};

--- a/mobile/asa-go/yarn.lock
+++ b/mobile/asa-go/yarn.lock
@@ -278,6 +278,11 @@
   resolved "https://registry.npmjs.org/@capacitor/network/-/network-7.0.0.tgz"
   integrity sha512-cIr0tElqiAKxbRJ7/OGOPssSyaVpyU8ushjcOItdYaGu/L9RAI+4tKdRCoL9cngCycgcUGWn+SkuN9oJCf8iHw==
 
+"@capacitor/push-notifications@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@capacitor/push-notifications/-/push-notifications-7.0.2.tgz#755c2eeed58626304ab72d19d08626ace89916d5"
+  integrity sha512-naw1R61V0qlEBa4CsF7+w3ay7V1PdZ4bQ1cJum+lgZB/yz3ASb6fRHm5GPjJFgTR9ET8zN0Q9y7lfgMTBgDOiA==
+
 "@capacitor/splash-screen@^7.0.1":
   version "7.0.2"
   resolved "https://registry.npmjs.org/@capacitor/splash-screen/-/splash-screen-7.0.2.tgz"


### PR DESCRIPTION
Implement push notification setup for the app side. Requests permissions from the user to allow push notifications and registers the app and device with the notification service (currently just iOS and APNs https://en.wikipedia.org/wiki/Apple_Push_Notification_service).