### PR TITLE
Fix typescript errors in tests

### DIFF
--- a/mobile/asa-go/src/components/report/fireZoneUnitTabs.test.tsx
+++ b/mobile/asa-go/src/components/report/fireZoneUnitTabs.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import FireZoneUnitTabs from "@/components/report/FireZoneUnitTabs";
 import { FireCenter, FireShape } from "@/api/fbaAPI";
+import { DateTime } from "luxon";
 
 // Mock calculateStatusColour
 vi.mock("@/utils/calculateZoneStatus", () => ({
@@ -30,7 +31,7 @@ describe("FireZoneUnitTabs", () => {
   const mockFireCenter: FireCenter = {
     id: 1,
     name: "Fire Center 1",
-    stations: []
+    stations: [],
   };
 
   const mockFireShape: FireShape = {
@@ -52,6 +53,7 @@ describe("FireZoneUnitTabs", () => {
         selectedFireCenter={mockFireCenter}
         selectedFireZoneUnit={mockFireShape}
         setSelectedFireZoneUnit={setSelectedFireZoneUnit}
+        date={DateTime.now()}
       >
         <div data-testid="child-content">Child Content</div>
       </FireZoneUnitTabs>
@@ -69,6 +71,7 @@ describe("FireZoneUnitTabs", () => {
         selectedFireCenter={mockFireCenter}
         selectedFireZoneUnit={mockFireShape}
         setSelectedFireZoneUnit={setSelectedFireZoneUnit}
+        date={DateTime.now()}
       >
         <div />
       </FireZoneUnitTabs>

--- a/mobile/asa-go/src/slices/dataSlice.test.ts
+++ b/mobile/asa-go/src/slices/dataSlice.test.ts
@@ -318,7 +318,7 @@ describe("data reducer", () => {
 
 describe("fetchAndCacheData thunk", () => {
   const mockCacheWithData = () => {
-    (readFromFilesystem as Mock).mockImplementation((filesystem, key) => {
+    (readFromFilesystem as Mock).mockImplementation((_filesystem, key) => {
       switch (key) {
         case PROVINCIAL_SUMMARY_KEY:
           return {

--- a/mobile/asa-go/src/slices/fireCentersSlice.test.ts
+++ b/mobile/asa-go/src/slices/fireCentersSlice.test.ts
@@ -66,13 +66,13 @@ describe("fetchFireCenters thunk", () => {
     stations: [],
   };
   const mockCacheWithNoData = () => {
-    (readFromFilesystem as Mock).mockImplementation((filesystem, key) => {
+    (readFromFilesystem as Mock).mockImplementation(() => {
       console.log("Reading from null file system");
       return null;
     });
   };
   const mockCacheWithData = (isStale: boolean) => {
-    (readFromFilesystem as Mock).mockImplementation((filesystem, key) => {
+    (readFromFilesystem as Mock).mockImplementation((_filesystem, key) => {
       if (key === FIRE_CENTERS_KEY) {
         return {
           lastUpdated: isStale ? yesterday : today,


### PR DESCRIPTION
A few fixes for recently introduced typescript errors in tests.

# Test Links:
[Landing Page](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4921-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
