### PR TITLE
Fix forecast cronjob label to account for 8am and 345pm suffixes

### DIFF
--- a/openshift/scripts/oc_provision_sfms_daily_forecasts_cronjob.sh
+++ b/openshift/scripts/oc_provision_sfms_daily_forecasts_cronjob.sh
@@ -28,10 +28,14 @@ PROJ_TARGET="${PROJ_TARGET:-${PROJ_DEV}}"
 # Schedule: 15:00 UTC (8:00 AM PDT)
 SCHEDULE="${SCHEDULE:-0 15 * * *}"
 
+# Strip time-of-day variant (e.g. pr-5331-8am -> pr-5331) so APP_LABEL matches
+# the label used by oc_cleanup.sh, which selects by the base PR suffix.
+BASE_SUFFIX="${SUFFIX%-*}"
+
 # Process template
 OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/sfms_daily_forecasts.cronjob.yaml \
 -p JOB_NAME=sfms-forecast-${APP_NAME}-${SUFFIX} \
--p APP_LABEL=${APP_NAME}-${SUFFIX} \
+-p APP_LABEL=${APP_NAME}-${BASE_SUFFIX} \
 -p NAME=${APP_NAME} \
 -p SUFFIX=${SUFFIX} \
 -p SCHEDULE=\"${SCHEDULE}\""


### PR DESCRIPTION
Strip time-of-day variant (e.g. `pr-5331-8am` -> `pr-5331`) so `APP_LABEL` matches the label used by `oc_cleanup.sh`, which selects by the base PR suffix.
# Test Links:
[Landing Page](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5332-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
