### PR TITLE
Handle basemap creation error when offline

### DIFF
--- a/mobile/asa-go/src/components/map/ASAGoMap.tsx
+++ b/mobile/asa-go/src/components/map/ASAGoMap.tsx
@@ -441,10 +441,14 @@ const ASAGoMap = ({
         const localBasemapLayer = await createLocalBasemapVectorLayer();
         setLocalBasemapVectorLayer(localBasemapLayer);
 
-        const basemapLayer = await createBasemapLayer();
-        setBasemapLayer(basemapLayer);
-
-        mapObject.addLayer(basemapLayer);
+        try {
+          const basemapLayer = await createBasemapLayer();
+          setBasemapLayer(basemapLayer);
+          mapObject.addLayer(basemapLayer);
+        } catch (e) {
+          // offline or endpoint unreachable — local basemap will be used
+          console.warn(e);
+        }
         mapObject.addLayer(fireCentreFileLayer);
         mapObject.addLayer(fireCentreLabelsFileLayer);
         mapObject.addLayer(fireZoneFileLayer);

--- a/mobile/asa-go/src/components/map/asaGoMap.test.tsx
+++ b/mobile/asa-go/src/components/map/asaGoMap.test.tsx
@@ -50,7 +50,7 @@ vi.mock("@/layerDefinitions", async () => {
   };
 });
 
-import { HFI_LAYER_NAME } from "@/layerDefinitions";
+import { createBasemapLayer, HFI_LAYER_NAME } from "@/layerDefinitions";
 
 describe("ASAGoMap", () => {
   beforeAll(() => {
@@ -235,6 +235,27 @@ describe("ASAGoMap", () => {
       false,
     );
     await waitFor(() => expect(hfiCheckbox).not.toBeChecked());
+  });
+
+  it("handles createBasemapLayer failure gracefully when offline", async () => {
+    const error = new Error("Network unavailable");
+    vi.mocked(createBasemapLayer).mockRejectedValueOnce(error);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const store = createTestStore();
+    render(
+      <Provider store={store}>
+        <ASAGoMap {...defaultProps} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId(defaultProps.testId)).toBeVisible();
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(error);
+    });
+
+    warnSpy.mockRestore();
   });
 
   it("calls save and load map view state", async () => {


### PR DESCRIPTION
- adds a try/catch around the creation of the online version of the basemap
- this should fix the ArcGIS related Sentry errors
- also fixes the missing boundary and label layers when cold starting offline

Closes: #5334 
# Test Links:
[Landing Page](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5349-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
