### PR TITLE
Add PSU API collection for Bruno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ Pods
 
 # bruno envs
 **/prod.bru
+**/local.bru

--- a/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get All Fire Centers.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get All Fire Centers.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get All Fire Centers
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{API_BASE_URL}}/fba/fire-centers
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Fire Centre Tpi Stats.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Fire Centre Tpi Stats.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Fire Centre Tpi Stats
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{API_BASE_URL}}/fba/fire-centre-tpi-stats/:run_type/:for_date/:run_datetime/:fire_centre_name
+  body: none
+  auth: bearer
+}
+
+params:path {
+  fire_centre_name: 
+  run_type: 
+  run_datetime: 
+  for_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Hfi Fuels Data For Fire Centre.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Hfi Fuels Data For Fire Centre.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Hfi Fuels Data For Fire Centre
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{API_BASE_URL}}/fba/fire-centre-hfi-stats/:run_type/:for_date/:run_datetime/:fire_centre_name
+  body: none
+  auth: bearer
+}
+
+params:path {
+  run_type: 
+  for_date: 
+  run_datetime: 
+  fire_centre_name: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Latest Sfms Run Datetime For Date.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Latest Sfms Run Datetime For Date.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Latest Sfms Run Datetime For Date
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{API_BASE_URL}}/fba/latest-sfms-run-datetime/:for_date
+  body: none
+  auth: bearer
+}
+
+params:path {
+  for_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Provincial Summary.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Provincial Summary.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get Provincial Summary
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{API_BASE_URL}}/fba/provincial-summary/:run_type/:run_datetime/:for_date
+  body: none
+  auth: none
+}
+
+params:path {
+  run_type: 
+  run_datetime: 
+  for_date: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Run Datetimes For Date And Runtype.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Run Datetimes For Date And Runtype.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Run Datetimes For Date And Runtype
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{API_BASE_URL}}/fba/sfms-run-datetimes/:run_type/:for_date
+  body: none
+  auth: bearer
+}
+
+params:path {
+  run_type: 
+  for_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Sfms Run Bounds.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Sfms Run Bounds.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Sfms Run Bounds
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{API_BASE_URL}}/fba/sfms-run-bounds
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Shapes.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Auto Spatial Advisory/Get Shapes.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get Shapes
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{API_BASE_URL}}/fba/fire-shape-areas/:run_type/:run_datetime/:for_date
+  body: none
+  auth: bearer
+}
+
+params:path {
+  run_type: 
+  run_datetime: 
+  for_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/C Haines/Get C Haines Model Run Prediction.bru
+++ b/.vscode/bruno-collections/Predictive Services API/C Haines/Get C Haines Model Run Prediction.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get C Haines Model Run Prediction
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{API_BASE_URL}}/c-haines/:model/prediction
+  body: none
+  auth: none
+}
+
+params:query {
+  ~response_format: 
+}
+
+params:path {
+  model: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/C Haines/Get C Haines Model Run.bru
+++ b/.vscode/bruno-collections/Predictive Services API/C Haines/Get C Haines Model Run.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get C Haines Model Run
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{API_BASE_URL}}/c-haines/:model/predictions
+  body: none
+  auth: none
+}
+
+params:query {
+  ~model_run_timestamp: 
+  ~response_format: 
+}
+
+params:path {
+  model: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/C Haines/Get Kml Network Link.bru
+++ b/.vscode/bruno-collections/Predictive Services API/C Haines/Get Kml Network Link.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Kml Network Link
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{API_BASE_URL}}/c-haines/network-link
+  body: none
+  auth: none
+}

