### PR TITLE
UI fixes following MUI update

### DIFF
--- a/mobile/asa-go/src/components/map/Legend.tsx
+++ b/mobile/asa-go/src/components/map/Legend.tsx
@@ -113,7 +113,7 @@ const LegendItem = ({
               <ListItemIcon>
                 <LegendSymbol sx={{ backgroundColor: subItem.symbol }} />
               </ListItemIcon>
-              <ListItemText>{subItem.label}</ListItemText>
+              <ListItemText sx={{ pl: 1 }}>{subItem.label}</ListItemText>
             </ListItem>
           ))}
         </List>

--- a/web/apps/wps-web/src/features/fba/components/ASADatePicker.tsx
+++ b/web/apps/wps-web/src/features/fba/components/ASADatePicker.tsx
@@ -1,5 +1,5 @@
 import { PlayArrow } from '@mui/icons-material'
-import { CircularProgress, IconButton, TextField } from '@mui/material'
+import { CircularProgress, IconButton, TextField, TextFieldProps } from '@mui/material'
 import {
   CalendarIcon,
   DatePicker,
@@ -14,16 +14,19 @@ import { isNil, isNull } from 'lodash'
 import { DateTime } from 'luxon'
 import React from 'react'
 
+type FieldSlotProps = { input?: NonNullable<TextFieldProps['slotProps']>['input'] }
+
 interface CustomDateTextFieldProps extends DatePickerFieldProps {
   date: DateTime | null
   updateDate: React.Dispatch<React.SetStateAction<DateTime>>
   minimumDate: DateTime
   maximumDate: DateTime
+  slotProps?: FieldSlotProps
 }
 
 function CustomDateTextField(props: Readonly<CustomDateTextFieldProps>) {
   const { forwardedProps } = useSplitFieldProps(props, 'date')
-  const { date, updateDate, minimumDate, maximumDate, ...other } = forwardedProps
+  const { date, updateDate, minimumDate, maximumDate, slotProps: externalSlotProps, ...other } = forwardedProps
   const pickerContext = usePickerContext<DateTime | null>()
   const disabled = pickerContext.disabled
 
@@ -79,18 +82,20 @@ function CustomDateTextField(props: Readonly<CustomDateTextFieldProps>) {
       }
       slotProps={{
         input: {
+          ...externalSlotProps?.input,
           ref: pickerContext.triggerRef,
           readOnly: true,
           startAdornment: renderStartAdornments(),
           endAdornment: renderEndAdornments(),
-          sx: { cursor: disabled ? 'default' : 'pointer', '& *': { cursor: 'inherit' } }
+          sx: { cursor: disabled ? 'default' : 'pointer', '& *': { cursor: 'inherit' }, ...(externalSlotProps?.input as { sx?: object })?.sx }
         }
       }}
     />
   )
 }
 
-interface ASADatePickerProps extends DatePickerProps {
+interface ASADatePickerProps extends Omit<DatePickerProps, 'slotProps'> {
+  slotProps?: DatePickerProps['slotProps'] & FieldSlotProps
   date: DateTime | null
   updateDate: (d: DateTime) => void
   currentYearMinDate?: DateTime
@@ -133,7 +138,8 @@ const ASADatePicker = ({
             updateDate,
             minimumDate: currentYearMinDate,
             maximumDate: currentYearMaxDate,
-            sx: other.sx
+            sx: other.sx,
+            slotProps: other.slotProps
           } as any
         }}
         value={date}

--- a/web/apps/wps-web/src/features/fba/components/ASADatePicker.tsx
+++ b/web/apps/wps-web/src/features/fba/components/ASADatePicker.tsx
@@ -132,10 +132,10 @@ const ASADatePicker = ({
             date,
             updateDate,
             minimumDate: currentYearMinDate,
-            maximumDate: currentYearMaxDate
+            maximumDate: currentYearMaxDate,
+            sx: other.sx
           } as any
         }}
-        sx={{ ...other.sx }}
         value={date}
       />
     </LocalizationProvider>

--- a/web/apps/wps-web/src/features/fba/components/map/Legend.tsx
+++ b/web/apps/wps-web/src/features/fba/components/map/Legend.tsx
@@ -94,7 +94,7 @@ const LegendItem: React.FC<LegendItemProps> = ({
                 <ListItemIcon>
                   <LegendSymbol sx={{ backgroundColor: subItem.symbol }} />
                 </ListItemIcon>
-                <ListItemText>{subItem.label}</ListItemText>
+                <ListItemText sx={{ pl: 1 }}>{subItem.label}</ListItemText>
               </ListItem>
             ))}
           </List>

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/RasterLegend.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/RasterLegend.tsx
@@ -45,7 +45,7 @@ const RasterLegend = ({ rasterType }: RasterLegendProps) => {
             <ListItemIcon>
               <LegendSymbol sx={{ backgroundColor: colorBreak.color }} />
             </ListItemIcon>
-            <ListItemText>{colorBreak.label}</ListItemText>
+            <ListItemText sx={{ pl: 1 }}>{colorBreak.label}</ListItemText>
           </ListItem>
         ))}
       </List>

--- a/web/apps/wps-web/src/features/weatherToolkit/components/SidePanel.tsx
+++ b/web/apps/wps-web/src/features/weatherToolkit/components/SidePanel.tsx
@@ -38,10 +38,11 @@ const SidePanel = ({
         <Typography
           variant="overline"
           sx={{
-            color: "text.secondary",
+            color: 'text.secondary',
             fontWeight: 600,
             letterSpacing: 1.5
-          }}>
+          }}
+        >
           Time
         </Typography>
       </Box>
@@ -54,6 +55,7 @@ const SidePanel = ({
         historicalMaxDate={DateTime.utc()}
         label="Model Run Date (UTC)"
         sx={{ mb: 2, width: '100%' }}
+        slotProps={{ input: { sx: { px: 1 } } }}
       />
       <FormControl fullWidth sx={{ mb: 4 }}>
         <InputLabel id="model-run-hour-label">Model Run Hour</InputLabel>
@@ -73,10 +75,11 @@ const SidePanel = ({
         <Typography
           variant="overline"
           sx={{
-            color: "text.secondary",
+            color: 'text.secondary',
             fontWeight: 600,
             letterSpacing: 1.5
-          }}>
+          }}
+        >
           Data Configuration
         </Typography>
       </Box>
@@ -94,7 +97,7 @@ const SidePanel = ({
         </Select>
       </FormControl>
     </Box>
-  );
+  )
 }
 
 export default SidePanel


### PR DESCRIPTION
- adds padding between legend swatches and text in ASA web and ASA Go
- adds padding below the date picker in Weather Toolkit
- adds ability to style ASADatePicker with slot props. Allows us to change padding on the input field to prevent the date from being truncated in the Weather Toolkit

 
<img width="300" height="145" alt="image" src="https://github.com/user-attachments/assets/08dcc0dc-36bc-4ba2-99e0-4ed3ce06aa0a" />

<img width="187" height="90" alt="image" src="https://github.com/user-attachments/assets/8392cea1-a77c-467f-9a99-efe51f1c2f73" />

# Test Links:
[Landing Page](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5430-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
