### PR TITLE
Fix duplicate fuel data

### DIFF
--- a/backend/packages/wps-api/src/app/routers/fba.py
+++ b/backend/packages/wps-api/src/app/routers/fba.py
@@ -111,6 +111,7 @@ async def get_all_zone_data_for_source_ids(
             )
 
         zone_fuel_stats = []
+        hfi_fuel_type_ids_for_zone_set = list(set(hfi_fuel_type_ids_for_zone))
         for (
             critical_hour_start,
             critical_hour_end,
@@ -119,7 +120,7 @@ async def get_all_zone_data_for_source_ids(
             area,
             fuel_area,
             percent_conifer,
-        ) in hfi_fuel_type_ids_for_zone:
+        ) in hfi_fuel_type_ids_for_zone_set:
             hfi_threshold = hfi_thresholds_by_id.get(threshold_id)
             if hfi_threshold is None:
                 logger.error(f"No hfi threshold for id: {threshold_id}")

--- a/backend/packages/wps-api/src/app/tests/fba/test_get_all_zone_data_for_source_ids.py
+++ b/backend/packages/wps-api/src/app/tests/fba/test_get_all_zone_data_for_source_ids.py
@@ -1,15 +1,13 @@
 """Unit tests for get_all_zone_data_for_source_ids in app.routers.fba"""
-import asyncio
+import pytest
 from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
+from app.auto_spatial_advisory.process_hfi import RunType
+from app.routers.fba import get_all_zone_data_for_source_ids
 from wps_shared.db.models.auto_spatial_advisory import AdvisoryHFIWindSpeed, SFMSFuelType
 from wps_shared.db.models.fuel_type_raster import FuelTypeRaster
 from wps_shared.schemas.fba import HfiThreshold
-
-from app.auto_spatial_advisory.process_hfi import RunType
-from app.routers.fba import get_all_zone_data_for_source_ids
 
 FOR_DATE = date(2024, 7, 15)
 RUN_DATETIME = datetime(2024, 7, 15, 12, tzinfo=timezone.utc)
