### PR TITLE
ASA Go: Refresh Data

### DIFF
--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -140,25 +140,15 @@ const App = () => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (networkStatus.connected) {
+    const doiISODate = dateOfInterest.toISODate();
+    if (isActive && !isNull(doiISODate)) {
       dispatch(fetchSFMSRunParameters());
     }
-  }, [networkStatus.connected, dispatch]);
+  }, [isActive, dateOfInterest, networkStatus.connected, dispatch]);
 
   useEffect(() => {
     dispatch(fetchFireCentres());
-    const doiISODate = dateOfInterest.toISODate();
-    if (!isNull(doiISODate)) {
-      dispatch(fetchSFMSRunParameters());
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    const doiISODate = dateOfInterest.toISODate();
-    if (!isNull(doiISODate)) {
-      dispatch(fetchSFMSRunParameters());
-    }
-  }, [dateOfInterest, networkStatus.connected]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dispatch]);
 
   useEffect(() => {
     if (!isNil(runParameters)) {


### PR DESCRIPTION
- Consolidates hooks
  - `fetchRunParameters` runs when the app first renders, when the app foregrounds, when the selected date changes, or when network status changes
  - `fetchFireCentres` on app load (same behaviour as previous)
# Test Links:
[Landing Page](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5406-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
