### PR TITLE
Wire VANITY_DOMAIN into nats deployment for WEB_BASE_URL

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -109,7 +109,7 @@ jobs:
       - name: NATS Message Queue
         shell: bash
         run: |
-          MEMORY_REQUEST=250Mi MEMORY_LIMIT=500Mi CPU_REQUEST="250m" bash openshift/scripts/oc_provision_nats.sh ${SUFFIX} apply
+          MEMORY_REQUEST=250Mi MEMORY_LIMIT=500Mi CPU_REQUEST="250m" VANITY_DOMAIN="${SUFFIX}-dev-psu.apps.silver.devops.gov.bc.ca" bash openshift/scripts/oc_provision_nats.sh ${SUFFIX} apply
 
   deploy-dev:
     name: Deploy to Dev

--- a/openshift/scripts/oc_deploy_to_production.sh
+++ b/openshift/scripts/oc_deploy_to_production.sh
@@ -38,7 +38,7 @@ echo Provision database
 PROJ_TARGET=${PROJ_TARGET} BUCKET=lwzrin CPU_REQUEST=2 MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi DATA_SIZE=65Gi WAL_SIZE=15Gi REPLICAS=3 bash $(dirname ${0})/oc_provision_crunchy.sh prod ${RUN_TYPE}
 
 echo Provision NATS
-PROJ_TARGET=${PROJ_TARGET} bash $(dirname ${0})/oc_provision_nats.sh prod ${RUN_TYPE}
+PROJ_TARGET=${PROJ_TARGET} VANITY_DOMAIN=psu.nrs.gov.bc.ca bash $(dirname ${0})/oc_provision_nats.sh prod ${RUN_TYPE}
 echo Deploy API
 MODULE_NAME=api GUNICORN_WORKERS=8 CPU_REQUEST=100m MEMORY_REQUEST=6Gi MEMORY_LIMIT=8Gi REPLICAS=3 PROJ_TARGET=${PROJ_TARGET} VANITY_DOMAIN=psu.nrs.gov.bc.ca SECOND_LEVEL_DOMAIN=apps.silver.devops.gov.bc.ca ENVIRONMENT="production" bash $(dirname ${0})/oc_deploy.sh prod ${RUN_TYPE}
 echo Deploy ASA Go API

--- a/openshift/scripts/oc_provision_nats.sh
+++ b/openshift/scripts/oc_provision_nats.sh
@@ -33,7 +33,8 @@ OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${PATH_NATS} \
  ${MEMORY_LIMIT:+ "-p MEMORY_LIMIT=${MEMORY_LIMIT}"} \
  ${CPU_REQUEST:+ "-p CPU_REQUEST=${CPU_REQUEST}"} \
  -p CRUNCHYDB_USER=${CRUNCHY_NAME}-${SUFFIX}-pguser-${CRUNCHY_NAME}-${SUFFIX} \
- -p APP_NAME=${APP_NAME}"
+ -p APP_NAME=${APP_NAME} \
+ -p VANITY_DOMAIN=${VANITY_DOMAIN}"
 
 # Apply a template (apply or use --dry-run=client)
 #

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -45,6 +45,9 @@ parameters:
   - name: CPU_REQUEST
     required: true
     value: "1.5"
+  - name: VANITY_DOMAIN
+    description: Vanity domain for the web application (e.g. psu.nrs.gov.bc.ca)
+    required: true
 
 objects:
   - apiVersion: v1
@@ -559,7 +562,4 @@ objects:
                       name: ${GLOBAL_NAME}
                       key: ches-sender-email
                 - name: WEB_BASE_URL
-                  valueFrom:
-                    configMapKeyRef:
-                      name: ${GLOBAL_NAME}
-                      key: env.web-base-url
+                  value: https://${VANITY_DOMAIN}


### PR DESCRIPTION
- Adds `VANITY_DOMAIN` as a required parameter to the nats OpenShift template
- Replaces the missing `env.web-base-url` ConfigMap lookup with an inline value derived from the vanity route
- Passes `VANITY_DOMAIN` through the provision script and deployment workflow
