### PR TITLE
SMURFI: Fix smurfi nats subject

### DIFF
--- a/backend/packages/wps-api/src/app/smurfi/nats_config.py
+++ b/backend/packages/wps-api/src/app/smurfi/nats_config.py
@@ -5,6 +5,6 @@ from wps_shared import config
 server: Final = config.get("NATS_SERVER")
 stream_prefix: Final = config.get("NATS_STREAM_PREFIX")
 stream_name: Final = f"{stream_prefix}smurfi"
-subjects: Final = ["smurfi.*"]
+subjects: Final = ["smurfi.>"]
 smurfi_spot_update_subject: Final = "smurfi.spot.update"
 smurfi_spot_update_durable: Final = "smurfi_spot_update"


### PR DESCRIPTION
`subjects = ["smurfi.*"]` matches `smurfi.spot` but NOT `smurfi.spot.update` — three tokens. So when `pull_subscribe` tries to create a consumer with filter subject `smurfi.spot.update`, NATS rejects it because it's not a subset of the stream's `smurfi.*`.

`smurfi.>` matches any subject with `smurfi.` as a prefix regardless of depth, so `smurfi.spot.update` is now a valid subset.