### PR TITLE
Fix SFMS CronJob resources missing app label

### DIFF
--- a/openshift/templates/sfms_calculations.cronjob.yaml
+++ b/openshift/templates/sfms_calculations.cronjob.yaml
@@ -34,6 +34,8 @@ objects:
     apiVersion: batch/v1
     metadata:
       name: ${JOB_NAME}
+      labels:
+        app: ${APP_LABEL}
     spec:
       schedule: ${SCHEDULE}
       # We use the "Replace" policy, because we never want the cronjobs to run concurrently,

--- a/openshift/templates/sfms_daily_actuals.cronjob.yaml
+++ b/openshift/templates/sfms_daily_actuals.cronjob.yaml
@@ -38,6 +38,8 @@ objects:
     apiVersion: batch/v1
     metadata:
       name: ${JOB_NAME}
+      labels:
+        app: ${APP_LABEL}
     spec:
       schedule: ${SCHEDULE}
       # We use the "Replace" policy, because we never want the cronjobs to run concurrently,

--- a/openshift/templates/sfms_daily_forecasts.cronjob.yaml
+++ b/openshift/templates/sfms_daily_forecasts.cronjob.yaml
@@ -26,6 +26,8 @@ objects:
     apiVersion: batch/v1
     metadata:
       name: ${JOB_NAME}
+      labels:
+        app: ${APP_LABEL}
     spec:
       schedule: ${SCHEDULE}
       concurrencyPolicy: "Replace"


### PR DESCRIPTION
  - The app: `${APP_LABEL}` label was only set on jobTemplate.metadata (the pods) and not on the CronJob resources themselves
  - `oc_cleanup.sh` deletes resources by `-l app=${APP_LABEL}`, so CronJob objects were silently skipped on PR teardown and leaked in the cluster
  - Adds app: `${APP_LABEL}` to the CronJob metadata in all three SFMS templates: `sfms_daily_forecasts`, `sfms_daily_actuals`, `sfms_calculations`
# Test Links:
[Landing Page](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5331-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
