### PR TITLE
Make 4-panel charts public

### DIFF
--- a/backend/packages/wps-api/src/app/routers/object_store_proxy.py
+++ b/backend/packages/wps-api/src/app/routers/object_store_proxy.py
@@ -146,9 +146,7 @@ async def proxy_s3_object(
     return await _proxy(path, request.headers.get("range"), S3Client.stream_object)
 
 
-wx_router = APIRouter(
-    prefix="/wx-object-store-proxy", dependencies=[Depends(authentication_required)]
-)
+wx_router = APIRouter(prefix="/wx-object-store-proxy")
 
 
 @wx_router.get("/{path:path}")

--- a/web/apps/wps-web/src/app/Routes.tsx
+++ b/web/apps/wps-web/src/app/Routes.tsx
@@ -111,14 +111,7 @@ const WPSRoutes: React.FunctionComponent = () => {
               </AuthWrapper>
             }
           />
-          <Route
-            path={WEATHER_TOOLKIT_ROUTE}
-            element={
-              <AuthWrapper>
-                <WeatherToolkitPage />
-              </AuthWrapper>
-            }
-          />
+          <Route path={WEATHER_TOOLKIT_ROUTE} element={<WeatherToolkitPage />} />
           <Route path="*" element={<NoMatchPage />} />
         </Routes>
       </Suspense>


### PR DESCRIPTION
Remove auth requirement for 4-Panel Charts so they can be shared with partner agencies.
# Test Links:
[Landing Page](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5284-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
