### PR TITLE
ASA Go: Add MUI license validation

### DIFF
--- a/.github/actions/asa-go-setup/action.yml
+++ b/.github/actions/asa-go-setup/action.yml
@@ -1,5 +1,10 @@
 name: ASA Go Setup
-description: Install Node.js, build the keycloak plugin, and install asa-go dependencies
+description: Install Node.js, build the keycloak plugin, install asa-go dependencies, and validate the MUI license
+
+inputs:
+  mui-license-key:
+    description: MUI X Pro license key
+    required: true
 
 runs:
   using: composite
@@ -37,3 +42,17 @@ runs:
       working-directory: ./mobile/asa-go
       shell: bash
       run: yarn install
+
+    - name: Validate MUI License
+      working-directory: ./mobile/asa-go
+      shell: bash
+      env:
+        VITE_MUI_LICENSE_KEY: ${{ inputs.mui-license-key }}
+      run: |
+        node -e "
+          const { verifyLicense, generateReleaseInfo } = require('./node_modules/@mui/x-license-pro/node/verifyLicense/verifyLicense.js');
+          const result = verifyLicense({ releaseInfo: generateReleaseInfo(), licenseKey: process.env.VITE_MUI_LICENSE_KEY, acceptedScopes: ['pro', 'premium'] });
+          if (result.meta?.expiryTimestamp) console.log('MUI license expiry:', new Date(result.meta.expiryTimestamp).toISOString().split('T')[0]);
+          console.log('MUI license status:', result.status);
+          if (result.status !== 'Valid') { console.error('MUI license check failed'); process.exit(1); }
+        "

--- a/.github/workflows/asa_go_android_build.yml
+++ b/.github/workflows/asa_go_android_build.yml
@@ -21,6 +21,7 @@ jobs:
             "SIGNING_STORE_PASSWORD"
             "SIGNING_KEY_PASSWORD"
             "GOOGLE_SERVICES_JSON"
+            "VITE_MUI_LICENSE_KEY"
             "VITE_BASEMAP_TILE_URL"
             "VITE_BASEMAP_STYLE_URL"
             "VITE_SENTRY_DSN"
@@ -38,6 +39,7 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
           SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          VITE_MUI_LICENSE_KEY: ${{ secrets.VITE_MUI_LICENSE_KEY }}
           VITE_BASEMAP_TILE_URL: ${{ secrets.VITE_BASEMAP_TILE_URL }}
           VITE_BASEMAP_STYLE_URL: ${{ secrets.VITE_BASEMAP_STYLE_URL }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
@@ -55,6 +57,8 @@ jobs:
 
       - name: Setup ASA Go
         uses: ./.github/actions/asa-go-setup
+        with:
+          mui-license-key: ${{ secrets.VITE_MUI_LICENSE_KEY }}
 
       - name: Create environment settings
         working-directory: ./mobile/asa-go

--- a/.github/workflows/asa_go_ios_build_deploy.yml
+++ b/.github/workflows/asa_go_ios_build_deploy.yml
@@ -22,6 +22,7 @@ jobs:
           "KEYCHAIN_PASSWD"
           "PROVISIONING_PROFILE"
           "GOOGLE_SERVICES_PLIST"
+          "VITE_MUI_LICENSE_KEY"
           "VITE_BASEMAP_TILE_URL"
           "VITE_BASEMAP_STYLE_URL"
           "VITE_SENTRY_DSN"
@@ -38,6 +39,7 @@ jobs:
           KEYCHAIN_PASSWD: ${{ secrets.APPLE_APP_STORE_BUILD_CERTIFICATE_PASSWD }}
           PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISION_PROFILE_BASE64 }}
           GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}
+          VITE_MUI_LICENSE_KEY: ${{ secrets.VITE_MUI_LICENSE_KEY }}
           VITE_BASEMAP_TILE_URL: ${{ secrets.VITE_BASEMAP_TILE_URL }}
           VITE_BASEMAP_STYLE_URL: ${{ secrets.VITE_BASEMAP_STYLE_URL }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
@@ -54,6 +56,8 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
       - name: Setup ASA Go
         uses: ./.github/actions/asa-go-setup
+        with:
+          mui-license-key: ${{ secrets.VITE_MUI_LICENSE_KEY }}
       - name: Create environment settings
         working-directory: ./mobile/asa-go
         env:


### PR DESCRIPTION
  Adds a validation step to both the Android and iOS build workflows that checks the MUI X Pro license is present and valid before proceeding with
  the build. Previously, an expired or missing license would only surface at runtime as a watermark — now it fails the build early.

  - `VITE_MUI_LICENSE_KEY` added to check-secrets in both workflows so a missing secret fails fast
  - asa-go-setup action gains a mui-license-key input and a final validation step that calls verifyLicense directly from the installed
  `@mui/x-license-pro` package — fails the build on anything other than Valid
# Test Links:
[Landing Page](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5322-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
