### PR TITLE
Round MODIS projection origin coords

### DIFF
--- a/backend/packages/wps-api/src/app/jobs/viirs_snow.py
+++ b/backend/packages/wps-api/src/app/jobs/viirs_snow.py
@@ -39,7 +39,7 @@ BBOX = (-139.06, 48.3, -114.03, 60.0)
 R_SPHERE = 6371007.181  # meters
 TILE_SIZE_M = 1111950.519  # meters (tile width/height)
 GLOBAL_ULX = -20015109
-GLOBAL_ULY = 10007555
+GLOBAL_ULY = 10007554
 MODIS_SINUSOIDAL_PROJ4 = "+proj=sinu +R=6371007.181 +nadgrids=@null +wktext +units=m +no_defs"
 RESAMPLING = "near"
 SUBDATASET = "://HDFEOS/GRIDS/VIIRS_Grid_IMG_2D/Data_Fields/CGF_NDSI_Snow_Cover"


### PR DESCRIPTION
Snow coverage outputs are seeing some very coarse resolutions over northern Vancouver Island due to rounding/floating point math. This PR sets the MODIS projection origin to rounded integers as specified by NASA.

# Test Links:
[Landing Page](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5099-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
