### PR TITLE
ASA sfms bounds bug fix

### DIFF
--- a/web/apps/wps-web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
+++ b/web/apps/wps-web/src/features/fba/pages/FireBehaviourAdvisoryPage.tsx
@@ -70,11 +70,13 @@ const FireBehaviourAdvisoryPage: React.FunctionComponent = () => {
     const runTypeLower = runType.toLocaleLowerCase()
     if (!isNull(sfmsBounds) && !isEmpty(sfmsBounds)) {
       for (const key of Object.keys(sfmsBounds)) {
-        const minValue = sfmsBounds[key][runTypeLower]['minimum']
-        const maxValue = sfmsBounds[key][runTypeLower]['maximum']
-        const minDate = DateTime.fromISO(minValue)
-        const maxDate = DateTime.fromISO(maxValue)
-        dates.push(minDate, maxDate)
+        const minValue = sfmsBounds[key]?.[runTypeLower]?.['minimum']
+        const maxValue = sfmsBounds[key]?.[runTypeLower]?.['maximum']
+        if (minValue && maxValue) {
+          const minDate = DateTime.fromISO(minValue)
+          const maxDate = DateTime.fromISO(maxValue)
+          dates.push(minDate, maxDate)
+        }
       }
       if (dates.length >= 2) {
         dates.sort(dateTimeComparator)


### PR DESCRIPTION
Adds safety checks when determining sfms bounds.
# Test Links:
[Landing Page](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5264-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