--- a/.vscode/bruno-collections/Predictive Services API/C Haines/Get Model Runs.bru
+++ b/.vscode/bruno-collections/Predictive Services API/C Haines/Get Model Runs.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Model Runs
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{API_BASE_URL}}/c-haines/model-runs
+  body: none
+  auth: none
+}
+
+params:query {
+  ~model_run_timestamp: 
+  ~response_format: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/FBA Calc/Get Stations Data.bru
+++ b/.vscode/bruno-collections/Predictive Services API/FBA Calc/Get Stations Data.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Get Stations Data
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{API_BASE_URL}}/fba-calc/stations
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "date": "",
+    "stations": [
+      {
+        "id": "",
+        "station_code": 0,
+        "fuel_type": "",
+        "percentage_conifer": "",
+        "percentage_dead_balsam_fir": "",
+        "grass_cure": "",
+        "crown_base_height": "",
+        "crown_fuel_load": "",
+        "wind_speed": "",
+        "precipitation": ""
+      }
+    ]
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Fire Watch/Get All Fire Centres.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Fire Watch/Get All Fire Centres.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get All Fire Centres
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{API_BASE_URL}}/fire-watch/fire-centres
+  body: none
+  auth: none
+}

--- a/.vscode/bruno-collections/Predictive Services API/Fire Watch/Get Burn Forecasts.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Fire Watch/Get Burn Forecasts.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Burn Forecasts
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{API_BASE_URL}}/fire-watch/burn-forecasts
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Fire Watch/Get Fire Watches.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Fire Watch/Get Fire Watches.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Fire Watches
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{API_BASE_URL}}/fire-watch/
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Fire Watch/Save New Fire Watch.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Fire Watch/Save New Fire Watch.bru
@@ -1,0 +1,67 @@
+meta {
+  name: Save New Fire Watch
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_BASE_URL}}/fire-watch/watch
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "fire_watch": {
+      "burn_location": [],
+      "burn_window_end": "",
+      "burn_window_start": "",
+      "contact_email": [],
+      "fire_centre": {
+        "id": 0,
+        "name": ""
+      },
+      "station": {
+        "code": 0,
+        "name": ""
+      },
+      "status": "",
+      "title": "",
+      "fuel_type": "",
+      "percent_conifer": "",
+      "percent_dead_fir": "",
+      "percent_grass_curing": "",
+      "temp_min": "",
+      "temp_preferred": "",
+      "temp_max": "",
+      "rh_min": "",
+      "rh_preferred": "",
+      "rh_max": "",
+      "wind_speed_min": "",
+      "wind_speed_preferred": "",
+      "wind_speed_max": "",
+      "ffmc_min": "",
+      "ffmc_preferred": "",
+      "ffmc_max": "",
+      "dmc_min": "",
+      "dmc_preferred": "",
+      "dmc_max": "",
+      "dc_min": "",
+      "dc_preferred": "",
+      "dc_max": "",
+      "isi_min": "",
+      "isi_preferred": "",
+      "isi_max": "",
+      "bui_min": "",
+      "bui_preferred": "",
+      "bui_max": "",
+      "hfi_min": "",
+      "hfi_preferred": "",
+      "hfi_max": ""
+    }
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Fire Watch/Update Existing Fire Watch.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Fire Watch/Update Existing Fire Watch.bru
@@ -1,0 +1,71 @@
+meta {
+  name: Update Existing Fire Watch
+  type: http
+  seq: 3
+}
+
+patch {
+  url: {{API_BASE_URL}}/fire-watch/watch/:fire_watch_id
+  body: json
+  auth: bearer
+}
+
+params:path {
+  fire_watch_id: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "fire_watch": {
+      "burn_location": [],
+      "burn_window_end": "",
+      "burn_window_start": "",
+      "contact_email": [],
+      "fire_centre": {
+        "id": 0,
+        "name": ""
+      },
+      "station": {
+        "code": 0,
+        "name": ""
+      },
+      "status": "",
+      "title": "",
+      "fuel_type": "",
+      "percent_conifer": "",
+      "percent_dead_fir": "",
+      "percent_grass_curing": "",
+      "temp_min": "",
+      "temp_preferred": "",
+      "temp_max": "",
+      "rh_min": "",
+      "rh_preferred": "",
+      "rh_max": "",
+      "wind_speed_min": "",
+      "wind_speed_preferred": "",
+      "wind_speed_max": "",
+      "ffmc_min": "",
+      "ffmc_preferred": "",
+      "ffmc_max": "",
+      "dmc_min": "",
+      "dmc_preferred": "",
+      "dmc_max": "",
+      "dc_min": "",
+      "dc_preferred": "",
+      "dc_max": "",
+      "isi_min": "",
+      "isi_preferred": "",
+      "isi_max": "",
+      "bui_min": "",
+      "bui_preferred": "",
+      "bui_max": "",
+      "hfi_min": "",
+      "hfi_preferred": "",
+      "hfi_max": ""
+    }
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Forecasts/Get Noon Forecasts Summaries.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Forecasts/Get Noon Forecasts Summaries.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Noon Forecasts Summaries
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_BASE_URL}}/forecasts/noon/summaries/
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "stations": [],
+    "time_of_interest": ""
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Forecasts/Get Noon Forecasts.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Forecasts/Get Noon Forecasts.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Noon Forecasts
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{API_BASE_URL}}/forecasts/noon/
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "stations": [],
+    "time_of_interest": ""
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Get Health.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Get Health.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Health
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{API_BASE_URL}}/health
+  body: none
+  auth: none
+}

