### PR TITLE
Fix Docker base image publish failure across UTC midnight

### DIFF
--- a/.github/workflows/publish_docker_base.yml
+++ b/.github/workflows/publish_docker_base.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Build and Publish Base Image
         run: |
           cd openshift/wps-api-base/docker
-          docker build . --tag ghcr.io/bcgov/wps/wps-api-base:$(date +%m-%d-%Y)
-          docker tag ghcr.io/bcgov/wps/wps-api-base:$(date +%m-%d-%Y) ghcr.io/bcgov/wps/wps-api-base:latest
-          docker push ghcr.io/bcgov/wps/wps-api-base:$(date +%m-%d-%Y)
+          DATE_TAG=$(date +%m-%d-%Y)
+          docker build . --tag ghcr.io/bcgov/wps/wps-api-base:${DATE_TAG}
+          docker tag ghcr.io/bcgov/wps/wps-api-base:${DATE_TAG} ghcr.io/bcgov/wps/wps-api-base:latest
+          docker push ghcr.io/bcgov/wps/wps-api-base:${DATE_TAG}
           docker push ghcr.io/bcgov/wps/wps-api-base:latest


### PR DESCRIPTION
  **Bug:**
  Docker build fails when workflow runs across UTC midnight boundary. The `$(date +%m-%d-%Y)` command is called multiple times, causing the image to be built with one date tag (e.g., `01-06-2026`) but pushed with a different tag (e.g., `01-07-2026`), resulting in "No such image" error. This happened here: https://github.com/bcgov/wps/actions/runs/20765643305/job/59631041587

  **Fix:**
  Capture date once at the start of the script and reuse the `DATE_TAG` variable throughout to ensure consistent tagging across build, tag, and push operations.
# Test Links:
[Landing Page](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-4997-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
