### PR TITLE
Fix session variable shadowing in grass curing job

### DIFF
--- a/backend/packages/wps-api/src/app/jobs/grass_curing.py
+++ b/backend/packages/wps-api/src/app/jobs/grass_curing.py
@@ -113,8 +113,8 @@ class GrassCuringJob():
 
                 # Open the reprojected grass curing data
                 raster = gdal.Open(f"{temp_dir}/{GRASS_CURING_FILE_NAME_4326}")
-                async with ClientSession() as session:
-                    wfwx_api = WfwxApi(session)
+                async with ClientSession() as http_session:
+                    wfwx_api = WfwxApi(http_session)
                     stations = await wfwx_api.get_station_data()
                 for station, value in self._yield_value_for_stations(raster, stations):
                     percent_grass_curing = PercentGrassCuring(for_date=today,


### PR DESCRIPTION
`ClientSession()` on line 116 shadowed the DB `session` from line 107, causing `save_percent_grass_curing` to receive an HTTP client instead of a SQLAlchemy session. Renamed to `http_session`.
# Test Links:
[Landing Page](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5144-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