--- a/.vscode/bruno-collections/Predictive Services API/Get Hourlies.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Get Hourlies.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Hourlies
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{API_BASE_URL}}/observations/
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "stations": [],
+    "time_of_interest": ""
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Get Percentiles.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Get Percentiles.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Percentiles
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{API_BASE_URL}}/percentiles/
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "stations": [],
+    "percentile": 0,
+    "year_range": {
+      "start": 0,
+      "end": 0
+    }
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Get Ready.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Get Ready.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Ready
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{API_BASE_URL}}/ready
+  body: none
+  auth: none
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Admin Update Stations.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Admin Update Stations.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Admin Update Stations
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{API_BASE_URL}}/hfi-calc/admin/stations
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "fire_centre_id": 0,
+    "added": [
+      {
+        "planning_area_id": 0,
+        "station_code": 0,
+        "fuel_type_id": 0
+      }
+    ],
+    "removed": [
+      {
+        "planning_area_id": 0,
+        "station_code": 0,
+        "row_id": 0
+      }
+    ]
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Get All Ready Records.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Get All Ready Records.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get All Ready Records
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{API_BASE_URL}}/hfi-calc/fire_centre/:fire_centre_id/:start_date/:end_date/ready
+  body: none
+  auth: bearer
+}
+
+params:path {
+  fire_centre_id: 
+  start_date: 
+  end_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Get Fire Centres.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Get Fire Centres.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Fire Centres
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{API_BASE_URL}}/hfi-calc/fire-centres
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Get Fuel Types.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Get Fuel Types.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Fuel Types
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{API_BASE_URL}}/hfi-calc/fuel_types
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Get Hfi Result With Date.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Get Hfi Result With Date.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get Hfi Result With Date
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{API_BASE_URL}}/hfi-calc/fire_centre/:fire_centre_id/:start_date/:end_date
+  body: none
+  auth: bearer
+}
+
+params:path {
+  fire_centre_id: 
+  start_date: 
+  end_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Get Hfi Result.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Get Hfi Result.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Hfi Result
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{API_BASE_URL}}/hfi-calc/fire_centre/:fire_centre_id
+  body: none
+  auth: bearer
+}
+
+params:path {
+  fire_centre_id: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Get Pdf.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Get Pdf.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get Pdf
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{API_BASE_URL}}/hfi-calc/fire_centre/:fire_centre_id/:start_date/:end_date/pdf
+  body: none
+  auth: none
+}
+
+params:path {
+  fire_centre_id: 
+  start_date: 
+  end_date: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Set Fire Start Range.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Set Fire Start Range.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Set Fire Start Range
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{API_BASE_URL}}/hfi-calc/fire_centre/:fire_centre_id/:start_date/:end_date/planning_area/:planning_area_id/fire_starts/:prep_day_date/fire_start_range/:fire_start_range_id
+  body: none
+  auth: none
+}
+
+params:path {
+  fire_centre_id: 
+  start_date: 
+  end_date: 
+  planning_area_id: 
+  prep_day_date: 
+  fire_start_range_id: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Set Planning Area Station Fuel Type.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Set Planning Area Station Fuel Type.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Set Planning Area Station Fuel Type
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{API_BASE_URL}}/hfi-calc/fire_centre/:fire_centre_id/:start_date/:end_date/planning_area/:planning_area_id/station/:station_code/fuel_type/:fuel_type_id
+  body: none
+  auth: bearer
+}
+
+params:path {
+  fire_centre_id: 
+  start_date: 
+  end_date: 
+  planning_area_id: 
+  station_code: 
+  fuel_type_id: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Set Planning Area Station.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Set Planning Area Station.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Set Planning Area Station
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_BASE_URL}}/hfi-calc/fire_centre/:fire_centre_id/:start_date/:end_date/planning_area/:planning_area_id/station/:station_code/selected/:enable
+  body: none
+  auth: bearer
+}
+
+params:path {
+  fire_centre_id: 
+  start_date: 
+  end_date: 
+  planning_area_id: 
+  station_code: 
+  enable: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/HFI/Toggle Planning Area Ready.bru
+++ b/.vscode/bruno-collections/Predictive Services API/HFI/Toggle Planning Area Ready.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Toggle Planning Area Ready
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{API_BASE_URL}}/hfi-calc/fire_centre/:fire_centre_id/planning_area/:planning_area_id/:start_date/:end_date/ready
+  body: none
+  auth: bearer
+}
+
+params:path {
+  fire_centre_id: 
+  planning_area_id: 
+  start_date: 
+  end_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Determinates For Date Range.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Determinates For Date Range.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Determinates For Date Range
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{API_BASE_URL}}/morecast-v2/determinates/:start_date/:end_date
+  body: json
+  auth: bearer
+}
+
+params:path {
+  start_date: 
+  end_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "stations": []
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Forecasts By Date Range.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Forecasts By Date Range.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Forecasts By Date Range
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_BASE_URL}}/morecast-v2/forecasts/:start_date/:end_date
+  body: json
+  auth: bearer
+}
+
+params:path {
+  start_date: 
+  end_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "stations": []
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Forecasts For Date And User.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Forecasts For Date And User.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Forecasts For Date And User
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{API_BASE_URL}}/morecast-v2/forecasts/:for_date
+  body: none
+  auth: bearer
+}
+
+params:path {
+  for_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Observed Dailies.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Observed Dailies.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Observed Dailies
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{API_BASE_URL}}/morecast-v2/observed-dailies/:start_date/:end_date
+  body: json
+  auth: bearer
+}
+
+params:path {
+  start_date: 
+  end_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "station_codes": []
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Yesterdays Actual Dailies.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Morecast v2/Get Yesterdays Actual Dailies.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get Yesterdays Actual Dailies
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{API_BASE_URL}}/morecast-v2/yesterday-dailies/:today
+  body: json
+  auth: bearer
+}
+
+params:path {
+  today: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "station_codes": []
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Morecast v2/Save Forecasts.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Morecast v2/Save Forecasts.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Save Forecasts
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{API_BASE_URL}}/morecast-v2/forecast
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "forecasts": [
+      {
+        "station_code": 0,
+        "for_date": 0,
+        "temp": "",
+        "rh": "",
+        "precip": "",
+        "wind_speed": "",
+        "wind_direction": "",
+        "grass_curing": ""
+      }
+    ]
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/SFMS Insights/Get Most Recent By Date.bru
+++ b/.vscode/bruno-collections/Predictive Services API/SFMS Insights/Get Most Recent By Date.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Most Recent By Date
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{API_BASE_URL}}/snow/most-recent-by-date/:for_date
+  body: none
+  auth: bearer
+}
+
+params:path {
+  for_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/SFMS/Get Hourlies.bru
+++ b/.vscode/bruno-collections/Predictive Services API/SFMS/Get Hourlies.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Hourlies
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{API_BASE_URL}}/sfms/hourlies
+  body: none
+  auth: none
+}

