### PR TITLE
ESlint web fixes

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -1,11 +1,17 @@
-const { fixupConfigRules, fixupPluginRules } = require('@eslint/compat')
-const typescriptEslint = require('@typescript-eslint/eslint-plugin')
-const prettier = require('eslint-plugin-prettier')
-const react = require('eslint-plugin-react')
-const globals = require('globals')
-const tsParser = require('@typescript-eslint/parser')
-const js = require('@eslint/js')
-const { FlatCompat } = require('@eslint/eslintrc')
+import js from '@eslint/js'
+import { fixupConfigRules, fixupPluginRules } from '@eslint/compat'
+import { FlatCompat } from '@eslint/eslintrc'
+import tsParser from '@typescript-eslint/parser'
+import typescriptEslint from '@typescript-eslint/eslint-plugin'
+import globals from 'globals'
+import path from 'node:path'
+import prettier from 'eslint-plugin-prettier'
+import react from 'eslint-plugin-react'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const srcFiles = ['src/**/*.{ts,tsx}']
 
 const compat = new FlatCompat({
   baseDirectory: __dirname,
@@ -13,24 +19,27 @@ const compat = new FlatCompat({
   allConfig: js.configs.all
 })
 
-module.export = [
-  {
-    files: './src/**/*.{ts,tsx}'
-  },
+const compatConfigs = compat
+  .extends(
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended'
+  )
+  .map(config => ({
+    ...config,
+    files: srcFiles
+  }))
+
+export default [
   {
     ignores: ['src/serviceWorker.ts', 'src/**/__tests__/**/*', 'src/**/*.stories.tsx', 'src/types/**/*', '**/cypress/']
   },
-  ...fixupConfigRules(
-    compat.extends(
-      'eslint:recommended',
-      'plugin:react/recommended',
-      'plugin:react-hooks/recommended',
-      'plugin:@typescript-eslint/eslint-recommended',
-      'plugin:@typescript-eslint/recommended',
-      'plugin:prettier/recommended'
-    )
-  ),
+  ...fixupConfigRules(compatConfigs),
   {
+    files: srcFiles,
     plugins: {
       '@typescript-eslint': fixupPluginRules(typescriptEslint),
       prettier: fixupPluginRules(prettier),
@@ -64,6 +73,8 @@ module.export = [
         }
       ],
       'react/prop-types': 'off',
+      'react/react-in-jsx-scope': 'off',
+      'react/jsx-uses-react': 'off',
       'no-useless-catch': 'off',
       '@typescript-eslint/ban-ts-comment': 'warn',
       '@typescript-eslint/camelcase': 'off',


### PR DESCRIPTION
This PR fixes ESLint configuration issues in `web` so React and TypeScript linting work

- Fixed the `web` ESLint config so it is actually loaded by ESLint.
- Migrated the config from CommonJS to ESM by renaming eslint.config.cjs to eslint.config.js.
- Scoped the TS/React lint rules to `src/**/*.{ts,tsx}` so the ESLint config file itself is not linted as application code.
- Disabled outdated React JSX scope rules for the automatic JSX runtime:
  - `react/react-in-jsx-scope`
  - `react/jsx-uses-react`

**Why**

The `web` ESLint setup had a few issues that prevented expected lint feedback:
- the config had an invalid export/config shape
- ESLint 9 flat config expected `files` to be an array
- ESLint config no longer reports `require()`-style import warnings 

These issues caused missing or misleading lint output in VS Code, especially for React hook warnings
# Test Links:
[Landing Page](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5234-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
