### PR TITLE
Fix grass curing job errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,6 +85,14 @@
             "python": "${workspaceFolder}/backend/.venv/bin/python"
         },
         {
+            "name": "Grass Curing",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "app.jobs.grass_curing",
+            "cwd": "${workspaceFolder}/backend",
+            "python": "${workspaceFolder}/backend/.venv/bin/python"
+        },
+        {
             "name": "app.jobs.hourly_actuals",
             "type": "debugpy",
             "request": "launch",

--- a/backend/packages/wps-api/src/app/jobs/grass_curing.py
+++ b/backend/packages/wps-api/src/app/jobs/grass_curing.py
@@ -86,7 +86,17 @@ class GrassCuringJob():
             px, py = reverse_transform * (longitude, latitude)
             px = math.floor(px)
             py = math.floor(py)
-            yield (station.code, data_np_array[py][px])
+            try:
+                yield (station.code, data_np_array[py][px])
+            except IndexError:
+                # A station with bad coordinates shouldn't terminate the entire job but this should
+                # be picked up by Sentry so log an error.
+                logger.error(
+                    "Station %s at pixel (%s, %s) is out of raster bounds, skipping",
+                    station.code,
+                    px,
+                    py,
+                )
 
 
     async def _get_last_for_date(self):

--- a/backend/packages/wps-api/src/app/jobs/grass_curing.py
+++ b/backend/packages/wps-api/src/app/jobs/grass_curing.py
@@ -1,65 +1,59 @@
-from affine import Affine
-from datetime import date
-from aiohttp import ClientSession
-from osgeo import gdal
 import asyncio
 import logging
 import math
-import numpy as np
 import os
-import requests
 import sys
 import tempfile
-import xml.etree.ElementTree as ET
 
-from wps_wf1.wfwx_api import WfwxApi
-from wps_shared.wps_logging import configure_logging
-from wps_shared.db.crud.grass_curing import get_last_percent_grass_curing_for_date, save_percent_grass_curing
+import aiofiles
+import numpy as np
+from affine import Affine
+from aiohttp import ClientSession
+from osgeo import gdal
+from wps_shared.db.crud.grass_curing import (
+    get_last_percent_grass_curing_for_date,
+    save_percent_grass_curing,
+)
 from wps_shared.db.database import get_async_read_session_scope, get_async_write_session_scope
-from wps_shared.geospatial.geospatial import WGS84
 from wps_shared.db.models.grass_curing import PercentGrassCuring
+from wps_shared.geospatial.geospatial import WGS84
 from wps_shared.rocketchat_notifications import send_rocketchat_notification
+from wps_shared.utils.time import get_utc_now
+from wps_shared.wps_logging import configure_logging
+from wps_wf1.wfwx_api import WfwxApi
 
 logger = logging.getLogger(__name__)
 
 GRASS_CURING_FILE_NAME_3978 = "grass_curing_epsg_3978.tif"
 GRASS_CURING_FILE_NAME_4326 = "grass_curing_epsg_4326.tif"
-GRASS_CURING_COVERAGE_ID = "public:pc_current"
-WCS_URL = "https://cwfis.cfs.nrcan.gc.ca/geoserver/public/wcs"
+CWFIS_BASE_URL = "https://cwfis.cfs.nrcan.gc.ca/downloads/pcuring"
 
 
-class OwsException(Exception):
-    """ Raise when OWS service returns an exception report."""
+class GrassCuringFileNotFoundException(Exception):
+    """Raised when the CWFIS grass curing file is not yet available for the requested date."""
 
 
 class GrassCuringJob():
     """ Job that downloads and processes percent grass curing data from the CWFIS. """
 
-    async def _get_grass_curing_wcs_raster(self, path: str):
-        """ Gets the current percent grass curing as a tif from the CWFIS Web Coverage Service. """
-        session = requests.session()
-        param_dict= {
-            "service": "WCS",
-            "version": "2.0.0",
-            "request": "GetCoverage",
-            "format": "image/geotiff",
-            "coverageId": GRASS_CURING_COVERAGE_ID
-        }
-        response = session.get(WCS_URL, params = param_dict)
-        # Check HTTP response code for error condition
-        response.raise_for_status()
-        # GeoServer can return an exception report as xml within a 200 response. Check if we have a content type header 
-        # of application/xml and check if an exception is present.
-        if "Content-Type" in response.headers and response.headers["Content-Type"] == "application/xml":
-            root_element = ET.fromstring(response.content)
-            if "ExceptionReport" in root_element.tag:
-                message = f"GeoServer returned an exception when attempting to download percent grass curing from URL: {response.request.url}"
-                logger.error(message)
-                raise OwsException(message)
-        file_path = os.path.join(path, GRASS_CURING_FILE_NAME_3978)
-        with open(file_path, 'wb') as file:
-            file.write(response.content)
+    def __init__(self):
+        self.grass_cure_datetime = get_utc_now().replace(hour=0, minute=0, second=0, microsecond=0)
 
+    async def _get_grass_curing_raster(self, path: str):
+        """Gets the current percent grass curing as a tif from the CWFIS downloads endpoint."""
+        filename = f"pc{self.grass_cure_datetime.strftime('%Y%m%d')}.tif"
+        url = f"{CWFIS_BASE_URL}/{filename}"
+        async with ClientSession() as session:
+            async with session.get(url) as response:
+                if response.status == 404:
+                    message = f"Grass curing file not yet available at {url}"
+                    logger.warning(message)
+                    raise GrassCuringFileNotFoundException(message)
+                response.raise_for_status()
+                content = await response.read()
+        file_path = os.path.join(path, GRASS_CURING_FILE_NAME_3978)
+        async with aiofiles.open(file_path, "wb") as file:
+            await file.write(content)
 
     def _reproject_to_epsg_4326(self, path: str):
         """ Transforms coordinates in source_file geotiff to EPSG:3005 (BC Albers),
@@ -103,43 +97,50 @@ class GrassCuringJob():
 
 
     async def _process_grass_curing(self):
-        """ Download and process percent grass curing data. """
-        async with get_async_write_session_scope() as session:
-            today = date.today()
-            logger.info(f"Starting collection of percent grass curing data from CWFIS for {today}.")
-            with tempfile.TemporaryDirectory() as temp_dir:
-                await self._get_grass_curing_wcs_raster(temp_dir)
-                self._reproject_to_epsg_4326(temp_dir)
+        """Download and process percent grass curing data."""
+        logger.info(
+            f"Starting collection of percent grass curing data from CWFIS for {self.grass_cure_datetime}."
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            await self._get_grass_curing_raster(temp_dir)
+            self._reproject_to_epsg_4326(temp_dir)
 
-                # Open the reprojected grass curing data
-                raster = gdal.Open(f"{temp_dir}/{GRASS_CURING_FILE_NAME_4326}")
-                async with ClientSession() as http_session:
-                    wfwx_api = WfwxApi(http_session)
-                    stations = await wfwx_api.get_station_data()
-                for station, value in self._yield_value_for_stations(raster, stations):
-                    percent_grass_curing = PercentGrassCuring(for_date=today,
-                                                                percent_grass_curing=value,
-                                                                station_code=station )
+            # Open the reprojected grass curing data
+            raster = gdal.Open(f"{temp_dir}/{GRASS_CURING_FILE_NAME_4326}")
+            async with ClientSession() as http_session:
+                wfwx_api = WfwxApi(http_session)
+                stations = await wfwx_api.get_station_data()
+            for station, value in self._yield_value_for_stations(raster, stations):
+                percent_grass_curing = PercentGrassCuring(
+                    for_date=self.grass_cure_datetime,
+                    percent_grass_curing=value,
+                    station_code=station,
+                )
+                async with get_async_write_session_scope() as session:
                     await save_percent_grass_curing(session, percent_grass_curing)
-        logger.info(f"Finished processing percent grass curing data from CWFIS for {today}.")
+            raster = None
+        logger.info(
+            f"Finished processing percent grass curing data from CWFIS for {self.grass_cure_datetime}."
+        )
             
 
     async def _run_grass_curing(self):
         """ Entry point for running the job. """   
         last_processed = await self._get_last_for_date()
-        if last_processed is None or last_processed.date() < date.today():
+        if last_processed is None or last_processed.date() < self.grass_cure_datetime.date():
             await self._process_grass_curing()
         else:
-            logger.info(f"Percent grass curing processing is up to date as of {date.today()}")
+            logger.info(
+                f"Percent grass curing processing is up to date as of {self.grass_cure_datetime}"
+            )
 
 
 def main():
-    """ Kicks off asynchronous processing of VIIRS snow coverage data.
-    """
+    """Kicks off asynchronous processing of grass curing data."""
     try:
         # We don't want gdal to silently swallow errors.
         gdal.UseExceptions()
-        logger.debug('Begin processing VIIRS snow coverage data.')
+        logger.debug("Begin processing percent grass curing data.")
 
         bot = GrassCuringJob()
         loop = asyncio.new_event_loop()
@@ -148,10 +149,15 @@ def main():
 
         # Exit with 0 - success.
         sys.exit(os.EX_OK)
+    except GrassCuringFileNotFoundException:
+        # A missing file is expected early in the day. The job will re-try later.
+        sys.exit(os.EX_OK)
     except Exception as exception:
         # Exit non 0 - failure.
-        logger.error("An error occurred while processing CWFIS grass curing data.", exc_info=exception)
-        rc_message = ':scream: Encountered an error while processing CWFIS grass curing data.'
+        logger.error(
+            "An error occurred while processing CWFIS grass curing data.", exc_info=exception
+        )
+        rc_message = ":scream: Encountered an error while processing CWFIS grass curing data."
         send_rocketchat_notification(rc_message, exception)
         sys.exit(os.EX_SOFTWARE)
 

--- a/backend/packages/wps-api/src/app/tests/jobs/test_grass_curing.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_grass_curing.py
@@ -1,15 +1,54 @@
 """ Unit testing for CWFIS grass curing data processing """
 
+import asyncio
 import os
-import pytest
+from contextlib import asynccontextmanager
 from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
 from pytest_mock import MockerFixture
+from wps_shared.geospatial.geospatial import WGS84
+
 from app.jobs import grass_curing
-from app.jobs.grass_curing import GrassCuringJob
+from app.jobs.grass_curing import (
+    CWFIS_BASE_URL,
+    GRASS_CURING_FILE_NAME_3978,
+    GRASS_CURING_FILE_NAME_4326,
+    GrassCuringFileNotFoundException,
+    GrassCuringJob,
+)
 
 
-def test_grass_curing_job_fail(mocker: MockerFixture,
-                                 monkeypatch):
+def _make_mock_client_session(mocker: MockerFixture, content: bytes = b"fake tiff bytes"):
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.read = AsyncMock(return_value=content)
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    mocker.patch("app.jobs.grass_curing.ClientSession", return_value=mock_session)
+    return mock_session, mock_response
+
+
+def _make_mock_data_source(data: np.ndarray, geo_transform: tuple):
+    """Build a mock gdal data source from a numpy array and a GDAL geotransform tuple."""
+    mock_band = MagicMock()
+    mock_band.ReadAsArray.return_value = data
+    mock_ds = MagicMock()
+    mock_ds.GetRasterBand.return_value = mock_band
+    mock_ds.GetGeoTransform.return_value = geo_transform
+    return mock_ds
+
+
+def test_grass_curing_job_fail(mocker: MockerFixture, monkeypatch):
     """
     Test that when the bot fails, a message is sent to rocket-chat, and our exit code is 1.
     """
@@ -22,22 +61,240 @@ def test_grass_curing_job_fail(mocker: MockerFixture,
 
     with pytest.raises(SystemExit) as excinfo:
         grass_curing.main()
-    # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_SOFTWARE
-    # Assert that rocket chat was called.
     assert rocket_chat_spy.call_count == 1
 
 
 def test_grass_curing_job_exits_without_error_when_no_work_required(monkeypatch):
-    """ Test that grass_curing_job exits without error when no data needs to be processed.
-    """
+    """Test that grass_curing_job exits without error when no data needs to be processed."""
     async def mock__get_last_for_date(self):
         return datetime.now()
-    
-    monkeypatch.setattr(GrassCuringJob, '_get_last_for_date', mock__get_last_for_date)
+
+    monkeypatch.setattr(GrassCuringJob, "_get_last_for_date", mock__get_last_for_date)
 
     with pytest.raises(SystemExit) as excinfo:
         grass_curing.main()
-    # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_OK
-    
+
+
+def test_get_grass_curing_raster_writes_file(mocker: MockerFixture):
+    """Test that _get_grass_curing_raster downloads content and writes it to the expected path."""
+    fake_content = b"fake tiff bytes"
+    mock_session, _ = _make_mock_client_session(mocker, fake_content)
+
+    mock_file = AsyncMock()
+    mock_file.__aenter__ = AsyncMock(return_value=mock_file)
+    mock_file.__aexit__ = AsyncMock(return_value=None)
+    mock_open = mocker.patch("app.jobs.grass_curing.aiofiles.open", return_value=mock_file)
+
+    job = GrassCuringJob()
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(job._get_grass_curing_raster("/tmp"))
+
+    expected_url = f"{CWFIS_BASE_URL}/pc{job.grass_cure_datetime.strftime('%Y%m%d')}.tif"
+    mock_session.get.assert_called_once_with(expected_url)
+    mock_open.assert_called_once_with(os.path.join("/tmp", GRASS_CURING_FILE_NAME_3978), "wb")
+    mock_file.write.assert_called_once_with(fake_content)
+
+
+def test_get_grass_curing_raster_raises_on_http_error(mocker: MockerFixture):
+    """Test that _get_grass_curing_raster raises when the server returns an HTTP error."""
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock(side_effect=Exception("500 Server Error"))
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    mocker.patch("app.jobs.grass_curing.ClientSession", return_value=mock_session)
+
+    loop = asyncio.new_event_loop()
+    with pytest.raises(Exception, match="500 Server Error"):
+        loop.run_until_complete(GrassCuringJob()._get_grass_curing_raster("/tmp"))
+
+
+def test_get_grass_curing_raster_raises_file_not_found_on_404(mocker: MockerFixture):
+    """Test that _get_grass_curing_raster raises GrassCuringFileNotFoundException on a 404."""
+    mock_response = AsyncMock()
+    mock_response.status = 404
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    mocker.patch("app.jobs.grass_curing.ClientSession", return_value=mock_session)
+
+    loop = asyncio.new_event_loop()
+    with pytest.raises(GrassCuringFileNotFoundException):
+        loop.run_until_complete(GrassCuringJob()._get_grass_curing_raster("/tmp"))
+
+
+def test_main_exits_cleanly_when_file_not_found(mocker: MockerFixture, monkeypatch):
+    """Test that main exits with EX_OK and skips rocket chat when the file is not yet available."""
+    async def mock__run_grass_curing(self):
+        raise GrassCuringFileNotFoundException("not found")
+
+    monkeypatch.setattr(GrassCuringJob, "_run_grass_curing", mock__run_grass_curing)
+    rocket_chat_spy = mocker.spy(grass_curing, "send_rocketchat_notification")
+
+    with pytest.raises(SystemExit) as excinfo:
+        grass_curing.main()
+
+    assert excinfo.value.code == os.EX_OK
+    assert rocket_chat_spy.call_count == 0
+
+
+def test_yield_value_for_stations_returns_correct_pixel_values():
+    """Test that station coordinates are mapped to the correct raster pixel values."""
+    # 3x3 grid, origin (-130, 60), 1-degree pixels north-up.
+    # forward: x = col - 130, y = -row + 60
+    # inverse: col = lon + 130, row = 60 - lat
+    data = np.array(
+        [
+            [10, 20, 30],
+            [40, 50, 60],
+            [70, 80, 90],
+        ]
+    )
+    geo_transform = (-130.0, 1.0, 0.0, 60.0, 0.0, -1.0)
+    mock_ds = _make_mock_data_source(data, geo_transform)
+
+    stations = [
+        SimpleNamespace(code=1, long=-130.0, lat=60.0),  # col=0, row=0 → 10
+        SimpleNamespace(code=2, long=-129.0, lat=59.0),  # col=1, row=1 → 50
+        SimpleNamespace(code=3, long=-128.0, lat=58.0),  # col=2, row=2 → 90
+    ]
+
+    results = list(GrassCuringJob()._yield_value_for_stations(mock_ds, stations))
+
+    assert results == [(1, 10), (2, 50), (3, 90)]
+
+
+def test_yield_value_for_stations_floors_fractional_pixel_coordinates():
+    """Test that sub-pixel coordinates are floored to the containing pixel."""
+    data = np.array(
+        [
+            [10, 20],
+            [30, 40],
+        ]
+    )
+    geo_transform = (-130.0, 1.0, 0.0, 60.0, 0.0, -1.0)
+    mock_ds = _make_mock_data_source(data, geo_transform)
+
+    # col = floor(-129.9 + 130) = floor(0.1) = 0, row = floor(60 - 59.9) = floor(0.1) = 0
+    stations = [SimpleNamespace(code=1, long=-129.9, lat=59.9)]
+
+    results = list(GrassCuringJob()._yield_value_for_stations(mock_ds, stations))
+
+    assert results == [(1, 10)]
+
+
+def test_reproject_to_epsg_4326_calls_gdal_with_correct_paths(mocker: MockerFixture):
+    """Test that _reproject_to_epsg_4326 opens the 3978 source and warps to a 4326 destination."""
+    mock_ds = MagicMock()
+    mock_gdal_open = mocker.patch("app.jobs.grass_curing.gdal.Open", return_value=mock_ds)
+    mock_gdal_warp = mocker.patch("app.jobs.grass_curing.gdal.Warp")
+
+    GrassCuringJob()._reproject_to_epsg_4326("/tmp")
+
+    mock_gdal_open.assert_called_once_with(
+        f"/tmp/{GRASS_CURING_FILE_NAME_3978}", grass_curing.gdal.GA_ReadOnly
+    )
+    mock_gdal_warp.assert_called_once_with(
+        f"/tmp/{GRASS_CURING_FILE_NAME_4326}", mock_ds, dstSRS=WGS84
+    )
+
+
+def test_process_grass_curing_saves_value_per_station(mocker: MockerFixture, monkeypatch):
+    """Test that _process_grass_curing saves one record per station returned by the API."""
+
+    async def mock_get_raster(self, path):
+        pass
+
+    def mock_reproject(self, path):
+        pass
+
+    monkeypatch.setattr(GrassCuringJob, "_get_grass_curing_raster", mock_get_raster)
+    monkeypatch.setattr(GrassCuringJob, "_reproject_to_epsg_4326", mock_reproject)
+
+    stations = [
+        SimpleNamespace(code=1, long=-130.0, lat=60.0, name="Station A"),
+        SimpleNamespace(code=2, long=-129.0, lat=59.0, name="Station B"),
+    ]
+
+    mock_wfwx_api = MagicMock()
+    mock_wfwx_api.get_station_data = AsyncMock(return_value=stations)
+    mocker.patch("app.jobs.grass_curing.WfwxApi", return_value=mock_wfwx_api)
+
+    data = np.array([[10, 20], [30, 40]])
+    mock_raster = _make_mock_data_source(data, (-130.0, 1.0, 0.0, 60.0, 0.0, -1.0))
+    mocker.patch("app.jobs.grass_curing.gdal.Open", return_value=mock_raster)
+
+    mock_db_session = MagicMock()
+
+    @asynccontextmanager
+    async def mock_write_scope():
+        yield mock_db_session
+
+    mocker.patch("app.jobs.grass_curing.get_async_write_session_scope", mock_write_scope)
+    mock_save = mocker.patch(
+        "app.jobs.grass_curing.save_percent_grass_curing", new_callable=AsyncMock
+    )
+
+    _make_mock_client_session(mocker)
+
+    job = GrassCuringJob()
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(job._process_grass_curing())
+
+    assert mock_save.call_count == len(stations)
+    saved_records = [call.args[1] for call in mock_save.call_args_list]
+    assert saved_records[0].station_code == 1
+    assert saved_records[1].station_code == 2
+    assert all(r.for_date == job.grass_cure_datetime for r in saved_records)
+
+
+def test_run_grass_curing_triggers_processing_when_no_previous_data(monkeypatch):
+    """Test that _run_grass_curing calls _process_grass_curing when last_processed is None."""
+    processed = []
+
+    async def mock_get_last_for_date(self):
+        return None
+
+    async def mock_process_grass_curing(self):
+        processed.append(True)
+
+    monkeypatch.setattr(GrassCuringJob, "_get_last_for_date", mock_get_last_for_date)
+    monkeypatch.setattr(GrassCuringJob, "_process_grass_curing", mock_process_grass_curing)
+
+    with pytest.raises(SystemExit) as excinfo:
+        grass_curing.main()
+
+    assert excinfo.value.code == os.EX_OK
+    assert len(processed) == 1
+
+
+def test_run_grass_curing_triggers_processing_when_last_processed_before_today(monkeypatch):
+    """Test that _run_grass_curing calls _process_grass_curing when last_processed is before today."""
+    processed = []
+
+    async def mock_get_last_for_date(self):
+        return datetime(2000, 1, 1)
+
+    async def mock_process_grass_curing(self):
+        processed.append(True)
+
+    monkeypatch.setattr(GrassCuringJob, "_get_last_for_date", mock_get_last_for_date)
+    monkeypatch.setattr(GrassCuringJob, "_process_grass_curing", mock_process_grass_curing)
+
+    with pytest.raises(SystemExit) as excinfo:
+        grass_curing.main()
+
+    assert excinfo.value.code == os.EX_OK
+    assert len(processed) == 1

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/grass_curing.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/grass_curing.py
@@ -1,11 +1,14 @@
 """ CRUD operations relating to processing grass curing
 """
 from datetime import date
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
+
 from wps_shared.db.models.grass_curing import PercentGrassCuring
+
 
 async def save_percent_grass_curing(session: AsyncSession, percent_grass_curing: PercentGrassCuring):
     """ Add a new PercentGrassCuring record.
@@ -30,8 +33,8 @@ async def get_last_percent_grass_curing_for_date(session: AsyncSession):
 
 
 def get_percent_grass_curing_by_station_for_date_range(session: Session, start_date: date, end_date: date, station_codes: list[int]):
-    """ Given a list of stations, a start date and an end date, return the percent grass curing from processed CWFIS data
-        for each station and each date in the specidifed range.
+    """Given a list of stations, a start date and an end date, return the percent grass curing from processed CWFIS data
+        for each station and each date in the specified range.
 
     :param session: A session object for asynchronous database access.
     :type session: AsyncSession

--- a/openshift/scripts/oc_provision_grass_curing_cronjob.sh
+++ b/openshift/scripts/oc_provision_grass_curing_cronjob.sh
@@ -26,7 +26,7 @@ source "$(dirname ${0})/common/common"
 PROJ_TARGET="${PROJ_TARGET:-${PROJ_DEV}}"
 
 # Specify a default schedule to run daily at 5am-ish
-SCHEDULE="${SCHEDULE:-$((3 + $RANDOM % 54)) 5 * * *}"
+SCHEDULE="${SCHEDULE:-$((3 + $RANDOM % 54)) * * * *}"
 
 # Process template
 OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/grass_curing.cronjob.yaml \


### PR DESCRIPTION
The CWFIS GeoServer is super flaky when it comes to down loading Web Coverage data. Fortunately, the CWFIS also makes the grass curing data available by https now. Included in this PR:

- download percent grass curing data via https
- ignore 404 responses as data may not yet be available early in the morning (log a warning)
- improves test coverage
- uses async methods when fetching and writing the grass coverage tif
# Test Links:
[Landing Page](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5382-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