--- a/.vscode/bruno-collections/Predictive Services API/SFMS/Upload Hourlies.bru
+++ b/.vscode/bruno-collections/Predictive Services API/SFMS/Upload Hourlies.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Upload Hourlies
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_BASE_URL}}/sfms/upload/hourlies
+  body: multipartForm
+  auth: none
+}
+
+body:multipart-form {
+  file: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/SFMS/Upload Manual Msg.bru
+++ b/.vscode/bruno-collections/Predictive Services API/SFMS/Upload Manual Msg.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Upload Manual Msg
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{API_BASE_URL}}/sfms/manual/msgOnly
+  body: json
+  auth: none
+}
+
+headers {
+  ~secret: 
+}
+
+body:json {
+  {
+    "key": "",
+    "for_date": "",
+    "runtype": "",
+    "run_date": ""
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/SFMS/Upload Manual.bru
+++ b/.vscode/bruno-collections/Predictive Services API/SFMS/Upload Manual.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Upload Manual
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{API_BASE_URL}}/sfms/manual
+  body: multipartForm
+  auth: none
+}
+
+body:multipart-form {
+  file: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/SFMS/Upload.bru
+++ b/.vscode/bruno-collections/Predictive Services API/SFMS/Upload.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Upload
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{API_BASE_URL}}/sfms/upload
+  body: multipartForm
+  auth: none
+}
+
+body:multipart-form {
+  file: 
+}

