### PR TITLE
Morecast: null value bug fix

### DIFF
--- a/web/apps/wps-web/src/features/moreCast2/components/GridComponentRenderer.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/GridComponentRenderer.tsx
@@ -50,6 +50,15 @@ export class GridComponentRenderer {
     return this.isPredictionItem(value) ? value.value : value
   }
 
+  private readonly parseEditableNumber = (value: GridRendererEditableValue): number => {
+    if (value == null || value === '') {
+      return Number.NaN
+    }
+
+    const parsedValue = Number(value)
+    return Number.isNaN(parsedValue) ? Number.NaN : parsedValue
+  }
+
   public renderForecastHeaderWith = (
     params: GridColumnHeaderParams<MoreCast2Row>,
     columnClickHandlerProps: ColumnClickHandlerProps
@@ -231,10 +240,8 @@ export class GridComponentRenderer {
       return row
     }
 
-    const oldValue = predictionItem.value
-
-    const parsedValue = Number(value)
-    const newValue = Number.isNaN(parsedValue) ? Number.NaN : parsedValue
+    const oldValue = this.parseEditableNumber(predictionItem.value)
+    const newValue = this.parseEditableNumber(value)
 
     if (Number.isNaN(oldValue) && Number.isNaN(newValue)) {
       return row

--- a/web/apps/wps-web/src/features/moreCast2/components/gridComponentRenderer.test.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/gridComponentRenderer.test.tsx
@@ -548,6 +548,24 @@ describe('GridComponentRenderer', () => {
     expect(updatedRow).toBe(mockRow)
   })
 
+  it('should update a null prediction value without crashing', () => {
+    const mockRow = {
+      tempForecast: {
+        value: null,
+        choice: ModelChoice.GDPS
+      }
+    } as unknown as MoreCast2Row
+
+    const updatedRow = gridComponentRenderer.predictionItemValueSetter(2, mockRow, 'tempForecast', 1)
+
+    expect(updatedRow).toEqual({
+      tempForecast: {
+        value: 2,
+        choice: ModelChoice.MANUAL
+      }
+    })
+  })
+
   it('should round decimal edits using the configured precision and mark the choice as manual', () => {
     const mockRow = {
       tempForecast: {

--- a/web/apps/wps-web/src/features/moreCast2/forecastDraft.test.ts
+++ b/web/apps/wps-web/src/features/moreCast2/forecastDraft.test.ts
@@ -4,6 +4,7 @@ import { buildValidActualRow, buildValidForecastRow } from 'features/moreCast2/r
 import { DateTime } from 'luxon'
 import * as DateUtils from '@wps/utils/date'
 import { vi } from 'vitest'
+import { ModelChoice } from '@wps/api/moreCast2API'
 
 const TEST_DATE = DateTime.fromISO('2024-01-01T00:00:00.000-08:00')
 
@@ -47,6 +48,19 @@ describe('MorecastDraftForecast', () => {
     draftForecast.getStoredDraftForecasts()
 
     expect(getSpy).toHaveBeenCalledWith(draftForecast.STORAGE_KEY)
+  })
+  it('should restore null prediction values as NaN', () => {
+    const storedRow = buildValidForecastRow(111, TEST_DATE.plus({ days: 1 }))
+    storedRow.tempForecast!.value = null as unknown as number
+    storedRow.ffmcCalcForecast = { choice: ModelChoice.NULL, value: null as unknown as number }
+    const storedDraft: DraftMorecast2Rows = { rows: [storedRow], lastEdited: TEST_DATE }
+
+    vi.spyOn(localStorageMock, 'getItem').mockReturnValue(JSON.stringify(storedDraft))
+
+    const restoredDraft = draftForecast.getStoredDraftForecasts()
+
+    expect(Number.isNaN(restoredDraft?.rows[0].tempForecast?.value)).toBe(true)
+    expect(Number.isNaN(restoredDraft?.rows[0].ffmcCalcForecast?.value)).toBe(true)
   })
   it('should delete saved rows from storage', () => {
     const storedDraft: DraftMorecast2Rows = { rows: mockRowData.slice(0, 4), lastEdited: TEST_DATE }

--- a/web/apps/wps-web/src/features/moreCast2/forecastDraft.ts
+++ b/web/apps/wps-web/src/features/moreCast2/forecastDraft.ts
@@ -2,6 +2,14 @@ import { DraftMorecast2Rows, MoreCast2ForecastRow, MoreCast2Row } from 'features
 import { getRowsMap, isForecastRow } from 'features/moreCast2/util'
 import { DateTime } from 'luxon'
 
+function restorePredictionItemNaN(this: { choice?: unknown }, key: string, value: unknown) {
+  if (key === 'value' && value === null && this.choice !== undefined) {
+    return Number.NaN
+  }
+
+  return value
+}
+
 export class MorecastDraftForecast {
   public readonly STORAGE_KEY = 'morecastForecastDraft'
   private readonly localStorage: Storage
@@ -14,7 +22,7 @@ export class MorecastDraftForecast {
     const storedDraftString = this.localStorage.getItem(this.STORAGE_KEY)
 
     if (storedDraftString) {
-      const storedDraft = JSON.parse(storedDraftString)
+      const storedDraft = JSON.parse(storedDraftString, restorePredictionItemNaN)
       storedDraft.lastEdited = storedDraft.lastEdited ? DateTime.fromISO(storedDraft.lastEdited) : undefined
       return storedDraft
     }


### PR DESCRIPTION
The bug was that when data was restored from local storage, `PredictionItems` could have `null` instead of `NaN`. This fix guards against that in the `predictionItemValueSetter` but also adds a JSON reviver to convert null `PredictionItem` values back to `NaN` from `null`

# Test Links:
[Landing Page](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5433-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
