### PR TITLE
Add snow layer date to checkbox label

### DIFF
--- a/web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
+++ b/web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
@@ -96,7 +96,7 @@ describe('SFMSInsightsPage', () => {
   it('should render the snow checkbox', async () => {
     renderWithStore(<SFMSInsightsPage />)
     await waitFor(() => {
-      const checkbox = screen.getByRole('checkbox', { name: /show snow/i })
+      const checkbox = screen.getByRole('checkbox', { name: /show latest snow/i })
       expect(checkbox).toBeInTheDocument()
     })
   })
@@ -104,7 +104,7 @@ describe('SFMSInsightsPage', () => {
   it('should have the snow checkbox checked by default', async () => {
     renderWithStore(<SFMSInsightsPage />)
     await waitFor(() => {
-      const checkbox = screen.getByRole('checkbox', { name: /show snow/i }) as HTMLInputElement
+      const checkbox = screen.getByRole('checkbox', { name: /show latest snow/i }) as HTMLInputElement
       expect(checkbox.checked).toBe(true)
     })
   })
@@ -113,11 +113,11 @@ describe('SFMSInsightsPage', () => {
     renderWithStore(<SFMSInsightsPage />)
 
     await waitFor(() => {
-      const checkbox = screen.getByRole('checkbox', { name: /show snow/i })
+      const checkbox = screen.getByRole('checkbox', { name: /show latest snow/i })
       expect(checkbox).toBeInTheDocument()
     })
 
-    const checkbox = screen.getByRole('checkbox', { name: /show snow/i }) as HTMLInputElement
+    const checkbox = screen.getByRole('checkbox', { name: /show latest snow/i }) as HTMLInputElement
     expect(checkbox.checked).toBe(true)
 
     fireEvent.click(checkbox)
@@ -138,7 +138,7 @@ describe('SFMSInsightsPage', () => {
 
   it('should pass showSnow=false to SFMSMap when checkbox is unchecked', async () => {
     renderWithStore(<SFMSInsightsPage />)
-    const checkbox = screen.getByRole('checkbox', { name: /show snow/i })
+    const checkbox = screen.getByRole('checkbox', { name: /show latest snow/i })
 
     fireEvent.click(checkbox)
 
@@ -153,7 +153,7 @@ describe('SFMSInsightsPage', () => {
 
     await waitFor(() => {
       const rasterDropdown = screen.getByTestId('raster-type-dropdown')
-      const snowCheckbox = screen.getByRole('checkbox', { name: /show snow/i })
+      const snowCheckbox = screen.getByRole('checkbox', { name: /show latest snow/i })
 
       expect(rasterDropdown).toBeInTheDocument()
       expect(snowCheckbox).toBeInTheDocument()
@@ -182,18 +182,18 @@ describe('SFMSInsightsPage', () => {
     renderWithStore(<SFMSInsightsPage />)
 
     await waitFor(() => {
-      const checkbox = screen.getByRole('checkbox', { name: /show snow \(nov 2, 2025\)/i })
+      const checkbox = screen.getByRole('checkbox', { name: /show latest snow: nov 2, 2025/i })
       expect(checkbox).toBeInTheDocument()
     })
   })
 
-  it('should display "Show Snow" without date when no snow data available', async () => {
+  it('should display "Show Latest Snow" without date when no snow data available', async () => {
     ;(getMostRecentProcessedSnowByDate as Mock).mockResolvedValue(null)
 
     renderWithStore(<SFMSInsightsPage />)
 
     await waitFor(() => {
-      const checkbox = screen.getByRole('checkbox', { name: 'Show Snow' })
+      const checkbox = screen.getByRole('checkbox', { name: 'Show Latest Snow' })
       expect(checkbox).toBeInTheDocument()
     })
   })

--- a/web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
+++ b/web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
@@ -71,7 +71,7 @@ export const SFMSInsightsPage = () => {
           <Grid item>
             <FormControlLabel
               control={<Checkbox checked={showSnow} onChange={e => setShowSnow(e.target.checked)} />}
-              label={snowDate ? `Show Snow (${snowDate.toLocaleString(DateTime.DATE_MED)})` : 'Show Snow'}
+              label={snowDate ? `Show Latest Snow: ${snowDate.toLocaleString(DateTime.DATE_MED)}` : 'Show Latest Snow'}
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
  - Updated "Show Snow" checkbox label to display the snow data date (e.g., "Show Latest Snow: Nov 2, 2025")
  - Falls back to "Show Snow" when no snow data is available
  - Uses Luxon's DATE_MED format for user-friendly date display
# Test Links:
[Landing Page](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5001-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
