### PR TITLE
Exclude 4 panel charts from sonarcloud

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -11,12 +11,12 @@ sonar.python.version=3.10
 # Path is relative to the sonar-project.properties file. Defaults to .
 sonar.sources=.
 
-sonar.exclusions=**/Makefile, **/*.Dockerfile, api/app/data/**, api/alembic/versions/**, sfms/**, tileserv/alembic/**, tileserv/models/**
+sonar.exclusions=**/Makefile, **/*.Dockerfile, backend/packages/wps-api/src/app/data/**, backend/packages/wps-api/alembic/versions/**, sfms/**, backend/packages/wps-weather/src/wx_4panel_charts/**
 sonar.test.exclusions=*.feature
 sonar.tests.inclusions=**/*.test.tsx
 
-# Exclude duplication in fba tests due to many similar calculation numbers, ignore sample code as it's temporary, ignore sfms entrypoint, ignore util tests, ignore temporary fwi folder
-sonar.cpd.exclusions=api/app/tests/fba_calc/*.py, api/app/weather_models/wind_direction_sample.py, web/src/features/moreCast2/util.test.ts, web/src/features/moreCast2/components/gridComponentRenderer.test.tsx, web/src/utils/fwi, mobile/asa-go/src/**, mobile/asa-go/**/*.test.tsx, mobile/asa-go/**/*.test.ts, backend/packages/wps-api/alembic/versions/archive/**
+# Exclude duplication in fba tests due to many similar calculation numbers, ignore sample code as it's temporary, ignore sfms entrypoint, ignore util tests, ignore temporary fwi folder, ignore 4 panel chart code
+sonar.cpd.exclusions=backend/packages/wps-api/app/tests/fba_calc/*.py, backend/packages/wps-api/app/weather_models/wind_direction_sample.py, web/src/features/moreCast2/util.test.ts, web/src/features/moreCast2/components/gridComponentRenderer.test.tsx, web/src/utils/fwi, mobile/asa-go/src/**, mobile/asa-go/**/*.test.tsx, mobile/asa-go/**/*.test.ts, backend/packages/wps-api/alembic/versions/archive/**
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- exclude 4 panel charts from sonar cloud
- update paths in `.sonarcloud.properties` to account for code shuffling with when switching to `uv`
# Test Links:
[Landing Page](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5158-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
