### PR TITLE
Conditional Image Promotion

### DIFF
--- a/openshift/scripts/oc_promote.sh
+++ b/openshift/scripts/oc_promote.sh
@@ -35,10 +35,12 @@ tag_if_exists_or_fail() {
         if [ "${MODULE_NAME}" = "weather" ]; then
             echo "Image ${SOURCE} not found (allowed for weather module) — skipping."
         else
-            echo "ERROR: Image ${SOURCE} not found."
+            echo "ERROR: Image ${SOURCE} not found." >&2
             exit 1
         fi
     fi
+
+	return 0
 }
 
 IMG_DEST="${APP_NAME}-${MODULE_NAME}-${TAG_PROD}"


### PR DESCRIPTION
Some minor changes to `oc_promote.sh` to allow the `weather` image to not exist, since we don't always build it if nothing has changed in the `wps-weather` package

# Test Links:
[Landing Page](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5137-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
