### PR TITLE
Handle adjusted FWI error

### DIFF
--- a/backend/packages/wps-api/src/app/fire_behaviour/fwi_adjust.py
+++ b/backend/packages/wps-api/src/app/fire_behaviour/fwi_adjust.py
@@ -61,6 +61,11 @@ def calculate_adjusted_fwi_result(
     )
     isi = cffdrs.initial_spread_index(ffmc, wind_speed)
     fwi = cffdrs.fire_weather_index(isi, bui)
+
+    missing = [name for name, val in (("ffmc", ffmc), ("bui", bui), ("isi", isi), ("fwi", fwi)) if val is None]
+    if missing:
+        raise ValueError(f"Insufficient weather data for station — could not compute: {', '.join(missing)}")
+
     return AdjustedFWIResult(
         ffmc=ffmc,
         isi=isi,

--- a/backend/packages/wps-api/src/app/tests/fire_behavior/test_fwi_adjust.py
+++ b/backend/packages/wps-api/src/app/tests/fire_behavior/test_fwi_adjust.py
@@ -1,6 +1,8 @@
 import math
 from datetime import datetime
 
+import pytest
+
 from app.fire_behaviour.fwi_adjust import calculate_adjusted_fwi_result
 from wps_shared.fuel_types import FuelTypeEnum
 from wps_shared.schemas.fba_calc import StationRequest
@@ -95,3 +97,23 @@ def test_adjusted_fwi_result_with_precipitation():
     assert math.isclose(adjusted_fwi_result.wind_speed, 1.0, abs_tol=0.001)
     assert math.isclose(adjusted_fwi_result.fwi, 0.0, abs_tol=0.001)
     assert adjusted_fwi_result.status == "ADJUSTED"
+
+
+def test_adjusted_fwi_result_raises_when_weather_data_missing():
+    raw_daily_missing = {
+        "duffMoistureCode": None,
+        "droughtCode": None,
+        "temperature": None,
+        "relativeHumidity": None,
+        "precipitation": None,
+        "windSpeed": None,
+        "recordType": {"id": "ACTUAL"},
+    }
+    with pytest.raises(ValueError, match="Insufficient weather data"):
+        calculate_adjusted_fwi_result(
+            requested_station=StationRequest(station_code=1, fuel_type=FuelTypeEnum.C2),
+            wfwx_station=station_1,
+            time_of_interest=time_of_interest,
+            yesterday={},
+            raw_daily=raw_daily_missing,
+        )


### PR DESCRIPTION
When a station has missing weather data, ffmc/bui/isi/fwi all return `None` from the FWI chain functions. This caused a Pydantic `ValidationError` when constructing `AdjustedFWIResult`, which was caught and logged as critical — making it look like a code bug rather than a data availability issue.

This PR raises a `ValueError` with a clear message, that's handled and logged, before hitting `Pydantic`, so the log reflects what actually happened. Behaviour for end users is unchanged (the exception is still caught and returns an error station response).