### PR TITLE
Responsive landing page

### DIFF
--- a/mobile/asa-go/src/components/AppDescription.tsx
+++ b/mobile/asa-go/src/components/AppDescription.tsx
@@ -1,26 +1,29 @@
-import { styled, Typography } from "@mui/material";
+import { Box, styled, Typography, useTheme } from "@mui/material";
 
-const StyledDescription = styled(Typography)(({ theme }) => ({
-  [theme.breakpoints.down("md")]: { maxWidth: "80%" },
-  [theme.breakpoints.up("md")]: { maxWidth: "50%" },
+const StyledDescription = styled(Typography)(() => ({
+  color: "white",
+  textAlign: "center",
+  fontWeight: "bold",
 }));
 
 const AppDescription = () => {
+  const theme = useTheme();
   return (
-    <StyledDescription
-      data-testid="app-description"
-      sx={{
-        color: "white",
-        display: "flex",
-        textAlign: "center",
-        fontWeight: "bold",
-      }}
-      variant="body1"
-    >
-      {
-        "A spatial analysis tool that automates the continuous monitoring, updating, and communication of anticipated fire behaviour that will challenge direct suppression efforts and put the safety of responders at risk."
-      }
-    </StyledDescription>
+    <Box>
+      <StyledDescription data-testid="app-description-p1" variant="body1">
+        A spatial analysis tool that automates the continuous monitoring,
+        updating, and communication of anticipated fire behaviour that will
+        challenge direct suppression efforts and put the safety of responders at
+        risk.
+      </StyledDescription>
+      <StyledDescription
+        data-testid="app-description-p2"
+        variant="body1"
+        sx={{ pt: theme.spacing(4) }}
+      >
+        A government of BC IDIR is required for advanced features.
+      </StyledDescription>
+    </Box>
   );
 };
 

--- a/mobile/asa-go/src/components/AuthWrapper.test.tsx
+++ b/mobile/asa-go/src/components/AuthWrapper.test.tsx
@@ -1,22 +1,22 @@
 import * as selectors from "@/store";
 import { createTestStore } from "@/testUtils";
-import * as capacitor from "@capacitor/core";
+import { useIsPortrait } from "@/hooks/useIsPortrait";
+import { useIsTablet } from "@/hooks/useIsTablet";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AuthWrapper from "./AuthWrapper";
 
-// Mock LoginButton and AsaIcon
-vi.mock("@/components/LoginButton", () => ({
-  default: ({ label }: { label: string }) => <button>{label}</button>,
+vi.mock("@/hooks/useIsPortrait", () => ({ useIsPortrait: vi.fn() }));
+vi.mock("@/hooks/useIsTablet", () => ({ useIsTablet: vi.fn() }));
+vi.mock("@/components/PortraitLandingPage", () => ({
+  default: () => <div data-testid="portrait-landing-page" />,
+}));
+vi.mock("@/components/LandscapeLandingPage", () => ({
+  default: () => <div data-testid="landscape-landing-page" />,
 }));
 
-vi.mock("@/assets/asa-go-transparent.png", () => ({
-  default: "mocked-image.png",
-}));
-
-// Create a typed mock store
 const mockStore = createTestStore();
 const theme = createTheme();
 
@@ -32,10 +32,11 @@ const renderWithProviders = (children = <div>Protected</div>) =>
 describe("AuthWrapper", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.mocked(useIsPortrait).mockReturnValue(true);
+    vi.mocked(useIsTablet).mockReturnValue(false);
   });
 
   it("renders children when authenticated", () => {
-    vi.spyOn(capacitor.Capacitor, "getPlatform").mockReturnValue("web");
     vi.spyOn(selectors, "selectAuthentication").mockReturnValue({
       sessionMode: "authenticated",
       authenticating: false,
@@ -52,8 +53,7 @@ describe("AuthWrapper", () => {
     expect(screen.getByText("Protected")).toBeInTheDocument();
   });
 
-  it("renders children when not authenticated and offline", () => {
-    vi.spyOn(capacitor.Capacitor, "getPlatform").mockReturnValue("web");
+  it("renders children when unauthenticated and offline", () => {
     vi.spyOn(selectors, "selectAuthentication").mockReturnValue({
       sessionMode: "login",
       authenticating: false,
@@ -73,91 +73,48 @@ describe("AuthWrapper", () => {
     expect(screen.getByText("Protected")).toBeInTheDocument();
   });
 
-  it("renders login button when online, in login mode and not authenticating", () => {
-    vi.spyOn(capacitor.Capacitor, "getPlatform").mockReturnValue("web");
-    vi.spyOn(selectors, "selectAuthentication").mockReturnValue({
-      sessionMode: "login",
-      authenticating: false,
-      error: null,
-      tokenRefreshed: false,
-      idToken: undefined,
-      idir: undefined,
-      token: "test-token",
-      email: "test@email.com",
-    });
-    vi.spyOn(selectors, "selectNetworkStatus").mockReturnValue({
-      networkStatus: { connected: true, connectionType: "wifi" },
-    });
-
-    renderWithProviders();
-
-    expect(screen.getByText("Login")).toBeInTheDocument();
-  });
-
-  it("renders app description and title when unauthenticated and not authenticating", () => {
-    vi.spyOn(capacitor.Capacitor, "getPlatform").mockReturnValue("web");
-    vi.spyOn(selectors, "selectAuthentication").mockReturnValue({
-      sessionMode: "login",
-      authenticating: false,
-      error: null,
-      tokenRefreshed: false,
-      idToken: undefined,
-      idir: undefined,
-      token: "test-token",
-      email: "test@email.com",
-    });
-    vi.spyOn(selectors, "selectNetworkStatus").mockReturnValue({
-      networkStatus: { connected: true, connectionType: "wifi" },
+  describe("landing page routing when online and unauthenticated", () => {
+    beforeEach(() => {
+      vi.spyOn(selectors, "selectAuthentication").mockReturnValue({
+        sessionMode: "login",
+        authenticating: false,
+        error: null,
+        tokenRefreshed: false,
+        idToken: undefined,
+        idir: undefined,
+        token: undefined,
+        email: undefined,
+      });
+      vi.spyOn(selectors, "selectNetworkStatus").mockReturnValue({
+        networkStatus: { connected: true, connectionType: "wifi" },
+      });
     });
 
-    renderWithProviders();
+    it("renders PortraitLandingPage in portrait orientation", () => {
+      vi.mocked(useIsPortrait).mockReturnValue(true);
+      vi.mocked(useIsTablet).mockReturnValue(false);
 
-    expect(screen.getByText("ASA Go")).toBeInTheDocument();
-    const description = screen.getByTestId("app-description");
-    expect(description).toBeInTheDocument();
-  });
+      renderWithProviders();
 
-  it("renders loading spinner when authenticating", () => {
-    vi.spyOn(capacitor.Capacitor, "getPlatform").mockReturnValue("web");
-    vi.spyOn(selectors, "selectAuthentication").mockReturnValue({
-      sessionMode: "login",
-      authenticating: true,
-      error: null,
-      tokenRefreshed: false,
-      idToken: undefined,
-      idir: undefined,
-      token: "test-token",
-      email: "test@email.com",
-    });
-    vi.spyOn(selectors, "selectNetworkStatus").mockReturnValue({
-      networkStatus: { connected: true, connectionType: "wifi" },
+      expect(screen.getByTestId("portrait-landing-page")).toBeInTheDocument();
     });
 
-    renderWithProviders();
+    it("renders PortraitLandingPage on a tablet regardless of orientation", () => {
+      vi.mocked(useIsPortrait).mockReturnValue(false);
+      vi.mocked(useIsTablet).mockReturnValue(true);
 
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
-  });
+      renderWithProviders();
 
-  it("renders error message when login fails", () => {
-    vi.spyOn(capacitor.Capacitor, "getPlatform").mockReturnValue("web");
-    vi.spyOn(selectors, "selectAuthentication").mockReturnValue({
-      sessionMode: "login",
-      authenticating: false,
-      error: "Invalid credentials",
-      tokenRefreshed: false,
-      idToken: undefined,
-      idir: undefined,
-      token: "test-token",
-      email: "test@email.com",
-    });
-    vi.spyOn(selectors, "selectNetworkStatus").mockReturnValue({
-      networkStatus: { connected: true, connectionType: "wifi" },
+      expect(screen.getByTestId("portrait-landing-page")).toBeInTheDocument();
     });
 
-    renderWithProviders();
+    it("renders LandscapeLandingPage on a phone in landscape orientation", () => {
+      vi.mocked(useIsPortrait).mockReturnValue(false);
+      vi.mocked(useIsTablet).mockReturnValue(false);
 
-    expect(
-      screen.getByText("Unable to login, please try again."),
-    ).toBeInTheDocument();
+      renderWithProviders();
+
+      expect(screen.getByTestId("landscape-landing-page")).toBeInTheDocument();
+    });
   });
 });

--- a/mobile/asa-go/src/components/AuthWrapper.tsx
+++ b/mobile/asa-go/src/components/AuthWrapper.tsx
@@ -1,9 +1,8 @@
-import AsaIcon from "@/assets/asa-go-transparent.png";
-import AppDescription from "@/components/AppDescription";
-import LoginButton from "@/components/LoginButton";
+import LandscapeLandingPage from "@/components/LandscapeLandingPage";
+import PortraitLandingPage from "@/components/PortraitLandingPage";
+import { useIsPortrait } from "@/hooks/useIsPortrait";
+import { useIsTablet } from "@/hooks/useIsTablet";
 import { selectAuthentication, selectNetworkStatus } from "@/store";
-import { Box, CircularProgress, Typography, useTheme } from "@mui/material";
-import { isNull } from "lodash";
 import React from "react";
 import { useSelector } from "react-redux";
 
@@ -12,104 +11,21 @@ interface Props {
 }
 
 const AuthWrapper = ({ children }: Props) => {
-  const theme = useTheme();
-  const { sessionMode, authenticating, error } =
-    useSelector(selectAuthentication);
+  const { sessionMode } = useSelector(selectAuthentication);
   const { networkStatus } = useSelector(selectNetworkStatus);
+  const isPortrait = useIsPortrait();
+  const isTablet = useIsTablet();
 
   if (sessionMode === "authenticated" || !networkStatus.connected) {
     return <React.StrictMode>{children}</React.StrictMode>;
   }
 
-  return (
-    <Box
-      sx={{
-        bgcolor: theme.palette.primary.dark,
-        display: "flex",
-        flexDirection: "column",
-        height: "100vh",
-      }}
-    >
-      <Box
-        sx={{
-          alignItems: "flex-end",
-          display: "flex",
-          flexGrow: 1,
-          justifyContent: "center",
-        }}
-      >
-        <Box sx={{ display: "flex", flexGrow: 1, justifyContent: "Center" }}>
-          <Box
-            component="img"
-            sx={{
-              height: { xs: "250px", sm: "300px", lg: "400px" },
-              width: { xs: "250px", sm: "300px", lg: "400px" },
-            }}
-            src={AsaIcon}
-          />
-        </Box>
-      </Box>
-      <Box
-        sx={{
-          alignItems: "center",
-          justifyContent: "center",
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        <Typography
-          sx={{
-            color: "white",
-            fontWeight: "bold",
-            mb: theme.spacing(2),
-          }}
-          variant="h2"
-        >
-          ASA Go
-        </Typography>
-        <AppDescription />
-      </Box>
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          flexGrow: 1,
-          alignItems: "center",
-          justifyContent: "space-between",
-          pb: theme.spacing(6),
-        }}
-      >
-        <Typography
-          sx={{
-            color: "white",
-            textAlign: "center",
-            fontWeight: "bold",
-            mt: theme.spacing(4),
-          }}
-          variant="body1"
-        >
-          A Government of BC IDIR is required for login.
-        </Typography>
-        {!authenticating && (
-          <>
-            <LoginButton label="Login" />
-          </>
-        )}
-        {authenticating && (
-          <Box sx={{ pt: theme.spacing(4) }}>
-            <CircularProgress color="secondary" />
-          </Box>
-        )}
-        {!isNull(error) && (
-          <Typography
-            sx={{ color: "white", mt: theme.spacing(5) }}
-            variant="h5"
-          >
-            Unable to login, please try again.
-          </Typography>
-        )}
-      </Box>
-    </Box>
+  // Phones in portrait orientation and all tablets have enough vertical real estate to render all the
+  // landing page elements as a stack. Phones in landscape orientation need things re-organized.
+  return isPortrait || isTablet ? (
+    <PortraitLandingPage />
+  ) : (
+    <LandscapeLandingPage />
   );
 };
 

--- a/mobile/asa-go/src/components/AuthWrapper.tsx
+++ b/mobile/asa-go/src/components/AuthWrapper.tsx
@@ -20,7 +20,7 @@ const AuthWrapper = ({ children }: Props) => {
     return <React.StrictMode>{children}</React.StrictMode>;
   }
 
-  // Phones in portrait orientation and all tablets have enough vertical real estate to render all the
+  // A phone in portrait orientation and all tablets have enough vertical real estate to render all the
   // landing page elements as a stack. Phones in landscape orientation need things re-organized.
   return isPortrait || isTablet ? (
     <PortraitLandingPage />

--- a/mobile/asa-go/src/components/LandscapeLandingPage.test.tsx
+++ b/mobile/asa-go/src/components/LandscapeLandingPage.test.tsx
@@ -1,0 +1,61 @@
+import LandscapeLandingPage from "@/components/LandscapeLandingPage";
+import { useIsXSSmallScreen } from "@/hooks/useIsXSScreen";
+import { theme } from "@/theme";
+import { ThemeProvider } from "@mui/material/styles";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/useIsXSScreen", () => ({ useIsXSSmallScreen: vi.fn() }));
+vi.mock("@/components/LoginActions", () => ({
+  default: ({ direction }: { direction?: string }) => (
+    <div data-testid="login-actions" data-direction={direction ?? "column"} />
+  ),
+}));
+vi.mock("@/assets/asa-go-transparent.png", () => ({
+  default: "mocked-image.png",
+}));
+
+const renderComponent = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <LandscapeLandingPage />
+    </ThemeProvider>,
+  );
+
+describe("LandscapeLandingPage", () => {
+  beforeEach(() => {
+    vi.mocked(useIsXSSmallScreen).mockReturnValue(false);
+  });
+
+  describe("static content", () => {
+    it("renders the ASA Go title", () => {
+      renderComponent();
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: "ASA Go" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the app description", () => {
+      renderComponent();
+
+      expect(screen.getByTestId("app-description-p1")).toBeInTheDocument();
+      expect(screen.getByTestId("app-description-p2")).toBeInTheDocument();
+    });
+
+    it("renders the icon", () => {
+      renderComponent();
+
+      expect(screen.getByRole("img")).toHaveAttribute("src", "mocked-image.png");
+    });
+
+    it("renders LoginActions with row direction", () => {
+      renderComponent();
+
+      expect(screen.getByTestId("login-actions")).toHaveAttribute(
+        "data-direction",
+        "row",
+      );
+    });
+  });
+});

--- a/mobile/asa-go/src/components/LandscapeLandingPage.tsx
+++ b/mobile/asa-go/src/components/LandscapeLandingPage.tsx
@@ -1,0 +1,102 @@
+import AsaIcon from "@/assets/asa-go-transparent.png";
+import AppDescription from "@/components/AppDescription";
+import LoginButton from "@/components/LoginButton";
+import PublicLoginButton from "@/components/PublicLoginButton";
+import { useIsXSSmallScreen } from "@/hooks/useIsXSScreen";
+import { selectAuthentication } from "@/store";
+import { Box, CircularProgress, Typography, useTheme } from "@mui/material";
+import { isNull } from "lodash";
+import { useSelector } from "react-redux";
+
+// Landscape orientation landing page for phones only, not to be used with tablets.
+const LandscapeLandingPage = () => {
+  const theme = useTheme();
+  const isXSSmallScreen = useIsXSSmallScreen();
+  const { authenticating, error } = useSelector(selectAuthentication);
+
+  return (
+    <Box
+      sx={{
+        bgcolor: theme.palette.primary.dark,
+        display: "flex",
+        height: "100vh",
+      }}
+    >
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexDirection: "row",
+          px: theme.spacing(2),
+          width: "100%",
+          paddingRight: "env(safe-area-inset-right)",
+          paddingLeft: "env(safe-area-inset-left)",
+        }}
+      >
+        <Box
+          sx={{
+            alignItems: "center",
+            display: "flex",
+            flex: "0 0 40%",
+            flexDirection: "column",
+            justifyContent: "center",
+          }}
+        >
+          <Box
+            component="img"
+            sx={{
+              height: isXSSmallScreen ? "200px" : "250px",
+              width: isXSSmallScreen ? "200px" : "250px",
+            }}
+            src={AsaIcon}
+          />
+          <Typography sx={{ color: "white", fontWeight: "bold" }} variant="h3">
+            ASA Go
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            alignItems: "center",
+            display: "flex",
+            flex: 1,
+            flexDirection: "column",
+            pl: theme.spacing(2),
+          }}
+        >
+          <Box sx={{ maxWidth: "80%" }}>
+            <AppDescription />
+          </Box>
+          <Box
+            sx={{
+              alignItems: "center",
+              display: "flex",
+              flexDirection: "row",
+              gap: theme.spacing(2),
+              justifyContent: "center",
+              pt: theme.spacing(8),
+            }}
+          >
+            {!authenticating && (
+              <>
+                <Box sx={{ pr: theme.spacing(4) }}>
+                  <LoginButton />
+                </Box>
+                <Box sx={{ pl: theme.spacing(4) }}>
+                  <PublicLoginButton />
+                </Box>
+              </>
+            )}
+            {authenticating && <CircularProgress color="secondary" />}
+            {!isNull(error) && (
+              <Typography sx={{ color: "white" }} variant="body1">
+                Unable to login, please try again.
+              </Typography>
+            )}
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default LandscapeLandingPage;

--- a/mobile/asa-go/src/components/LandscapeLandingPage.tsx
+++ b/mobile/asa-go/src/components/LandscapeLandingPage.tsx
@@ -66,7 +66,7 @@ const LandscapeLandingPage = () => {
               alignItems: "center",
               display: "flex",
               justifyContent: "center",
-              pt: theme.spacing(8),
+              pt: theme.spacing(4),
             }}
           >
             <LoginActions direction="row" />

--- a/mobile/asa-go/src/components/LandscapeLandingPage.tsx
+++ b/mobile/asa-go/src/components/LandscapeLandingPage.tsx
@@ -1,18 +1,13 @@
 import AsaIcon from "@/assets/asa-go-transparent.png";
 import AppDescription from "@/components/AppDescription";
-import LoginButton from "@/components/LoginButton";
-import PublicLoginButton from "@/components/PublicLoginButton";
+import LoginActions from "@/components/LoginActions";
 import { useIsXSSmallScreen } from "@/hooks/useIsXSScreen";
-import { selectAuthentication } from "@/store";
-import { Box, CircularProgress, Typography, useTheme } from "@mui/material";
-import { isNull } from "lodash";
-import { useSelector } from "react-redux";
+import { Box, Typography, useTheme } from "@mui/material";
 
 // Landscape orientation landing page for phones only, not to be used with tablets.
 const LandscapeLandingPage = () => {
   const theme = useTheme();
   const isXSSmallScreen = useIsXSSmallScreen();
-  const { authenticating, error } = useSelector(selectAuthentication);
 
   return (
     <Box
@@ -70,28 +65,11 @@ const LandscapeLandingPage = () => {
             sx={{
               alignItems: "center",
               display: "flex",
-              flexDirection: "row",
-              gap: theme.spacing(2),
               justifyContent: "center",
               pt: theme.spacing(8),
             }}
           >
-            {!authenticating && (
-              <>
-                <Box sx={{ pr: theme.spacing(4) }}>
-                  <LoginButton />
-                </Box>
-                <Box sx={{ pl: theme.spacing(4) }}>
-                  <PublicLoginButton />
-                </Box>
-              </>
-            )}
-            {authenticating && <CircularProgress color="secondary" />}
-            {!isNull(error) && (
-              <Typography sx={{ color: "white" }} variant="body1">
-                Unable to login, please try again.
-              </Typography>
-            )}
+            <LoginActions direction="row" />
           </Box>
         </Box>
       </Box>

--- a/mobile/asa-go/src/components/LoginActions.test.tsx
+++ b/mobile/asa-go/src/components/LoginActions.test.tsx
@@ -1,0 +1,116 @@
+import LoginActions from "@/components/LoginActions";
+import * as selectors from "@/store";
+import { createTestStore } from "@/testUtils";
+import { theme } from "@/theme";
+import { ThemeProvider } from "@mui/material/styles";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/LoginButton", () => ({
+  default: () => <button>IDIR</button>,
+}));
+vi.mock("@/components/PublicLoginButton", () => ({
+  default: () => <button>Log-in as Guest</button>,
+}));
+
+const mockStore = createTestStore();
+
+const renderComponent = (direction?: "row" | "column") =>
+  render(
+    <Provider store={mockStore}>
+      <ThemeProvider theme={theme}>
+        <LoginActions direction={direction} />
+      </ThemeProvider>
+    </Provider>,
+  );
+
+const mockAuthState = (authenticating: boolean, error: string | null = null) =>
+  vi.spyOn(selectors, "selectAuthentication").mockReturnValue({
+    authenticating,
+    error,
+    isAuthenticated: false,
+    tokenRefreshed: false,
+    idToken: undefined,
+    idir: undefined,
+    token: undefined,
+  });
+
+describe("LoginActions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("authentication state", () => {
+    it("renders login buttons when not authenticating", () => {
+      mockAuthState(false);
+      renderComponent();
+
+      expect(screen.getByRole("button", { name: /idir/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /log-in as guest/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders a spinner when authenticating", () => {
+      mockAuthState(true);
+      renderComponent();
+
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+
+    it("hides login buttons when authenticating", () => {
+      mockAuthState(true);
+      renderComponent();
+
+      expect(
+        screen.queryByRole("button", { name: /idir/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /log-in as guest/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("error state", () => {
+    it("renders an error message when login fails", () => {
+      mockAuthState(false, "Invalid credentials");
+      renderComponent();
+
+      expect(
+        screen.getByText("Unable to login, please try again."),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render an error message when there is no error", () => {
+      mockAuthState(false, null);
+      renderComponent();
+
+      expect(
+        screen.queryByText("Unable to login, please try again."),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("direction prop", () => {
+    it("renders buttons with column direction by default", () => {
+      mockAuthState(false);
+      renderComponent();
+
+      expect(screen.getByRole("button", { name: /idir/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /log-in as guest/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders buttons with row direction", () => {
+      mockAuthState(false);
+      renderComponent("row");
+
+      expect(screen.getByRole("button", { name: /idir/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /log-in as guest/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/mobile/asa-go/src/components/LoginActions.test.tsx
+++ b/mobile/asa-go/src/components/LoginActions.test.tsx
@@ -10,9 +10,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/components/LoginButton", () => ({
   default: () => <button>IDIR</button>,
 }));
-vi.mock("@/components/PublicLoginButton", () => ({
-  default: () => <button>Log-in as Guest</button>,
-}));
 
 const mockStore = createTestStore();
 
@@ -42,14 +39,11 @@ describe("LoginActions", () => {
   });
 
   describe("authentication state", () => {
-    it("renders login buttons when not authenticating", () => {
+    it("renders login button when not authenticating", () => {
       mockAuthState(false);
       renderComponent();
 
       expect(screen.getByRole("button", { name: /idir/i })).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /log-in as guest/i }),
-      ).toBeInTheDocument();
     });
 
     it("renders a spinner when authenticating", () => {
@@ -59,15 +53,12 @@ describe("LoginActions", () => {
       expect(screen.getByRole("progressbar")).toBeInTheDocument();
     });
 
-    it("hides login buttons when authenticating", () => {
+    it("hides login button when authenticating", () => {
       mockAuthState(true);
       renderComponent();
 
       expect(
         screen.queryByRole("button", { name: /idir/i }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: /log-in as guest/i }),
       ).not.toBeInTheDocument();
     });
   });
@@ -93,24 +84,18 @@ describe("LoginActions", () => {
   });
 
   describe("direction prop", () => {
-    it("renders buttons with column direction by default", () => {
+    it("renders button with column direction by default", () => {
       mockAuthState(false);
       renderComponent();
 
       expect(screen.getByRole("button", { name: /idir/i })).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /log-in as guest/i }),
-      ).toBeInTheDocument();
     });
 
-    it("renders buttons with row direction", () => {
+    it("renders button with row direction", () => {
       mockAuthState(false);
       renderComponent("row");
 
       expect(screen.getByRole("button", { name: /idir/i })).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /log-in as guest/i }),
-      ).toBeInTheDocument();
     });
   });
 });

--- a/mobile/asa-go/src/components/LoginActions.tsx
+++ b/mobile/asa-go/src/components/LoginActions.tsx
@@ -1,0 +1,43 @@
+import LoginButton from "@/components/LoginButton";
+import PublicLoginButton from "@/components/PublicLoginButton";
+import { selectAuthentication } from "@/store";
+import { Box, CircularProgress, Typography, useTheme } from "@mui/material";
+import { isNull } from "lodash";
+import { useSelector } from "react-redux";
+
+interface LoginActionsProps {
+  direction?: "row" | "column";
+}
+
+const LoginActions = ({ direction = "column" }: LoginActionsProps) => {
+  const theme = useTheme();
+  const { authenticating, error } = useSelector(selectAuthentication);
+
+  if (authenticating) {
+    return <CircularProgress color="secondary" />;
+  }
+
+  return (
+    <>
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexDirection: direction,
+          gap: theme.spacing(2),
+          justifyContent: "center",
+        }}
+      >
+        <LoginButton />
+        <PublicLoginButton />
+      </Box>
+      {!isNull(error) && (
+        <Typography sx={{ color: "white" }} variant="body1">
+          Unable to login, please try again.
+        </Typography>
+      )}
+    </>
+  );
+};
+
+export default LoginActions;

--- a/mobile/asa-go/src/components/LoginActions.tsx
+++ b/mobile/asa-go/src/components/LoginActions.tsx
@@ -1,5 +1,4 @@
 import LoginButton from "@/components/LoginButton";
-import PublicLoginButton from "@/components/PublicLoginButton";
 import { selectAuthentication } from "@/store";
 import { Box, CircularProgress, Typography, useTheme } from "@mui/material";
 import { isNull } from "lodash";
@@ -18,7 +17,14 @@ const LoginActions = ({ direction = "column" }: LoginActionsProps) => {
   }
 
   return (
-    <>
+    <Box
+      sx={{
+        alignItems: "center",
+        display: "flex",
+        flexDirection: "column",
+        gap: theme.spacing(2),
+      }}
+    >
       <Box
         sx={{
           alignItems: "center",
@@ -29,14 +35,13 @@ const LoginActions = ({ direction = "column" }: LoginActionsProps) => {
         }}
       >
         <LoginButton />
-        <PublicLoginButton />
       </Box>
       {!isNull(error) && (
         <Typography sx={{ color: "white" }} variant="body1">
           Unable to login, please try again.
         </Typography>
       )}
-    </>
+    </Box>
   );
 };
 

--- a/mobile/asa-go/src/components/LoginButton.tsx
+++ b/mobile/asa-go/src/components/LoginButton.tsx
@@ -3,11 +3,7 @@ import { AppDispatch } from "@/store";
 import { Button, Typography, useTheme } from "@mui/material";
 import { useDispatch } from "react-redux";
 
-interface LoginButonProps {
-  label: string;
-}
-
-const LoginButton = ({ label }: LoginButonProps) => {
+const LoginButton = () => {
   const dispatch: AppDispatch = useDispatch();
   const theme = useTheme();
 
@@ -19,12 +15,12 @@ const LoginButton = ({ label }: LoginButonProps) => {
       onClick={handleLogin}
       size="large"
       sx={{
-        border: "1px solid white",
-        color: "white",
+        bgcolor: theme.palette.secondary.main,
+        color: theme.palette.primary.main,
         display: "block",
-        mt: theme.spacing(5),
+        minWidth: "100px",
       }}
-      variant="outlined"
+      variant="contained"
     >
       <Typography
         sx={{
@@ -33,7 +29,7 @@ const LoginButton = ({ label }: LoginButonProps) => {
           fontWeight: "bold",
         }}
       >
-        {label}
+        IDIR
       </Typography>
     </Button>
   );

--- a/mobile/asa-go/src/components/PortraitLandingPage.test.tsx
+++ b/mobile/asa-go/src/components/PortraitLandingPage.test.tsx
@@ -1,0 +1,94 @@
+import PortraitLandingPage from "@/components/PortraitLandingPage";
+import { useIsTablet } from "@/hooks/useIsTablet";
+import { useIsXSSmallScreen } from "@/hooks/useIsXSScreen";
+import { theme } from "@/theme";
+import { ThemeProvider } from "@mui/material/styles";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/useIsXSScreen", () => ({ useIsXSSmallScreen: vi.fn() }));
+vi.mock("@/hooks/useIsTablet", () => ({ useIsTablet: vi.fn() }));
+vi.mock("@/components/LoginActions", () => ({
+  default: ({ direction }: { direction?: string }) => (
+    <div data-testid="login-actions" data-direction={direction ?? "column"} />
+  ),
+}));
+vi.mock("@/assets/asa-go-transparent.png", () => ({
+  default: "mocked-image.png",
+}));
+
+const renderComponent = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <PortraitLandingPage />
+    </ThemeProvider>,
+  );
+
+describe("PortraitLandingPage", () => {
+  beforeEach(() => {
+    vi.mocked(useIsXSSmallScreen).mockReturnValue(false);
+    vi.mocked(useIsTablet).mockReturnValue(false);
+  });
+
+  describe("static content", () => {
+    it("renders the ASA Go title", () => {
+      renderComponent();
+
+      expect(screen.getByText("ASA Go")).toBeInTheDocument();
+    });
+
+    it("renders the app description", () => {
+      renderComponent();
+
+      expect(screen.getByTestId("app-description-p1")).toBeInTheDocument();
+      expect(screen.getByTestId("app-description-p2")).toBeInTheDocument();
+    });
+
+    it("renders the icon", () => {
+      renderComponent();
+
+      expect(screen.getByRole("img")).toHaveAttribute("src", "mocked-image.png");
+    });
+
+    it("renders LoginActions with column direction", () => {
+      renderComponent();
+
+      expect(screen.getByTestId("login-actions")).toHaveAttribute(
+        "data-direction",
+        "column",
+      );
+    });
+  });
+
+  describe("screen size variants", () => {
+    it("renders an h4 title on XS small screens", () => {
+      vi.mocked(useIsXSSmallScreen).mockReturnValue(true);
+      vi.mocked(useIsTablet).mockReturnValue(false);
+      renderComponent();
+
+      expect(
+        screen.getByRole("heading", { level: 4, name: "ASA Go" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders an h3 title on regular phone screens", () => {
+      vi.mocked(useIsXSSmallScreen).mockReturnValue(false);
+      vi.mocked(useIsTablet).mockReturnValue(false);
+      renderComponent();
+
+      expect(
+        screen.getByRole("heading", { level: 3, name: "ASA Go" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders an h2 title on tablet screens", () => {
+      vi.mocked(useIsXSSmallScreen).mockReturnValue(false);
+      vi.mocked(useIsTablet).mockReturnValue(true);
+      renderComponent();
+
+      expect(
+        screen.getByRole("heading", { level: 2, name: "ASA Go" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/mobile/asa-go/src/components/PortraitLandingPage.tsx
+++ b/mobile/asa-go/src/components/PortraitLandingPage.tsx
@@ -1,24 +1,14 @@
 import AsaIcon from "@/assets/asa-go-transparent.png";
 import AppDescription from "@/components/AppDescription";
-import LoginButton from "@/components/LoginButton";
-import PublicLoginButton from "@/components/PublicLoginButton";
+import LoginActions from "@/components/LoginActions";
 import { useIsTablet } from "@/hooks/useIsTablet";
 import { useIsXSSmallScreen } from "@/hooks/useIsXSScreen";
-import { selectAuthentication } from "@/store";
-import {
-  Box,
-  CircularProgress,
-  Typography,
-  TypographyVariant,
-  useTheme,
-} from "@mui/material";
-import { useSelector } from "react-redux";
+import { Box, Typography, TypographyVariant, useTheme } from "@mui/material";
 
 const PortraitLandingPage = () => {
   const theme = useTheme();
   const isXSSmallScreen = useIsXSSmallScreen();
   const isTablet = useIsTablet();
-  const { authenticating } = useSelector(selectAuthentication);
 
   const getValueByScreenSize = (xs: string, sm: string, md: string) => {
     if (isXSSmallScreen) {
@@ -91,36 +81,11 @@ const PortraitLandingPage = () => {
               display: "flex",
               flexDirection: "column",
               justifyContent: "center",
+              pt: theme.spacing(4),
               width: "100%",
             }}
           >
-            {!authenticating && (
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  justifyContent: "center",
-                  width: "100%",
-                }}
-              >
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "center",
-                    pt: theme.spacing(4),
-                    pb: theme.spacing(4),
-                  }}
-                >
-                  <LoginButton />
-                </Box>
-                <PublicLoginButton />
-              </Box>
-            )}
-            {authenticating && (
-              <Box sx={{ pt: theme.spacing(4) }}>
-                <CircularProgress color="secondary" />
-              </Box>
-            )}
+            <LoginActions />
           </Box>
         </Box>
       </Box>

--- a/mobile/asa-go/src/components/PortraitLandingPage.tsx
+++ b/mobile/asa-go/src/components/PortraitLandingPage.tsx
@@ -1,0 +1,132 @@
+import AsaIcon from "@/assets/asa-go-transparent.png";
+import AppDescription from "@/components/AppDescription";
+import LoginButton from "@/components/LoginButton";
+import PublicLoginButton from "@/components/PublicLoginButton";
+import { useIsTablet } from "@/hooks/useIsTablet";
+import { useIsXSSmallScreen } from "@/hooks/useIsXSScreen";
+import { selectAuthentication } from "@/store";
+import {
+  Box,
+  CircularProgress,
+  Typography,
+  TypographyVariant,
+  useTheme,
+} from "@mui/material";
+import { useSelector } from "react-redux";
+
+const PortraitLandingPage = () => {
+  const theme = useTheme();
+  const isXSSmallScreen = useIsXSSmallScreen();
+  const isTablet = useIsTablet();
+  const { authenticating } = useSelector(selectAuthentication);
+
+  const getValueByScreenSize = (xs: string, sm: string, md: string) => {
+    if (isXSSmallScreen) {
+      return xs;
+    }
+    if (isTablet) {
+      return md;
+    }
+    return sm;
+  };
+
+  return (
+    <Box
+      sx={{
+        bgcolor: theme.palette.primary.dark,
+        display: "flex",
+        height: "100vh",
+      }}
+    >
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          paddingTop: "env(safe-area-inset-top)",
+          paddingBottom: "env(safe-area-inset-bottom)",
+          width: "100%",
+        }}
+      >
+        <Box
+          component="img"
+          sx={{
+            height: getValueByScreenSize("200px", "300px", "350px"),
+            width: getValueByScreenSize("200px", "300px", "350px"),
+          }}
+          src={AsaIcon}
+        />
+        <Box
+          sx={{
+            alignItems: "center",
+            justifyContent: "center",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <Typography
+            sx={{
+              color: "white",
+              fontWeight: "bold",
+              mb: theme.spacing(2),
+            }}
+            variant={
+              getValueByScreenSize("h4", "h3", "h2") as TypographyVariant
+            }
+          >
+            ASA Go
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            maxWidth: getValueByScreenSize("100%", "80%", "50%"),
+            width: "100%",
+          }}
+        >
+          <AppDescription />
+          <Box
+            sx={{
+              alignItems: "center",
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              width: "100%",
+            }}
+          >
+            {!authenticating && (
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center",
+                  width: "100%",
+                }}
+              >
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "center",
+                    pt: theme.spacing(4),
+                    pb: theme.spacing(4),
+                  }}
+                >
+                  <LoginButton />
+                </Box>
+                <PublicLoginButton />
+              </Box>
+            )}
+            {authenticating && (
+              <Box sx={{ pt: theme.spacing(4) }}>
+                <CircularProgress color="secondary" />
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </Box>
+      );
+    </Box>
+  );
+};
+
+export default PortraitLandingPage;

--- a/mobile/asa-go/src/components/PublicLoginButton.test.tsx
+++ b/mobile/asa-go/src/components/PublicLoginButton.test.tsx
@@ -1,0 +1,51 @@
+import PublicLoginButton from "@/components/PublicLoginButton";
+import { continueAsGuest } from "@/slices/authenticationSlice";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useDispatch } from "react-redux";
+import { Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-redux", async () => {
+  const actual = await vi.importActual("react-redux");
+  return {
+    ...actual,
+    useDispatch: vi.fn(),
+  };
+});
+
+vi.mock("@/slices/authenticationSlice", () => ({
+  continueAsGuest: vi.fn(() => ({ type: "CONTINUE_AS_GUEST" })),
+}));
+
+describe("PublicLoginButton", () => {
+  const mockDispatch = vi.fn();
+  const theme = createTheme();
+
+  beforeEach(() => {
+    (useDispatch as unknown as Mock).mockReturnValue(mockDispatch);
+    mockDispatch.mockClear();
+  });
+
+  const renderComponent = () =>
+    render(
+      <ThemeProvider theme={theme}>
+        <PublicLoginButton />
+      </ThemeProvider>,
+    );
+
+  it("renders the continue as guest button", () => {
+    renderComponent();
+
+    expect(
+      screen.getByRole("button", { name: /continue as guest/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("dispatches continueAsGuest on click", () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByRole("button", { name: /continue as guest/i }));
+
+    expect(mockDispatch).toHaveBeenCalledWith(continueAsGuest());
+  });
+});

--- a/mobile/asa-go/src/components/PublicLoginButton.tsx
+++ b/mobile/asa-go/src/components/PublicLoginButton.tsx
@@ -1,9 +1,16 @@
+import { continueAsGuest } from "@/slices/authenticationSlice";
+import { AppDispatch } from "@/store";
 import { Button } from "@mui/material";
+import { useDispatch } from "react-redux";
 
 const PublicLoginButton = () => {
+  const dispatch: AppDispatch = useDispatch();
+  const handleClick = () => {
+    dispatch(continueAsGuest());
+  };
   return (
     <Button
-      onClick={() => console.log("PublicLoginButton clicked")}
+      onClick={handleClick}
       sx={{ color: "white", textDecoration: "underline" }}
     >
       Continue as guest

--- a/mobile/asa-go/src/components/PublicLoginButton.tsx
+++ b/mobile/asa-go/src/components/PublicLoginButton.tsx
@@ -1,0 +1,14 @@
+import { Button } from "@mui/material";
+
+const PublicLoginButton = () => {
+  return (
+    <Button
+      onClick={() => console.log("PublicLoginButton clicked")}
+      sx={{ color: "white", textDecoration: "underline" }}
+    >
+      Continue as guest
+    </Button>
+  );
+};
+
+export default PublicLoginButton;

--- a/mobile/asa-go/src/components/loginButton.test.tsx
+++ b/mobile/asa-go/src/components/loginButton.test.tsx
@@ -1,11 +1,10 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import { Mock, vi } from "vitest";
 import LoginButton from "@/components/LoginButton";
-import { useDispatch } from "react-redux";
 import { authenticate } from "@/slices/authenticationSlice";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useDispatch } from "react-redux";
+import { Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mocks
 vi.mock("react-redux", async () => {
   const actual = await vi.importActual("react-redux");
   return {
@@ -27,24 +26,23 @@ describe("LoginButton", () => {
     mockDispatch.mockClear();
   });
 
-  it("renders the button with the correct label", () => {
+  const renderComponent = () =>
     render(
       <ThemeProvider theme={theme}>
-        <LoginButton label="Sign In" />
-      </ThemeProvider>
+        <LoginButton />
+      </ThemeProvider>,
     );
 
-    expect(screen.getByText("Sign In")).toBeInTheDocument();
+  it("renders the IDIR label", () => {
+    renderComponent();
+
+    expect(screen.getByRole("button", { name: /idir/i })).toBeInTheDocument();
   });
 
   it("dispatches authenticate on click", () => {
-    render(
-      <ThemeProvider theme={theme}>
-        <LoginButton label="Sign In" />
-      </ThemeProvider>
-    );
+    renderComponent();
 
-    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    fireEvent.click(screen.getByRole("button", { name: /idir/i }));
 
     expect(mockDispatch).toHaveBeenCalledWith(authenticate());
   });

--- a/mobile/asa-go/src/hooks/useIsXSScreen.test.tsx
+++ b/mobile/asa-go/src/hooks/useIsXSScreen.test.tsx
@@ -1,0 +1,54 @@
+import { useIsXSSmallScreen } from "@/hooks/useIsXSScreen";
+import { theme } from "@/theme";
+import { useMediaQuery } from "@mui/material";
+import { ThemeProvider } from "@mui/material/styles";
+import { renderHook } from "@testing-library/react";
+import { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mui/material", async () => {
+  const actual = await vi.importActual<typeof import("@mui/material")>(
+    "@mui/material",
+  );
+
+  return {
+    ...actual,
+    useMediaQuery: vi.fn(),
+  };
+});
+
+describe("useIsXSSmallScreen", () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ThemeProvider theme={theme}>{children}</ThemeProvider>
+  );
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns true when the media query matches", () => {
+    vi.mocked(useMediaQuery).mockReturnValue(true);
+
+    const { result } = renderHook(() => useIsXSSmallScreen(), { wrapper });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when the media query does not match", () => {
+    vi.mocked(useMediaQuery).mockReturnValue(false);
+
+    const { result } = renderHook(() => useIsXSSmallScreen(), { wrapper });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("uses a query that matches when either dimension is below the sm threshold", () => {
+    vi.mocked(useMediaQuery).mockReturnValue(false);
+
+    renderHook(() => useIsXSSmallScreen(), { wrapper });
+
+    expect(useMediaQuery).toHaveBeenCalledWith(
+      `(max-width:${theme.breakpoints.values.sm}px) or (max-height:${theme.breakpoints.values.sm}px)`,
+    );
+  });
+});

--- a/mobile/asa-go/src/hooks/useIsXSScreen.ts
+++ b/mobile/asa-go/src/hooks/useIsXSScreen.ts
@@ -1,0 +1,12 @@
+import { useMediaQuery, useTheme } from "@mui/material";
+
+export function useIsXSSmallScreen() {
+  const theme = useTheme();
+  const maxXSScreenDimension = theme.breakpoints.values.sm;
+
+  // Require one dimension to be less than the threshold so the result stays
+  // stable when rotating a phone into landscape.
+  return useMediaQuery(
+    `(max-width:${maxXSScreenDimension}px) or (max-height:${maxXSScreenDimension}px)`,
+  );
+}


### PR DESCRIPTION
- creates separate components for portrait and landscape landing pages
- layout assumes three screen sizes (xs for iPhone SE, 'regular' phone and tablets)
- also adds a `PublicLoginButton` that is not yet used. I figured I'd keep it hidden for the pending release and expose it after load testing.

# Test Links:
[Landing Page](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5402-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