@@ -45,28 +43,26 @@ mock_fuel_types = [SFMSFuelType(id=1, fuel_type_id=1, fuel_type_code="C2", descr
 SAMPLE_ROW = (9.0, 11.0, 1, 1, 50, 100, 1)
 
 
-def run_async(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
-
-
 def make_session():
     return MagicMock()
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
 @patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
 @patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
-def test_basic_returns_zone_with_fuel_area_stats(*_):
+async def test_basic_returns_zone_with_fuel_area_stats(*_):
     """Returns a FireZoneHFIStats with one fuel_area_stats entry for a single valid row."""
-    result = run_async(
-        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    result = await get_all_zone_data_for_source_ids(
+        make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
     )
     assert 1 in result
     assert len(result[1].fuel_area_stats) == 1
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
@@ -76,19 +72,20 @@ def test_basic_returns_zone_with_fuel_area_stats(*_):
     new_callable=AsyncMock,
     return_value=[SAMPLE_ROW, SAMPLE_ROW, SAMPLE_ROW],
 )
-def test_duplicate_rows_are_deduplicated(*_):
+async def test_duplicate_rows_are_deduplicated(*_):
     """Duplicate rows from get_precomputed_stats_for_shape produce only one fuel_area_stats entry."""
-    result = run_async(
-        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    result = await get_all_zone_data_for_source_ids(
+        make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
     )
     assert 1 in result
     assert len(result[1].fuel_area_stats) == 1
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
 @patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
-def test_empty_current_year_falls_back_to_prev_year(mock_wind, mock_thresholds, mock_fuel_types_fn):
+async def test_empty_current_year_falls_back_to_prev_year(*_):
     """Falls back to previous year's fuel raster when current year returns no rows."""
     raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
     precomputed_side_effects = [[], [SAMPLE_ROW]]
@@ -99,20 +96,19 @@ def test_empty_current_year_falls_back_to_prev_year(mock_wind, mock_thresholds, 
             new_callable=AsyncMock,
             side_effect=precomputed_side_effects,
         ):
-            result = run_async(
-                get_all_zone_data_for_source_ids(
-                    make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
-                )
+            result = await get_all_zone_data_for_source_ids(
+                make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
             )
 
     assert 1 in result
     assert len(result[1].fuel_area_stats) == 1
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
 @patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
-def test_none_current_year_falls_back_to_prev_year(mock_wind, mock_thresholds, mock_fuel_types_fn):
+async def test_none_current_year_falls_back_to_prev_year(*_):
     """Falls back to previous year's fuel raster when current year returns None."""
     raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
     precomputed_side_effects = [None, [SAMPLE_ROW]]
@@ -123,20 +119,19 @@ def test_none_current_year_falls_back_to_prev_year(mock_wind, mock_thresholds, m
             new_callable=AsyncMock,
             side_effect=precomputed_side_effects,
         ):
-            result = run_async(
-                get_all_zone_data_for_source_ids(
-                    make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
-                )
+            result = await get_all_zone_data_for_source_ids(
+                make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
             )
 
     assert 1 in result
     assert len(result[1].fuel_area_stats) == 1
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
 @patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
-def test_no_data_for_either_year_returns_empty_fuel_stats(mock_wind, mock_thresholds, mock_fuel_types_fn):
+async def test_no_data_for_either_year_returns_empty_fuel_stats(*_):
     """Returns an empty fuel_area_stats list when neither year has precomputed stats."""
     raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
     precomputed_side_effects = [[], []]
@@ -147,30 +142,30 @@ def test_no_data_for_either_year_returns_empty_fuel_stats(mock_wind, mock_thresh
             new_callable=AsyncMock,
             side_effect=precomputed_side_effects,
         ):
-            result = run_async(
-                get_all_zone_data_for_source_ids(
-                    make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
-                )
+            result = await get_all_zone_data_for_source_ids(
+                make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
             )
 
     assert 1 in result
     assert result[1].fuel_area_stats == []
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value={})
 @patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
 @patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
-def test_missing_threshold_skips_row(*_):
+async def test_missing_threshold_skips_row(*_):
     """Skips rows whose threshold_id is not in hfi_thresholds_by_id."""
-    result = run_async(
-        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    result = await get_all_zone_data_for_source_ids(
+        make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
     )
     assert 1 in result
     assert result[1].fuel_area_stats == []
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
@@ -182,39 +177,39 @@ def test_missing_threshold_skips_row(*_):
     },
 )
 @patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
-def test_wind_stats_attached_to_correct_zone(*_):
+async def test_wind_stats_attached_to_correct_zone(*_):
     """Wind stats for a zone source ID are included in the corresponding FireZoneHFIStats."""
-    result = run_async(
-        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    result = await get_all_zone_data_for_source_ids(
+        make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
     )
     assert 1 in result
     assert len(result[1].min_wind_stats) == 1
-    assert result[1].min_wind_stats[0].min_wind_speed == 5.0
+    assert result[1].min_wind_stats[0].min_wind_speed == pytest.approx(5.0)
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
 @patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
 @patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
-def test_zone_without_wind_speed_data_has_empty_min_wind_stats(*_):
+async def test_zone_without_wind_speed_data_has_empty_min_wind_stats(*_):
     """Zones with no wind speed data in the response get an empty min_wind_stats list."""
-    result = run_async(
-        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    result = await get_all_zone_data_for_source_ids(
+        make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
     )
     assert 1 in result
     assert result[1].min_wind_stats == []
 
 
+@pytest.mark.anyio
 @patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
 @patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
 @patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
 @patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
 @patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[])
-def test_empty_zone_source_ids_returns_empty_dict(mock_precomputed, *_):
+async def test_empty_zone_source_ids_returns_empty_dict(mock_precomputed, *_):
     """Returns an empty dict when zone_source_ids is empty."""
-    result = run_async(
-        get_all_zone_data_for_source_ids(make_session(), [], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
-    )
+    result = await get_all_zone_data_for_source_ids(make_session(), [], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
     assert result == {}
     mock_precomputed.assert_not_called()

--- a/backend/packages/wps-api/src/app/tests/fba/test_get_all_zone_data_for_source_ids.py
+++ b/backend/packages/wps-api/src/app/tests/fba/test_get_all_zone_data_for_source_ids.py
@@ -1,0 +1,220 @@
+"""Unit tests for get_all_zone_data_for_source_ids in app.routers.fba"""
+import asyncio
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from wps_shared.db.models.auto_spatial_advisory import AdvisoryHFIWindSpeed, SFMSFuelType
+from wps_shared.db.models.fuel_type_raster import FuelTypeRaster
+from wps_shared.schemas.fba import HfiThreshold
+
+from app.auto_spatial_advisory.process_hfi import RunType
+from app.routers.fba import get_all_zone_data_for_source_ids
+
+FOR_DATE = date(2024, 7, 15)
+RUN_DATETIME = datetime(2024, 7, 15, 12, tzinfo=timezone.utc)
+ZONE_SOURCE_ID = "1"
+
+mock_fuel_type_raster = FuelTypeRaster(
+    id=1,
+    year=2024,
+    version=1,
+    xsize=100,
+    ysize=200,
+    object_store_path="test/path",
+    content_hash="abc123",
+    create_timestamp=datetime(2024, 5, 1, tzinfo=timezone.utc),
+)
+
+mock_prev_fuel_type_raster = FuelTypeRaster(
+    id=2,
+    year=2023,
+    version=1,
+    xsize=100,
+    ysize=200,
+    object_store_path="test/path/prev",
+    content_hash="def456",
+    create_timestamp=datetime(2023, 5, 1, tzinfo=timezone.utc),
+)
+
+mock_hfi_thresholds = {1: HfiThreshold(id=1, description="4000 < hfi < 10000", name="advisory")}
+
+mock_fuel_types = [SFMSFuelType(id=1, fuel_type_id=1, fuel_type_code="C2", description="test fuel type c2")]
+
+# (critical_hour_start, critical_hour_end, fuel_type_id, threshold_id, area, fuel_area, percent_conifer)
+SAMPLE_ROW = (9.0, 11.0, 1, 1, 50, 100, 1)
+
+
+def run_async(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def make_session():
+    return MagicMock()
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
+@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
+@patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
+def test_basic_returns_zone_with_fuel_area_stats(*_):
+    """Returns a FireZoneHFIStats with one fuel_area_stats entry for a single valid row."""
+    result = run_async(
+        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    )
+    assert 1 in result
+    assert len(result[1].fuel_area_stats) == 1
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
+@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
+@patch(
+    "app.routers.fba.get_precomputed_stats_for_shape",
+    new_callable=AsyncMock,
+    return_value=[SAMPLE_ROW, SAMPLE_ROW, SAMPLE_ROW],
+)
+def test_duplicate_rows_are_deduplicated(*_):
+    """Duplicate rows from get_precomputed_stats_for_shape produce only one fuel_area_stats entry."""
+    result = run_async(
+        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    )
+    assert 1 in result
+    assert len(result[1].fuel_area_stats) == 1
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
+@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
+def test_empty_current_year_falls_back_to_prev_year(mock_wind, mock_thresholds, mock_fuel_types_fn):
+    """Falls back to previous year's fuel raster when current year returns no rows."""
+    raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
+    precomputed_side_effects = [[], [SAMPLE_ROW]]
+
+    with patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, side_effect=raster_side_effects):
+        with patch(
+            "app.routers.fba.get_precomputed_stats_for_shape",
+            new_callable=AsyncMock,
+            side_effect=precomputed_side_effects,
+        ):
+            result = run_async(
+                get_all_zone_data_for_source_ids(
+                    make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
+                )
+            )
+
+    assert 1 in result
+    assert len(result[1].fuel_area_stats) == 1
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
+@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
+def test_none_current_year_falls_back_to_prev_year(mock_wind, mock_thresholds, mock_fuel_types_fn):
+    """Falls back to previous year's fuel raster when current year returns None."""
+    raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
+    precomputed_side_effects = [None, [SAMPLE_ROW]]
+
+    with patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, side_effect=raster_side_effects):
+        with patch(
+            "app.routers.fba.get_precomputed_stats_for_shape",
+            new_callable=AsyncMock,
+            side_effect=precomputed_side_effects,
+        ):
+            result = run_async(
+                get_all_zone_data_for_source_ids(
+                    make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
+                )
+            )
+
+    assert 1 in result
+    assert len(result[1].fuel_area_stats) == 1
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
+@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
+def test_no_data_for_either_year_returns_empty_fuel_stats(mock_wind, mock_thresholds, mock_fuel_types_fn):
+    """Returns an empty fuel_area_stats list when neither year has precomputed stats."""
+    raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
+    precomputed_side_effects = [[], []]
+
+    with patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, side_effect=raster_side_effects):
+        with patch(
+            "app.routers.fba.get_precomputed_stats_for_shape",
+            new_callable=AsyncMock,
+            side_effect=precomputed_side_effects,
+        ):
+            result = run_async(
+                get_all_zone_data_for_source_ids(
+                    make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
+                )
+            )
+
+    assert 1 in result
+    assert result[1].fuel_area_stats == []
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value={})
+@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
+@patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
+def test_missing_threshold_skips_row(*_):
+    """Skips rows whose threshold_id is not in hfi_thresholds_by_id."""
+    result = run_async(
+        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    )
+    assert 1 in result
+    assert result[1].fuel_area_stats == []
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
+@patch(
+    "app.routers.fba.get_min_wind_speed_hfi_thresholds",
+    new_callable=AsyncMock,
+    return_value={
+        1: (AdvisoryHFIWindSpeed(id=1, advisory_shape_id=1, threshold=1, run_parameters=1, min_wind_speed=5.0),)
+    },
+)
+@patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
+def test_wind_stats_attached_to_correct_zone(*_):
+    """Wind stats for a zone source ID are included in the corresponding FireZoneHFIStats."""
+    result = run_async(
+        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    )
+    assert 1 in result
+    assert len(result[1].min_wind_stats) == 1
+    assert result[1].min_wind_stats[0].min_wind_speed == 5.0
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
+@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
+@patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
+def test_zone_without_wind_speed_data_has_empty_min_wind_stats(*_):
+    """Zones with no wind speed data in the response get an empty min_wind_stats list."""
+    result = run_async(
+        get_all_zone_data_for_source_ids(make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    )
+    assert 1 in result
+    assert result[1].min_wind_stats == []
+
+
+@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
+@patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
+@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
+@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
+@patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[])
+def test_empty_zone_source_ids_returns_empty_dict(mock_precomputed, *_):
+    """Returns an empty dict when zone_source_ids is empty."""
+    result = run_async(
+        get_all_zone_data_for_source_ids(make_session(), [], RunType.FORECAST, FOR_DATE, RUN_DATETIME)
+    )
+    assert result == {}
+    mock_precomputed.assert_not_called()

--- a/backend/packages/wps-api/src/app/tests/fba/test_get_all_zone_data_for_source_ids.py
+++ b/backend/packages/wps-api/src/app/tests/fba/test_get_all_zone_data_for_source_ids.py
@@ -47,81 +47,59 @@ def make_session():
     return MagicMock()
 
 
-@pytest.mark.anyio
-@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
-@patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
-@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
-@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
-@patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, return_value=[SAMPLE_ROW])
-async def test_basic_returns_zone_with_fuel_area_stats(*_):
-    """Returns a FireZoneHFIStats with one fuel_area_stats entry for a single valid row."""
-    result = await get_all_zone_data_for_source_ids(
-        make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
-    )
-    assert 1 in result
-    assert len(result[1].fuel_area_stats) == 1
+def patch_common_deps(mocker):
+    mocker.patch("app.routers.fba.get_all_sfms_fuel_type_records", return_value=mock_fuel_types)
+    mocker.patch("app.routers.fba.get_all_hfi_thresholds_by_id", return_value=mock_hfi_thresholds)
+    mocker.patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", return_value={})
+    mocker.patch("app.routers.fba.get_fuel_type_raster_by_year", return_value=mock_fuel_type_raster)
 
 
 @pytest.mark.anyio
-@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
-@patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, return_value=mock_fuel_type_raster)
-@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
-@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
-@patch(
-    "app.routers.fba.get_precomputed_stats_for_shape",
-    new_callable=AsyncMock,
-    return_value=[SAMPLE_ROW, SAMPLE_ROW, SAMPLE_ROW],
+@pytest.mark.parametrize(
+    "precomputed_rows",
+    [
+        pytest.param([SAMPLE_ROW], id="single_row"),
+        pytest.param([SAMPLE_ROW, SAMPLE_ROW, SAMPLE_ROW], id="duplicate_rows"),
+    ],
 )
-async def test_duplicate_rows_are_deduplicated(*_):
-    """Duplicate rows from get_precomputed_stats_for_shape produce only one fuel_area_stats entry."""
+async def test_precomputed_rows_deduplicated_to_one_fuel_stat(mocker, precomputed_rows):
+    """Duplicate rows from get_precomputed_stats_for_shape are deduplicated to one fuel_area_stats entry."""
+    patch_common_deps(mocker)
+    mocker.patch("app.routers.fba.get_precomputed_stats_for_shape", return_value=precomputed_rows)
+
     result = await get_all_zone_data_for_source_ids(
         make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
     )
-    assert 1 in result
-    assert len(result[1].fuel_area_stats) == 1
-
-
-@pytest.mark.anyio
-@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
-@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
-@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
-async def test_empty_current_year_falls_back_to_prev_year(*_):
-    """Falls back to previous year's fuel raster when current year returns no rows."""
-    raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
-    precomputed_side_effects = [[], [SAMPLE_ROW]]
-
-    with patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, side_effect=raster_side_effects):
-        with patch(
-            "app.routers.fba.get_precomputed_stats_for_shape",
-            new_callable=AsyncMock,
-            side_effect=precomputed_side_effects,
-        ):
-            result = await get_all_zone_data_for_source_ids(
-                make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
-            )
 
     assert 1 in result
     assert len(result[1].fuel_area_stats) == 1
 
 
 @pytest.mark.anyio
-@patch("app.routers.fba.get_all_sfms_fuel_type_records", new_callable=AsyncMock, return_value=mock_fuel_types)
-@patch("app.routers.fba.get_all_hfi_thresholds_by_id", new_callable=AsyncMock, return_value=mock_hfi_thresholds)
-@patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
-async def test_none_current_year_falls_back_to_prev_year(*_):
-    """Falls back to previous year's fuel raster when current year returns None."""
-    raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
-    precomputed_side_effects = [None, [SAMPLE_ROW]]
+@pytest.mark.parametrize(
+    "first_precomputed_result",
+    [
+        pytest.param([], id="empty_list"),
+        pytest.param(None, id="none_result"),
+    ],
+)
+async def test_falls_back_to_prev_year_raster(mocker, first_precomputed_result):
+    """Falls back to previous year's fuel raster when current year returns empty or None."""
+    mocker.patch("app.routers.fba.get_all_sfms_fuel_type_records", return_value=mock_fuel_types)
+    mocker.patch("app.routers.fba.get_all_hfi_thresholds_by_id", return_value=mock_hfi_thresholds)
+    mocker.patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", return_value={})
+    mocker.patch(
+        "app.routers.fba.get_fuel_type_raster_by_year",
+        side_effect=[mock_fuel_type_raster, mock_prev_fuel_type_raster],
+    )
+    mocker.patch(
+        "app.routers.fba.get_precomputed_stats_for_shape",
+        side_effect=[first_precomputed_result, [SAMPLE_ROW]],
+    )
 
-    with patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, side_effect=raster_side_effects):
-        with patch(
-            "app.routers.fba.get_precomputed_stats_for_shape",
-            new_callable=AsyncMock,
-            side_effect=precomputed_side_effects,
-        ):
-            result = await get_all_zone_data_for_source_ids(
-                make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
-            )
+    result = await get_all_zone_data_for_source_ids(
+        make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
+    )
 
     assert 1 in result
     assert len(result[1].fuel_area_stats) == 1
@@ -133,15 +111,8 @@ async def test_none_current_year_falls_back_to_prev_year(*_):
 @patch("app.routers.fba.get_min_wind_speed_hfi_thresholds", new_callable=AsyncMock, return_value={})
 async def test_no_data_for_either_year_returns_empty_fuel_stats(*_):
     """Returns an empty fuel_area_stats list when neither year has precomputed stats."""
-    raster_side_effects = [mock_fuel_type_raster, mock_prev_fuel_type_raster]
-    precomputed_side_effects = [[], []]
-
-    with patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, side_effect=raster_side_effects):
-        with patch(
-            "app.routers.fba.get_precomputed_stats_for_shape",
-            new_callable=AsyncMock,
-            side_effect=precomputed_side_effects,
-        ):
+    with patch("app.routers.fba.get_fuel_type_raster_by_year", new_callable=AsyncMock, side_effect=[mock_fuel_type_raster, mock_prev_fuel_type_raster]):
+        with patch("app.routers.fba.get_precomputed_stats_for_shape", new_callable=AsyncMock, side_effect=[[], []]):
             result = await get_all_zone_data_for_source_ids(
                 make_session(), [ZONE_SOURCE_ID], RunType.FORECAST, FOR_DATE, RUN_DATETIME
             )


### PR DESCRIPTION
Duplicate data appeared for hfi fuel area stats on the front-end this morning. This was due to duplicate critical hours data in the db impacting joins in a complex query. This PR creates a set from the rows returned from the query for hfi fuel stats thus eliminating the duplicates.

If you want to test locally the easiest way to to create duplicate data is in `get_all_zone_data_for_source_ids` by adding the following at line 114 of `fba.py`.
`hfi_fuel_type_ids_for_zone = hfi_fuel_type_ids_for_zone * 2` 

# Test Links:
[Landing Page](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5386-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
