### PR TITLE
SideNavigation and FireCenterDropdown UI tweaks

### DIFF
--- a/mobile/asa-go/src/components/FireCenterDropdown.tsx
+++ b/mobile/asa-go/src/components/FireCenterDropdown.tsx
@@ -42,7 +42,7 @@ const FireCenterDropdown = ({
     <FormControl
       variant="outlined"
       size="small"
-      sx={{ minWidth: 175, height: BUTTON_HEIGHT - 2 }}
+      sx={{ minWidth: 175, height: BUTTON_HEIGHT }}
     >
       <InputLabel id="fire-center-label" shrink>
         Centre
@@ -60,7 +60,7 @@ const FireCenterDropdown = ({
         sx={{
           fontWeight: "bold",
           color: MAP_BUTTON_GREY,
-          height: BUTTON_HEIGHT - 2,
+          height: BUTTON_HEIGHT,
         }}
       >
         {fireCentreOptions.map((option) => {

--- a/mobile/asa-go/src/components/FireCenterDropdown.tsx
+++ b/mobile/asa-go/src/components/FireCenterDropdown.tsx
@@ -9,6 +9,7 @@ import {
 import { FireShape } from "api/fbaAPI";
 import type { FireCentre } from "@/types/fireCentre";
 import React from "react";
+import { BUTTON_HEIGHT } from "@/utils/constants";
 
 export interface FireCenterDropdownProps {
   selectedFireCentre?: FireCentre;
@@ -38,7 +39,11 @@ const FireCenterDropdown = ({
   };
 
   return (
-    <FormControl variant="outlined" size="small" sx={{ minWidth: 175 }}>
+    <FormControl
+      variant="outlined"
+      size="small"
+      sx={{ minWidth: 175, height: BUTTON_HEIGHT - 2 }}
+    >
       <InputLabel id="fire-center-label" shrink>
         Centre
       </InputLabel>
@@ -52,7 +57,11 @@ const FireCenterDropdown = ({
         label="Centre"
         displayEmpty
         renderValue={(value) => (value ? getDisplayName(value) : "")}
-        sx={{ fontWeight: "bold", color: MAP_BUTTON_GREY }}
+        sx={{
+          fontWeight: "bold",
+          color: MAP_BUTTON_GREY,
+          height: BUTTON_HEIGHT - 2,
+        }}
       >
         {fireCentreOptions.map((option) => {
           const displayName = getDisplayName(option.name);

--- a/mobile/asa-go/src/components/MapIconButton.tsx
+++ b/mobile/asa-go/src/components/MapIconButton.tsx
@@ -1,9 +1,7 @@
 import { MAP_BUTTON_GREY } from "@/theme";
+import { BORDER_RADIUS, BUTTON_HEIGHT } from "@/utils/constants";
 import { IconButton, IconButtonProps, SxProps, Theme } from "@mui/material";
 import React from "react";
-
-export const BORDER_RADIUS = 8;
-export const BUTTON_HEIGHT = 42;
 
 interface MapIconButtonProps extends Omit<IconButtonProps, "sx" | "children"> {
   icon: React.ReactElement;

--- a/mobile/asa-go/src/components/SideNavigation.tsx
+++ b/mobile/asa-go/src/components/SideNavigation.tsx
@@ -8,13 +8,14 @@ import TextSnippetIcon from "@mui/icons-material/TextSnippet";
 import { Drawer, List, styled } from "@mui/material";
 
 const StyledDrawer = styled(Drawer)({
-  width: 100,
+  width: "calc(100px + env(safe-area-inset-left))",
   flexShrink: 0,
   "& .MuiDrawer-paper": {
-    width: 100,
+    width: "calc(100px + env(safe-area-inset-left))",
     boxSizing: "border-box",
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
+    paddingLeft: "env(safe-area-inset-left)",
   },
 });
 

--- a/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
+++ b/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
@@ -62,7 +62,7 @@ const TodayTomorrowSwitch = ({
         background: "white",
         borderRadius: `${BORDER_RADIUS}px`,
         display: "flex",
-        height: `${BUTTON_HEIGHT - 2}px`,
+        height: `${BUTTON_HEIGHT}px`,
       }}
     >
       <StyledButton disabled={isToday} onClick={() => handleDayChange(0)}>

--- a/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
+++ b/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
@@ -1,8 +1,8 @@
 import { Box, Button, styled } from "@mui/material";
 import { DateTime } from "luxon";
 import { MAP_BUTTON_GREY } from "@/theme";
-import { BORDER_RADIUS, BUTTON_HEIGHT } from "@/components/MapIconButton";
 import { today } from "@/utils/dataSliceUtils";
+import { BORDER_RADIUS, BUTTON_HEIGHT } from "@/utils/constants";
 
 interface TodayTomorrowSwitchProps {
   border?: boolean;

--- a/mobile/asa-go/src/utils/constants.ts
+++ b/mobile/asa-go/src/utils/constants.ts
@@ -52,3 +52,6 @@ export enum NavPanel {
 
 export const subscriptionUpdateErrorMessage =
   "Failed to update notification settings. Please try again later.";
+
+export const BORDER_RADIUS = 8;
+export const BUTTON_HEIGHT = 42;


### PR DESCRIPTION
I noticed that on phones with persistent soft navigation buttons the `SideNavigation` gets covered in landscape orientation.
<img width="1819" height="838" alt="image" src="https://github.com/user-attachments/assets/663a2ad6-a902-4d5d-86fe-d9c23643ac1f" />

This PR adds safe areas inset padding to the left. Note that this also bumps the buttons out to prevent overlap with a camera island.

This PR also adjusts the height of the `FireCenterDropdown` to match the height of the `TodayTomorrowSwitch` as per Figma designs. iOS seemed to match heights before but Android didn't. 


Closes: #5298 

# Test Links:
[Landing Page](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5300-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
