### PR TITLE
Fix sequence name for processed_model_run_urls table

### DIFF
--- a/backend/packages/wps-api/alembic/versions/9bb0dc8ed7fb_initial_schema.py
+++ b/backend/packages/wps-api/alembic/versions/9bb0dc8ed7fb_initial_schema.py
@@ -359,6 +359,9 @@ def upgrade():
     op.create_index(
         op.f("ix_processed_model_run_urls_url"), "processed_model_run_urls", ["url"], unique=True
     )
+    op.execute(
+        "ALTER SEQUENCE processed_model_run_urls_id_seq RENAME TO processed_model_run_url_id_seq"
+    )
     op.create_table(
         "processed_snow",
         sa.Column("id", sa.Integer(), nullable=False),


### PR DESCRIPTION
Sequences are typically named as {table_name}_{field}_seq.
A sequence is manually defined in the `processed_model_run` table definition as follows:

`Sequence("processed_model_run_url_id_seq")` which is missing  a 's' after 'url'. This only causes issues for new deployments but is easily fixed with an addition to the initial alembic migration.

# Test Links:
[Landing Page](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5005-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
