### PR TITLE
ASA Go: Notifications are high priority

### DIFF
--- a/backend/packages/wps-api/src/app/fcm/notifications.py
+++ b/backend/packages/wps-api/src/app/fcm/notifications.py
@@ -45,10 +45,10 @@ def build_fcm_message(
     message = messaging.MulticastMessage(
         notification=messaging.Notification(title=title, body=content),
         android=messaging.AndroidConfig(
-            ttl=ttl, notification=messaging.AndroidNotification(tag=tag)
+            ttl=ttl, notification=messaging.AndroidNotification(tag=tag), priority="high"
         ),
         apns=messaging.APNSConfig(
-            headers={"apns-expiration": apns_expiration},
+            headers={"apns-expiration": apns_expiration, "apns-priority": 10},
             payload=messaging.APNSPayload(aps=messaging.Aps(thread_id=tag)),
         ),
         data=data,

--- a/backend/packages/wps-api/src/app/tests/fcm/test_notifications.py
+++ b/backend/packages/wps-api/src/app/tests/fcm/test_notifications.py
@@ -373,3 +373,15 @@ def test_build_fcm_message_platform_tags():
     assert msg.apns.payload.aps.thread_id == msg.android.notification.tag
     assert msg.android.ttl == timedelta(days=2)
     assert msg.apns.headers["apns-expiration"] == EXPECTED_APNS_EXPIRATION
+
+
+def test_build_fcm_message_android_high_priority():
+    """Android config uses high priority so messages deliver immediately."""
+    msg = build_fcm_message(MSG_DATE, ZONE, TOKENS)
+    assert msg.android.priority == "high"
+
+
+def test_build_fcm_message_apns_high_priority():
+    """APNS config uses priority 10 (immediate delivery) for time-sensitive advisories."""
+    msg = build_fcm_message(MSG_DATE, ZONE, TOKENS)
+    assert msg.apns.headers["apns-priority"] == 10


### PR DESCRIPTION
Configure notifications as high priority avoid notifications from being dropped:

https://firebase.google.com/docs/cloud-messaging/customize-messages/setting-message-priority
# Test Links:
[Landing Page](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5350-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
