### PR TITLE
Device and token check/update fix

### DIFF
--- a/backend/packages/wps-api/src/app/routers/fcm.py
+++ b/backend/packages/wps-api/src/app/routers/fcm.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from wps_shared.auth import asa_authentication_required, audit_asa
 from wps_shared.db.crud.fcm import (
     get_device_by_device_id,
+    get_device_by_token,
     get_notification_settings_for_device,
     save_device_token,
     upsert_notification_settings,
@@ -36,13 +37,16 @@ async def register_device(request: RegisterDeviceRequest):
     """
     logger.info("/device/register")
     async with get_async_write_session_scope() as session:
-        existing = await get_device_by_device_id(session, request.device_id)
+        existing = await get_device_by_token(session, request.token)
+        if existing is None:
+            existing = await get_device_by_device_id(session, request.device_id)
         if existing:
             existing.is_active = True
             existing.token = request.token
+            existing.device_id = request.device_id
             existing.updated_at = get_utc_now()
             existing.user_id = request.user_id
-            logger.info(f"Updated existing DeviceInfo record for token: {request.token}")
+            logger.info(f"Updated existing DeviceToken record for token: {request.token}")
         else:
             device_token = DeviceToken(
                 user_id=request.user_id,

--- a/backend/packages/wps-api/src/app/tests/fcm/test_fcm_router.py
+++ b/backend/packages/wps-api/src/app/tests/fcm/test_fcm_router.py
@@ -9,7 +9,8 @@ from fastapi.testclient import TestClient
 from wps_shared.db.models.fcm import PlatformEnum
 
 DB_SESSION = "app.routers.fcm.get_async_write_session_scope"
-GET_DEVICE_TOKEN = "app.routers.fcm.get_device_by_device_id"
+GET_DEVICE_BY_TOKEN = "app.routers.fcm.get_device_by_token"
+GET_DEVICE_BY_DEVICE_ID = "app.routers.fcm.get_device_by_device_id"
 SAVE_DEVICE_TOKEN = "app.routers.fcm.save_device_token"
 GET_NOTIFICATION_SETTINGS = "app.routers.fcm.get_notification_settings_for_device"
 UPSERT_NOTIFICATION_SETTINGS = "app.routers.fcm.upsert_notification_settings"
@@ -54,67 +55,69 @@ def test_endpoints_unauthorized(method, endpoint, kwargs, client: TestClient):
     assert response.status_code == 401
 
 
-@pytest.mark.usefixtures("mock_jwt_decode")
-def test_register_device_success():
-    """Test that device registration returns 200/OK."""
-    client = TestClient(app.main.app)
+def _make_device(**kwargs):
+    defaults = {"is_active": False, "device_id": "test_device_id", "token": "existing-fcm-token", "updated_at": datetime(2026, 1, 1), "user_id": None}
+    return type("", (object,), {**defaults, **kwargs})()
 
-    request_data = {
-        "user_id": "test-user-123",
-        "device_id": "test_device_id",
-        "token": "test-fcm-token-456",
-        "platform": "android",
-    }
+
+@pytest.mark.usefixtures("mock_jwt_decode")
+def test_register_device_new_token_and_device_id():
+    """Neither token nor device_id found — inserts a new row."""
+    client = TestClient(app.main.app)
 
     with patch(DB_SESSION) as mock_session_scope:
         mock_session_scope.return_value.__aenter__.return_value
         with (
-            patch(GET_DEVICE_TOKEN, return_value=None),
-            patch(SAVE_DEVICE_TOKEN),
-        ):
-            response = client.post(API_DEVICE_REGISTER, json=request_data)
-
-            assert response.status_code == 200
-            assert response.json()["success"] == True
-            assert response.headers["content-type"] == "application/json"
-
-
-@pytest.mark.usefixtures("mock_jwt_decode")
-def test_register_device_already_exists():
-    """Test that existing device registration updates successfully."""
-    client = TestClient(app.main.app)
-
-    request_data = {
-        "user_id": "test-user-123",
-        "device_id": "test_device_id",
-        "token": "existing-fcm-token",
-        "platform": "ios",
-    }
-
-    with patch(DB_SESSION) as mock_session_scope:
-        mock_session_scope.return_value.__aenter__.return_value
-
-        existing_device = type(
-            "",
-            (object,),
-            {
-                "is_active": False,
-                "device_id": "test_device_id",
-                "token": "existing-fcm-token",
-                "updated_at": datetime(2026, 1, 1),
-            },
-        )()
-
-        with (
-            patch(GET_DEVICE_TOKEN, return_value=existing_device),
+            patch(GET_DEVICE_BY_TOKEN, return_value=None),
+            patch(GET_DEVICE_BY_DEVICE_ID, return_value=None),
             patch(SAVE_DEVICE_TOKEN) as mock_save,
         ):
-            response = client.post(API_DEVICE_REGISTER, json=request_data)
+            response = client.post(API_DEVICE_REGISTER, json={"user_id": "test-user-123", "device_id": "test_device_id", "token": "test-fcm-token-456", "platform": "android"})
 
             assert response.status_code == 200
             assert response.json()["success"] == True
-            assert existing_device.is_active == True  # Should be updated
-            mock_save.assert_not_called()  # Should not call save for existing device
+            mock_save.assert_called_once()
+
+
+@pytest.mark.usefixtures("mock_jwt_decode")
+def test_register_device_token_found_updates_row():
+    """Token already registered — updates that row without inserting."""
+    client = TestClient(app.main.app)
+    existing = _make_device(token="existing-fcm-token", device_id="old_device_id")
+
+    with patch(DB_SESSION) as mock_session_scope:
+        mock_session_scope.return_value.__aenter__.return_value
+        with (
+            patch(GET_DEVICE_BY_TOKEN, return_value=existing),
+            patch(SAVE_DEVICE_TOKEN) as mock_save,
+        ):
+            response = client.post(API_DEVICE_REGISTER, json={"user_id": "test-user-123", "device_id": "new_device_id", "token": "existing-fcm-token", "platform": "android"})
+
+            assert response.status_code == 200
+            assert existing.is_active == True
+            assert existing.device_id == "new_device_id"
+            mock_save.assert_not_called()
+
+
+@pytest.mark.usefixtures("mock_jwt_decode")
+def test_register_device_device_id_found_updates_token():
+    """Token not found but device_id matches — updates the token on that row."""
+    client = TestClient(app.main.app)
+    existing = _make_device(token="old-token", device_id="test_device_id")
+
+    with patch(DB_SESSION) as mock_session_scope:
+        mock_session_scope.return_value.__aenter__.return_value
+        with (
+            patch(GET_DEVICE_BY_TOKEN, return_value=None),
+            patch(GET_DEVICE_BY_DEVICE_ID, return_value=existing),
+            patch(SAVE_DEVICE_TOKEN) as mock_save,
+        ):
+            response = client.post(API_DEVICE_REGISTER, json={"user_id": "test-user-123", "device_id": "test_device_id", "token": "new-rotated-token-xyz", "platform": "android"})
+
+            assert response.status_code == 200
+            assert existing.token == "new-rotated-token-xyz"
+            assert existing.is_active == True
+            mock_save.assert_not_called()
 
 
 @pytest.mark.usefixtures("mock_jwt_decode")
@@ -164,7 +167,8 @@ def test_register_device_without_user_id():
     with patch(DB_SESSION) as mock_session_scope:
         mock_session_scope.return_value.__aenter__.return_value
         with (
-            patch(GET_DEVICE_TOKEN, return_value=None),
+            patch(GET_DEVICE_BY_TOKEN, return_value=None),
+            patch(GET_DEVICE_BY_DEVICE_ID, return_value=None),
             patch(SAVE_DEVICE_TOKEN),
         ):
             response = client.post(API_DEVICE_REGISTER, json=request_data)

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/fcm.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/fcm.py
@@ -15,8 +15,12 @@ def save_device_token(session: AsyncSession, device_token: DeviceToken):
     session.add(device_token)
 
 
-async def get_device_by_device_id(session: AsyncSession, device_id: str):
+async def get_device_by_device_id(session: AsyncSession, device_id: str) -> DeviceToken | None:
     return await session.scalar(select(DeviceToken).where(DeviceToken.device_id == device_id))
+
+
+async def get_device_by_token(session: AsyncSession, token: str) -> DeviceToken | None:
+    return await session.scalar(select(DeviceToken).where(DeviceToken.token == token))
 
 
 async def update_device_token_is_active(session: AsyncSession, token: str, is_active: bool) -> bool:


### PR DESCRIPTION
1. Look up by token first — if found, update that row (token already registered, possibly with a stale device_id)
2. Fall back to device_id lookup — if found, update that row with the new token
3. Neither found → insert new row

This eliminates the conflict in all cases since we never try to write a token that already exists in another row.
# Test Links:
[Landing Page](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5311-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
