### PR TITLE
Fix alembic migrations

### DIFF
--- a/backend/packages/wps-api/alembic/env.py
+++ b/backend/packages/wps-api/alembic/env.py
@@ -79,37 +79,6 @@ def run_migrations_offline():
 
 
 def do_run_migrations(connection):
-    """Run migrations with automatic stamping for production databases."""
-    import os
-    from alembic.script import ScriptDirectory
-    from alembic.migration import MigrationContext
-
-    # Check if we should auto-stamp (production only)
-    is_production = os.getenv("ENVIRONMENT", "").lower() in ("production", "prod")
-
-    if is_production:
-        # Get current database version
-        migration_context = MigrationContext.configure(connection)
-        current_rev = migration_context.get_current_revision()
-
-        # d276ba9eed1f is the last migration before compression
-        # If production database is at this revision, stamp to last commit of the squashed migrations, then run any further migrations
-        if current_rev == "d276ba9eed1f":
-            script = ScriptDirectory.from_config(config)
-            head_revision = script.get_current_head()
-
-            # Ensure head is the expected compressed migration (seed data)
-            assert head_revision == "cf8397b26783", (
-                f"Expected head revision cf8397b26783 but got {head_revision}"
-            )
-
-            # Stamp the database to the seed application data migration, it should run the migrations after it
-            connection.execute(
-                sqlalchemy.text("UPDATE alembic_version SET version_num = '6157a8d08f28'")
-            )
-            connection.commit()
-            print(f"✓ Production database stamped from {current_rev} to 6157a8d08f28")
-
     context.configure(connection=connection, target_metadata=target_metadata)
 
     with context.begin_transaction():


### PR DESCRIPTION
Removes the code for stamping prod with a specific alembic version which messes with the `context`.
# Test Links:
[Landing Page](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5118-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
