### PR TITLE
Fix: Configure GDAL AWS credentials for fuel type areas job

### DIFF
--- a/backend/packages/wps-api/src/app/jobs/fuel_type_areas_per_zone.py
+++ b/backend/packages/wps-api/src/app/jobs/fuel_type_areas_per_zone.py
@@ -21,6 +21,7 @@ from wps_shared.geospatial.fuel_raster import get_versioned_fuel_raster_key
 from wps_shared.geospatial.geospatial import prepare_wkt_geom_for_gdal
 from wps_shared.rocketchat_notifications import send_rocketchat_notification
 from wps_shared.sfms.raster_addresser import RasterKeyAddresser
+from wps_shared.utils.s3 import set_s3_gdal_config
 from wps_shared.utils.time import get_utc_now
 from wps_shared.wps_logging import configure_logging
 
@@ -54,6 +55,7 @@ class FuelTypeAreasJob:
         """
         Entry point for calculating the area of each fuel type in each fire zone unit.
         """
+        set_s3_gdal_config()
         async with get_async_write_session_scope() as session:
             fuel_type_raster = await get_processed_fuel_raster_details(session, year, version)
             fuel_raster_key = get_versioned_fuel_raster_key(


### PR DESCRIPTION
GDAL requires AWS credentials to be explicitly configured via SetConfigOption before accessing S3 resources. This pattern was already used throughout the codebase but was missing from this job. I assume with the update these weren't being picked up automatically anymore.