--- a/.vscode/bruno-collections/Predictive Services API/Stations/Get Detailed Stations.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Stations/Get Detailed Stations.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Detailed Stations
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{API_BASE_URL}}/stations/details/
+  body: none
+  auth: bearer
+}
+
+params:query {
+  ~toi: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Stations/Get Station Groups.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Stations/Get Station Groups.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Station Groups
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{API_BASE_URL}}/stations/groups
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/.vscode/bruno-collections/Predictive Services API/Stations/Get Stations By Group Ids.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Stations/Get Stations By Group Ids.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get Stations By Group Ids
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{API_BASE_URL}}/stations/groups/members
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "group_ids": []
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Stations/Get Stations.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Stations/Get Stations.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Stations
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{API_BASE_URL}}/stations/
+  body: none
+  auth: none
+}

--- a/.vscode/bruno-collections/Predictive Services API/Weather Models/Get Model Prediction Summaries.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Weather Models/Get Model Prediction Summaries.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Model Prediction Summaries
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{API_BASE_URL}}/weather_models/:model/predictions/summaries/
+  body: json
+  auth: bearer
+}
+
+params:path {
+  model: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "stations": [],
+    "time_of_interest": ""
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Weather Models/Get Model Values For Date Range.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Weather Models/Get Model Values For Date Range.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Get Model Values For Date Range
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{API_BASE_URL}}/weather_models/:model/predictions/most_recent/:start_date/:end_date
+  body: json
+  auth: bearer
+}
+
+params:path {
+  model: 
+  start_date: 
+  end_date: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "stations": []
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/Weather Models/Get Most Recent Model Values.bru
+++ b/.vscode/bruno-collections/Predictive Services API/Weather Models/Get Most Recent Model Values.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Most Recent Model Values
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_BASE_URL}}/weather_models/:model/predictions/most_recent/
+  body: json
+  auth: bearer
+}
+
+params:path {
+  model: 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "stations": [],
+    "time_of_interest": ""
+  }
+}

--- a/.vscode/bruno-collections/Predictive Services API/bruno.json
+++ b/.vscode/bruno-collections/Predictive Services API/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "Predictive Services API",
+  "type": "collection"
+}

--- a/.vscode/bruno-collections/Predictive Services API/environments/local.sample.bru
+++ b/.vscode/bruno-collections/Predictive Services API/environments/local.sample.bru
@@ -1,0 +1,6 @@
+vars {
+  API_BASE_URL: 0.0.0.0:8080/api
+}
+vars:secret [
+  AUTH_TOKEN
+]


### PR DESCRIPTION
Bruno supports importing a collection from an openapi spec so I did that with the PSU API from https://psu.nrs.gov.bc.ca/api/openapi.json

Same pattern as WF1 collection, copy `local.sample.bru` to `local.bru` and edit as need be for variables.
# Test Links:
[Landing Page](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4896-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
