### PR TITLE
Full spot forecast detail page

### DIFF
--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
@@ -67,20 +67,20 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <Box>
         <Button variant="outlined" size="small" onClick={() => navigate(printableUrl)}>
           Printable Version
         </Button>
       </Box>
       <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2 }}>
         <Section title="Forecast Info">
+          <Field label="Fire Number(s)" value={spotRequest.fire_number?.join(', ') ?? '—'} />
+          <Field label="Requested By" value={spotRequest.requestor_name} />
           <Field label="Issued" value={formatDateTime(forecast.issued_at)} />
           <Field label="Expires" value={forecast.expires_at ? formatDateTime(forecast.expires_at) : '—'} />
           <Field label="Forecaster" value={forecast.forecaster_name} />
           <Field label="Email" value={forecast.forecaster_email} />
           {forecast.forecaster_phone && <Field label="Phone" value={forecast.forecaster_phone} />}
-          <Field label="Requested By" value={spotRequest.requestor_name} />
-          <Field label="Fire Number(s)" value={spotRequest.fire_number?.join(', ') ?? '—'} />
           {forecast.fire_size != null && <Field label="Fire Size" value={`${forecast.fire_size} ha`} />}
           <Box sx={{ gridColumn: '1 / -1' }}>
             <Field label="Representative Stations" value={stationsStr} />

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import { Box, Button, Divider, Paper, Typography } from '@mui/material'
+import { DateTime } from 'luxon'
+import { useNavigate } from 'react-router-dom'
+import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
+import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'
+import { RepresentativeStation } from '@/features/smurfi/interfaces'
+import { SMURFI_DASHBOARD_ROUTE } from '@wps/utils/constants'
+
+const TIMEZONE = 'America/Vancouver'
+
+const formatDateTime = (iso: string) => {
+  const dt = DateTime.fromISO(iso).setZone(TIMEZONE)
+  return dt.isValid ? `${dt.toFormat('HHmm')} ${dt.offsetNameShort} ${dt.toFormat('EEE, MMM d, yyyy')}` : iso
+}
+
+const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <Box>
+    <Typography
+      variant="caption"
+      color="text.secondary"
+      sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8 }}
+    >
+      {label}
+    </Typography>
+    <Typography variant="body1">{value ?? '—'}</Typography>
+  </Box>
+)
+
+const Section = ({ title, children, contentSx }: { title: string; children: React.ReactNode; contentSx?: object }) => (
+  <Paper variant="outlined" sx={{ p: 2.5, display: 'flex', flexDirection: 'column' }}>
+    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+      {title}
+    </Typography>
+    <Divider sx={{ mt: 0.5, mb: 2 }} />
+    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2, ...contentSx }}>{children}</Box>
+  </Paper>
+)
+
+const TextSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <Paper variant="outlined" sx={{ p: 2.5 }}>
+    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+      {title}
+    </Typography>
+    <Divider sx={{ mt: 0.5, mb: 2 }} />
+    <Typography variant="body1">{children}</Typography>
+  </Paper>
+)
+
+export interface FullSpotForecastProps {
+  forecast: SpotForecastOutput
+  spotRequest: SpotRequestOutput
+  representativeStations: RepresentativeStation[]
+}
+
+const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotRequest, representativeStations }) => {
+  const navigate = useNavigate()
+  const afternoonForecast = forecast.descriptive_weather.find(dw => dw.period === 'Today')
+  const tonightForecast = forecast.descriptive_weather.find(dw => dw.period === 'Tonight')
+  const tomorrowForecast = forecast.descriptive_weather.find(dw => dw.period === 'Tomorrow')
+  const stationsStr =
+    representativeStations.length > 0
+      ? representativeStations.map(s => `${s.name}${s.elevation != null ? ` (${s.elevation}m)` : ''}`).join(', ')
+      : '—'
+
+  const printableUrl = `${SMURFI_DASHBOARD_ROUTE}/${spotRequest.id}/forecasts/${forecast.id}/printable`
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Button variant="outlined" size="small" onClick={() => navigate(printableUrl)}>
+          Printable Version
+        </Button>
+      </Box>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2 }}>
+        <Section title="Forecast Info">
+          <Field label="Issued" value={formatDateTime(forecast.issued_at)} />
+          <Field label="Expires" value={forecast.expires_at ? formatDateTime(forecast.expires_at) : '—'} />
+          <Field label="Forecaster" value={forecast.forecaster_name} />
+          <Field label="Email" value={forecast.forecaster_email} />
+          {forecast.forecaster_phone && <Field label="Phone" value={forecast.forecaster_phone} />}
+          <Field label="Requested By" value={spotRequest.requestor_name} />
+          <Field label="Fire Number(s)" value={spotRequest.fire_number?.join(', ') ?? '—'} />
+          {forecast.fire_size != null && <Field label="Fire Size" value={`${forecast.fire_size} ha`} />}
+          <Box sx={{ gridColumn: '1 / -1' }}>
+            <Field label="Representative Stations" value={stationsStr} />
+          </Box>
+        </Section>
+
+        <Section title="Location">
+          <Box sx={{ gridColumn: '1 / -1' }}>
+            <Field label="Geographic Description" value={spotRequest.geographic_description} />
+          </Box>
+          <Field label="Latitude" value={spotRequest.latitude.toFixed(4)} />
+          <Field label="Longitude" value={spotRequest.longitude.toFixed(4)} />
+          <Field label="Elevation" value={spotRequest.elevation ? `${spotRequest.elevation} m` : '—'} />
+          <Field label="Slope / Aspect" value={spotRequest.aspect ?? '—'} />
+        </Section>
+      </Box>
+
+      {forecast.synopsis && <TextSection title="Synopsis">{forecast.synopsis}</TextSection>}
+
+      {(afternoonForecast ?? tonightForecast ?? tomorrowForecast) && (
+        <Section title="Forecast Summary" contentSx={{ gridTemplateColumns: '1fr' }}>
+          {afternoonForecast && (
+            <Box>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                Afternoon
+              </Typography>
+              <Typography variant="body2">
+                {afternoonForecast.conditions} Max Temp: {afternoonForecast.temperature ?? '—'}°C, Min RH:{' '}
+                {afternoonForecast.relative_humidity ?? '—'}%
+              </Typography>
+            </Box>
+          )}
+          {tonightForecast && (
+            <Box>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                Tonight
+              </Typography>
+              <Typography variant="body2">
+                {tonightForecast.conditions} Min Temp: {tonightForecast.temperature ?? '—'}°C, Max RH:{' '}
+                {tonightForecast.relative_humidity ?? '—'}%
+              </Typography>
+            </Box>
+          )}
+          {tomorrowForecast && (
+            <Box>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                Tomorrow
+              </Typography>
+              <Typography variant="body2">
+                {tomorrowForecast.conditions} Temp: {tomorrowForecast.temperature ?? '—'}°C, Min RH:{' '}
+                {tomorrowForecast.relative_humidity ?? '—'}%
+              </Typography>
+            </Box>
+          )}
+        </Section>
+      )}
+
+      {forecast.tabular_weather.length > 0 && (
+        <Paper variant="outlined" sx={{ p: 2.5 }}>
+          <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+            Weather Data
+          </Typography>
+          <Divider sx={{ mt: 0.5, mb: 2 }} />
+          <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} />
+        </Paper>
+      )}
+
+      <Box
+        sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: forecast.outlook ? '1fr 1fr' : '1fr' }, gap: 2 }}
+      >
+        {forecast.inversion_and_venting && (
+          <TextSection title="Inversion & Venting">{forecast.inversion_and_venting}</TextSection>
+        )}
+        {forecast.outlook && <TextSection title="Outlook (3–5 Day)">{forecast.outlook}</TextSection>}
+      </Box>
+
+      {forecast.confidence && <TextSection title="Confidence / Discussion">{forecast.confidence}</TextSection>}
+    </Box>
+  )
+}
+
+export default FullSpotForecast

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
@@ -108,8 +108,7 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
                 Afternoon
               </Typography>
               <Typography variant="body2">
-                {afternoonForecast.conditions} Max Temp: {afternoonForecast.temperature ?? '—'}°C, Min RH:{' '}
-                {afternoonForecast.relative_humidity ?? '—'}%
+                {`${afternoonForecast.conditions} Max Temp: ${afternoonForecast.temperature ?? '—'}°C, Min RH: ${afternoonForecast.relative_humidity ?? '—'}%`}
               </Typography>
             </Box>
           )}
@@ -119,8 +118,7 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
                 Tonight
               </Typography>
               <Typography variant="body2">
-                {tonightForecast.conditions} Min Temp: {tonightForecast.temperature ?? '—'}°C, Max RH:{' '}
-                {tonightForecast.relative_humidity ?? '—'}%
+                {`${tonightForecast.conditions} Min Temp: ${tonightForecast.temperature ?? '—'}°C, Max RH: ${tonightForecast.relative_humidity ?? '—'}%`}
               </Typography>
             </Box>
           )}
@@ -130,8 +128,7 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
                 Tomorrow
               </Typography>
               <Typography variant="body2">
-                {tomorrowForecast.conditions} Temp: {tomorrowForecast.temperature ?? '—'}°C, Min RH:{' '}
-                {tomorrowForecast.relative_humidity ?? '—'}%
+                {`${tomorrowForecast.conditions} Temp: ${tomorrowForecast.temperature ?? '—'}°C, Min RH: ${tomorrowForecast.relative_humidity ?? '—'}%`}
               </Typography>
             </Box>
           )}

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/MiniSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/MiniSpotForecast.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Box } from '@mui/material'
+import { SpotForecastOutput } from '@wps/api/SMURFIAPI'
+
+interface MiniSpotForecastProps {
+  forecast: SpotForecastOutput
+}
+
+const MiniSpotForecast: React.FC<MiniSpotForecastProps> = ({ forecast: _ }) => {
+  return <Box>Mini Spot Forecast placeholder</Box>
+}
+
+export default MiniSpotForecast

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableFullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableFullSpotForecast.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Box, Container, Typography } from '@mui/material'
+import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
+import SpotForecastHeaderTable from '@/features/smurfi/components/forecasts/SpotForecastHeaderTable'
+import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'
+import SpotForecastSummarySection from '@/features/smurfi/components/forecasts/SpotForecastSummarySection'
+import { RepresentativeStation } from '@/features/smurfi/interfaces'
+
+interface PrintableFullSpotForecastProps {
+  forecast: SpotForecastOutput
+  spotRequest: SpotRequestOutput
+  representativeStations: RepresentativeStation[]
+}
+
+const PrintableFullSpotForecast: React.FC<PrintableFullSpotForecastProps> = ({
+  forecast,
+  spotRequest,
+  representativeStations
+}) => {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
+      <Container maxWidth="lg">
+        <Typography variant="h5" sx={{ fontWeight: 'bold', textDecoration: 'underline', textAlign: 'center' }}>
+          BC Wild Fire Service Spot Forecast
+        </Typography>
+        <SpotForecastHeaderTable
+          forecast={forecast}
+          spotRequest={spotRequest}
+          representativeStations={representativeStations}
+        />
+
+        <Typography variant="body2" sx={{ mt: 1.5, lineHeight: 1.6 }}>
+          <strong>
+            <span style={{ textDecoration: 'underline' }}>SYNOPSIS:</span>
+          </strong>
+          {'  '}
+          {forecast.synopsis}
+        </Typography>
+
+        <SpotForecastSummarySection descriptiveWeather={forecast.descriptive_weather} />
+
+        <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} />
+
+        <Typography variant="body2" sx={{ mt: 2, lineHeight: 1.6 }}>
+          <strong>
+            <span style={{ textDecoration: 'underline' }}>INVERSION &amp; VENTING:</span>
+          </strong>
+          {'    '}
+          {forecast.inversion_and_venting}
+        </Typography>
+
+        {forecast.outlook && (
+          <Typography variant="body2" sx={{ mt: 2, lineHeight: 1.6 }}>
+            <strong>
+              <span style={{ textDecoration: 'underline' }}>OUTLOOK (3-5 Day Outlook</span>
+            </strong>{' '}
+            {forecast.outlook}
+          </Typography>
+        )}
+
+        <Typography variant="body2" sx={{ mt: 2, lineHeight: 1.6 }}>
+          <strong>
+            <span style={{ textDecoration: 'underline' }}>CONFIDENCE/DISCUSSION:</span>
+          </strong>
+          {'  '}
+          {forecast.confidence}
+        </Typography>
+      </Container>
+    </Box>
+  )
+}
+
+export default PrintableFullSpotForecast

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableFullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableFullSpotForecast.tsx
@@ -19,53 +19,51 @@ const PrintableFullSpotForecast: React.FC<PrintableFullSpotForecastProps> = ({
 }) => {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
-      <Container maxWidth="lg">
-        <Typography variant="h5" sx={{ fontWeight: 'bold', textDecoration: 'underline', textAlign: 'center' }}>
-          BC Wild Fire Service Spot Forecast
-        </Typography>
-        <SpotForecastHeaderTable
-          forecast={forecast}
-          spotRequest={spotRequest}
-          representativeStations={representativeStations}
-        />
+      <Typography variant="h6" sx={{ fontWeight: 'bold', textDecoration: 'underline', textAlign: 'center' }}>
+        BC Wild Fire Service Spot Forecast
+      </Typography>
+      <SpotForecastHeaderTable
+        forecast={forecast}
+        spotRequest={spotRequest}
+        representativeStations={representativeStations}
+      />
 
-        <Typography variant="body2" sx={{ mt: 1.5, lineHeight: 1.6 }}>
+      <Typography variant="body2" sx={{ mt: 1.5, fontSize: '12px', lineHeight: 1.6 }}>
+        <strong>
+          <span style={{ textDecoration: 'underline' }}>SYNOPSIS:</span>
+        </strong>
+        {'  '}
+        {forecast.synopsis}
+      </Typography>
+
+      <SpotForecastSummarySection descriptiveWeather={forecast.descriptive_weather} />
+
+      <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} fontSize="12px" />
+
+      <Typography variant="body2" sx={{ mt: 2, fontSize: '12px', lineHeight: 1.6 }}>
+        <strong>
+          <span style={{ textDecoration: 'underline' }}>INVERSION &amp; VENTING:</span>
+        </strong>
+        {'    '}
+        {forecast.inversion_and_venting}
+      </Typography>
+
+      {forecast.outlook && (
+        <Typography variant="body2" sx={{ mt: 2, fontSize: '12px', lineHeight: 1.6 }}>
           <strong>
-            <span style={{ textDecoration: 'underline' }}>SYNOPSIS:</span>
-          </strong>
-          {'  '}
-          {forecast.synopsis}
+            <span style={{ textDecoration: 'underline' }}>OUTLOOK (3-5 Day Outlook)</span>
+          </strong>{' '}
+          {forecast.outlook}
         </Typography>
+      )}
 
-        <SpotForecastSummarySection descriptiveWeather={forecast.descriptive_weather} />
-
-        <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} />
-
-        <Typography variant="body2" sx={{ mt: 2, lineHeight: 1.6 }}>
-          <strong>
-            <span style={{ textDecoration: 'underline' }}>INVERSION &amp; VENTING:</span>
-          </strong>
-          {'    '}
-          {forecast.inversion_and_venting}
-        </Typography>
-
-        {forecast.outlook && (
-          <Typography variant="body2" sx={{ mt: 2, lineHeight: 1.6 }}>
-            <strong>
-              <span style={{ textDecoration: 'underline' }}>OUTLOOK (3-5 Day Outlook</span>
-            </strong>{' '}
-            {forecast.outlook}
-          </Typography>
-        )}
-
-        <Typography variant="body2" sx={{ mt: 2, lineHeight: 1.6 }}>
-          <strong>
-            <span style={{ textDecoration: 'underline' }}>CONFIDENCE/DISCUSSION:</span>
-          </strong>
-          {'  '}
-          {forecast.confidence}
-        </Typography>
-      </Container>
+      <Typography variant="body2" sx={{ mt: 2, fontSize: '12px', lineHeight: 1.6 }}>
+        <strong>
+          <span style={{ textDecoration: 'underline' }}>CONFIDENCE/DISCUSSION:</span>
+        </strong>
+        {'  '}
+        {forecast.confidence}
+      </Typography>
     </Box>
   )
 }

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableFullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableFullSpotForecast.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Container, Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
 import SpotForecastHeaderTable from '@/features/smurfi/components/forecasts/SpotForecastHeaderTable'
 import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecast.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress, Typography } from '@mui/material'
+import { Box, CircularProgress, Typography } from '@mui/material'
 import { useParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
@@ -54,11 +54,13 @@ const SpotForecast = () => {
   }
 
   return (
-    <FullSpotForecast
-      forecast={spotForecast}
-      spotRequest={spotRequest}
-      representativeStations={representativeStations}
-    />
+    <Box sx={{ pb: 4 }}>
+      <FullSpotForecast
+        forecast={spotForecast}
+        spotRequest={spotRequest}
+        representativeStations={representativeStations}
+      />
+    </Box>
   )
 }
 

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastHeaderTable.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastHeaderTable.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { Box, Typography } from '@mui/material'
+import { DateTime } from 'luxon'
+import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
+import { RepresentativeStation } from '@/features/smurfi/interfaces'
+
+const TIMEZONE = 'America/Vancouver'
+
+const toDDM = (decimal: number): string => {
+  const abs = Math.abs(decimal)
+  const degrees = Math.floor(abs)
+  const minutes = ((abs - degrees) * 60).toFixed(3)
+  return `${decimal < 0 ? '-' : ''}${degrees} ${minutes}`
+}
+
+const cell: React.CSSProperties = {
+  border: '1px solid black',
+  padding: '3px 8px',
+  verticalAlign: 'top',
+  fontSize: '0.875rem'
+}
+
+interface SpotForecastHeaderTableProps {
+  forecast: SpotForecastOutput
+  spotRequest: SpotRequestOutput
+  representativeStations: RepresentativeStation[]
+}
+
+const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({ forecast, spotRequest, representativeStations }) => {
+  const issuedDt = DateTime.fromISO(forecast.issued_at).setZone(TIMEZONE)
+  const expiryDt = forecast.expires_at ? DateTime.fromISO(forecast.expires_at).setZone(TIMEZONE) : null
+
+  const issuedStr = `${issuedDt.toFormat('HHmm')} ${issuedDt.offsetNameShort} ${issuedDt.toFormat('EEEE, MMMM d, yyyy')}`
+  const expiryStr = expiryDt ? expiryDt.toFormat('EEEE MMMM d') : '—'
+
+  const stationsStr = representativeStations.length > 0
+    ? representativeStations.map(s => `${s.name}${s.elevation != null ? ` (${s.elevation}m)` : ''}`).join(', ')
+    : '—'
+  const fireNumberStr = spotRequest.fire_number?.join(', ') ?? '—'
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+        <Typography variant="body2">
+          <strong style={{ textDecoration: 'underline' }}>Date/time Issued:</strong>
+          {'  '}
+          {issuedStr}
+        </Typography>
+        <Typography variant="body2">
+          <strong style={{ textDecoration: 'underline' }}>Default Expiry:</strong> {expiryStr}
+        </Typography>
+      </Box>
+
+      <table role="presentation" style={{ borderCollapse: 'collapse', width: '100%' }}>
+        <colgroup>
+          <col style={{ width: '145px' }} />
+          <col style={{ width: '210px' }} />
+          <col />
+          <col style={{ width: '190px' }} />
+        </colgroup>
+        <tbody>
+          <tr>
+            <td style={{ ...cell, fontWeight: 'bold' }}>Fire/Proj #</td>
+            <td style={cell}>{fireNumberStr}</td>
+            <td colSpan={2} style={cell}>
+              Request by:{'  '}
+              {spotRequest.requestor_name}
+            </td>
+          </tr>
+          <tr>
+            <td style={cell}>Forecast by</td>
+            <td style={cell}>{forecast.forecaster_name}</td>
+            <td style={cell}>Email: {forecast.forecaster_email}</td>
+            <td style={cell}>Phone: {forecast.forecaster_phone ?? '—'}</td>
+          </tr>
+          <tr>
+            <td style={cell}>Geographic</td>
+            <td style={cell}>{spotRequest.geographic_description}</td>
+            <td colSpan={2} style={cell}>
+              Representative <span style={{ textDecoration: 'underline' }}>Stns</span>: {stationsStr}
+            </td>
+          </tr>
+          <tr>
+            <td style={cell}>
+              Coordinates (<span style={{ textDecoration: 'underline' }}>approx</span>)
+            </td>
+            <td style={cell}>
+              {toDDM(spotRequest.latitude)},{toDDM(spotRequest.longitude)}
+            </td>
+            <td style={cell}>
+              Slope/aspect:{'  '}
+              {spotRequest.aspect ?? '—'}
+            </td>
+            <td style={cell} />
+          </tr>
+          <tr>
+            <td style={cell}>Elevation</td>
+            <td style={cell}>{spotRequest.elevation ? `${spotRequest.elevation} m` : '—'}</td>
+            <td style={cell}>{forecast.fire_size ? `Size:   ${forecast.fire_size} ha` : ''}</td>
+            <td style={cell} />
+          </tr>
+        </tbody>
+      </table>
+    </Box>
+  )
+}
+
+export default SpotForecastHeaderTable

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastHeaderTable.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastHeaderTable.tsx
@@ -17,7 +17,7 @@ const cell: React.CSSProperties = {
   border: '1px solid black',
   padding: '3px 8px',
   verticalAlign: 'top',
-  fontSize: '0.875rem'
+  fontSize: '12px'
 }
 
 interface SpotForecastHeaderTableProps {
@@ -41,12 +41,12 @@ const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({ forec
   return (
     <Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-        <Typography variant="body2">
+        <Typography variant="body2" sx={{ fontSize: '12px' }}>
           <strong style={{ textDecoration: 'underline' }}>Date/time Issued:</strong>
           {'  '}
           {issuedStr}
         </Typography>
-        <Typography variant="body2">
+        <Typography variant="body2" sx={{ fontSize: '12px' }}>
           <strong style={{ textDecoration: 'underline' }}>Default Expiry:</strong> {expiryStr}
         </Typography>
       </Box>

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastHeaderTable.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastHeaderTable.tsx
@@ -13,11 +13,26 @@ const toDDM = (decimal: number): string => {
   return `${decimal < 0 ? '-' : ''}${degrees} ${minutes}`
 }
 
+const COLUMNS = '145px 210px 1fr 190px'
+
+const grid: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: COLUMNS,
+  borderTop: '1px solid black',
+  borderLeft: '1px solid black',
+  width: '100%'
+}
+
 const cell: React.CSSProperties = {
-  border: '1px solid black',
+  borderRight: '1px solid black',
+  borderBottom: '1px solid black',
   padding: '3px 8px',
-  verticalAlign: 'top',
   fontSize: '12px'
+}
+
+const span2: React.CSSProperties = {
+  ...cell,
+  gridColumn: 'span 2'
 }
 
 interface SpotForecastHeaderTableProps {
@@ -33,9 +48,10 @@ const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({ forec
   const issuedStr = `${issuedDt.toFormat('HHmm')} ${issuedDt.offsetNameShort} ${issuedDt.toFormat('EEEE, MMMM d, yyyy')}`
   const expiryStr = expiryDt ? expiryDt.toFormat('EEEE MMMM d') : '—'
 
-  const stationsStr = representativeStations.length > 0
-    ? representativeStations.map(s => `${s.name}${s.elevation != null ? ` (${s.elevation}m)` : ''}`).join(', ')
-    : '—'
+  const stationsStr =
+    representativeStations.length > 0
+      ? representativeStations.map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation}m)`)).join(', ')
+      : '—'
   const fireNumberStr = spotRequest.fire_number?.join(', ') ?? '—'
 
   return (
@@ -51,56 +67,42 @@ const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({ forec
         </Typography>
       </Box>
 
-      <table role="presentation" style={{ borderCollapse: 'collapse', width: '100%' }}>
-        <colgroup>
-          <col style={{ width: '145px' }} />
-          <col style={{ width: '210px' }} />
-          <col />
-          <col style={{ width: '190px' }} />
-        </colgroup>
-        <tbody>
-          <tr>
-            <td style={{ ...cell, fontWeight: 'bold' }}>Fire/Proj #</td>
-            <td style={cell}>{fireNumberStr}</td>
-            <td colSpan={2} style={cell}>
-              Request by:{'  '}
-              {spotRequest.requestor_name}
-            </td>
-          </tr>
-          <tr>
-            <td style={cell}>Forecast by</td>
-            <td style={cell}>{forecast.forecaster_name}</td>
-            <td style={cell}>Email: {forecast.forecaster_email}</td>
-            <td style={cell}>Phone: {forecast.forecaster_phone ?? '—'}</td>
-          </tr>
-          <tr>
-            <td style={cell}>Geographic</td>
-            <td style={cell}>{spotRequest.geographic_description}</td>
-            <td colSpan={2} style={cell}>
-              Representative <span style={{ textDecoration: 'underline' }}>Stns</span>: {stationsStr}
-            </td>
-          </tr>
-          <tr>
-            <td style={cell}>
-              Coordinates (<span style={{ textDecoration: 'underline' }}>approx</span>)
-            </td>
-            <td style={cell}>
-              {toDDM(spotRequest.latitude)},{toDDM(spotRequest.longitude)}
-            </td>
-            <td style={cell}>
-              Slope/aspect:{'  '}
-              {spotRequest.aspect ?? '—'}
-            </td>
-            <td style={cell} />
-          </tr>
-          <tr>
-            <td style={cell}>Elevation</td>
-            <td style={cell}>{spotRequest.elevation ? `${spotRequest.elevation} m` : '—'}</td>
-            <td style={cell}>{forecast.fire_size ? `Size:   ${forecast.fire_size} ha` : ''}</td>
-            <td style={cell} />
-          </tr>
-        </tbody>
-      </table>
+      <div style={grid}>
+        <div style={{ ...cell, fontWeight: 'bold' }}>Fire/Proj #</div>
+        <div style={cell}>{fireNumberStr}</div>
+        <div style={span2}>
+          Request by:{'  '}
+          {spotRequest.requestor_name}
+        </div>
+
+        <div style={cell}>Forecast by</div>
+        <div style={cell}>{forecast.forecaster_name}</div>
+        <div style={cell}>Email: {forecast.forecaster_email}</div>
+        <div style={cell}>Phone: {forecast.forecaster_phone ?? '—'}</div>
+
+        <div style={cell}>Geographic</div>
+        <div style={cell}>{spotRequest.geographic_description}</div>
+        <div style={span2}>
+          Representative <span style={{ textDecoration: 'underline' }}>Stations</span>: {stationsStr}
+        </div>
+
+        <div style={cell}>
+          Coordinates (<span style={{ textDecoration: 'underline' }}>approx</span>)
+        </div>
+        <div style={cell}>
+          {toDDM(spotRequest.latitude)},{toDDM(spotRequest.longitude)}
+        </div>
+        <div style={cell}>
+          Slope/aspect:{'  '}
+          {spotRequest.aspect ?? '—'}
+        </div>
+        <div style={cell} />
+
+        <div style={cell}>Elevation</div>
+        <div style={cell}>{spotRequest.elevation ? `${spotRequest.elevation} m` : '—'}</div>
+        <div style={cell}>{forecast.fire_size ? `Size:   ${forecast.fire_size} ha` : ''}</div>
+        <div style={cell} />
+      </div>
     </Box>
   )
 }

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastSummarySection.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastSummarySection.tsx
@@ -22,13 +22,13 @@ const SpotForecastSummarySection: React.FC<SpotForecastSummarySectionProps> = ({
 
   return (
     <Box sx={{ mt: 1.5 }}>
-      <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+      <Typography variant="body2" sx={{ fontSize: '12px', lineHeight: 1.6 }}>
         <strong>
           <span style={{ textDecoration: 'underline' }}>FORECAST:</span>
         </strong>
       </Typography>
       {afternoonForecast && (
-        <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+        <Typography variant="body2" sx={{ fontSize: '12px', lineHeight: 1.6 }}>
           <strong>AFTERNOON:</strong>
           {'  '}
           {ensurePeriod(afternoonForecast.conditions)} MAX TEMP {afternoonForecast.temperature}C, MIN RH{' '}
@@ -36,7 +36,7 @@ const SpotForecastSummarySection: React.FC<SpotForecastSummarySectionProps> = ({
         </Typography>
       )}
       {tonightForecast && (
-        <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+        <Typography variant="body2" sx={{ fontSize: '12px', lineHeight: 1.6 }}>
           <strong>TONIGHT:</strong>
           {'  '}
           {ensurePeriod(tonightForecast.conditions)} MIN TEMP {tonightForecast.temperature}C. MAX RH{' '}
@@ -44,7 +44,7 @@ const SpotForecastSummarySection: React.FC<SpotForecastSummarySectionProps> = ({
         </Typography>
       )}
       {tomorrowForecast && (
-        <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+        <Typography variant="body2" sx={{ fontSize: '12px', lineHeight: 1.6 }}>
           <strong>TOMORROW:</strong>
           {'  '}
           {ensurePeriod(tomorrowForecast.conditions)} TEMP {tomorrowForecast.temperature}C. MIN RH{' '}

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastSummarySection.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastSummarySection.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Box, Typography } from '@mui/material'
+import { SpotDescriptiveWeatherOutput } from '@wps/api/SMURFIAPI'
+
+const ensurePeriod = (text: string | null): string => {
+  if (!text) {
+    return ''
+  }
+  return text.endsWith('.') ? text : `${text}.`
+}
+
+interface SpotForecastSummarySectionProps {
+  descriptiveWeather: SpotDescriptiveWeatherOutput[]
+}
+
+const SpotForecastSummarySection: React.FC<SpotForecastSummarySectionProps> = ({ descriptiveWeather }) => {
+  if (!descriptiveWeather || descriptiveWeather.length === 0) return null
+
+  const afternoonForecast = descriptiveWeather.find(dw => dw.period === 'Today')
+  const tonightForecast = descriptiveWeather.find(dw => dw.period === 'Tonight')
+  const tomorrowForecast = descriptiveWeather.find(dw => dw.period === 'Tomorrow')
+
+  return (
+    <Box sx={{ mt: 1.5 }}>
+      <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+        <strong>
+          <span style={{ textDecoration: 'underline' }}>FORECAST:</span>
+        </strong>
+      </Typography>
+      {afternoonForecast && (
+        <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+          <strong>AFTERNOON:</strong>
+          {'  '}
+          {ensurePeriod(afternoonForecast.conditions)} MAX TEMP {afternoonForecast.temperature}C, MIN RH{' '}
+          {afternoonForecast.relative_humidity}%
+        </Typography>
+      )}
+      {tonightForecast && (
+        <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+          <strong>TONIGHT:</strong>
+          {'  '}
+          {ensurePeriod(tonightForecast.conditions)} MIN TEMP {tonightForecast.temperature}C. MAX RH{' '}
+          {tonightForecast.relative_humidity}%.
+        </Typography>
+      )}
+      {tomorrowForecast && (
+        <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+          <strong>TOMORROW:</strong>
+          {'  '}
+          {ensurePeriod(tomorrowForecast.conditions)} TEMP {tomorrowForecast.temperature}C. MIN RH{' '}
+          {tomorrowForecast.relative_humidity}%.
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+export default SpotForecastSummarySection

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecasts.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecasts.tsx
@@ -1,13 +1,34 @@
-import { Box } from '@mui/material'
+import { AppDispatch } from '@/app/store'
+import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
+import { Box, CircularProgress, Typography } from '@mui/material'
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 
-// Placeholder page for the SpotForecasts associated with the SpotRequested as referenced by param.id which is taken from the URL
 const SpotForecasts = () => {
-  const params = useParams()
+  const { id } = useParams<{ id: string }>()
+  const dispatch = useDispatch<AppDispatch>()
+  const { spotForecastsByRequestId, spotForecastsLoading } = useSelector(selectSmurfi)
+
+  const spotRequestId = Number(id)
+
+  useEffect(() => {
+    if (!spotForecastsByRequestId[spotRequestId]) {
+      dispatch(fetchSpotForecasts(spotRequestId))
+    }
+  }, [dispatch, spotRequestId, spotForecastsByRequestId])
+
+  if (spotForecastsLoading) {
+    return <CircularProgress />
+  }
+
+  const forecasts = spotForecastsByRequestId[spotRequestId] ?? []
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
-      Placeholder for spot forecasts associated with the Spot Request specified in the URL path SpotForecast:{' '}
-      {params.id}
+      <Typography>
+        Spot forecasts for request {id} — {forecasts.length} forecast(s)
+      </Typography>
     </Box>
   )
 }

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/WeatherDataTable.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/WeatherDataTable.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { DateTime } from 'luxon'
+import { SpotForecastOutput } from '@wps/api/SMURFIAPI'
+
+const TIMEZONE = 'America/Vancouver'
+
+const formatDateLabel = (dateTimeStr: string, issuedDateISO: string): string => {
+  const dt = DateTime.fromISO(dateTimeStr).setZone(TIMEZONE)
+  const issuedDay = DateTime.fromISO(issuedDateISO).setZone(TIMEZONE).startOf('day')
+  const dayDiff = Math.round(dt.startOf('day').diff(issuedDay, 'days').days)
+  const time = dt.toFormat('HHmm')
+
+  if (dayDiff === 0) return `Today ${time}`
+  if (dayDiff === 1) return dt.hour === 0 ? 'Tonight' : `Tomorrow ${time}`
+  if (dayDiff === 2) return dt.hour === 0 ? 'Tomorrow night' : `Next Day ${time}`
+  return dateTimeStr
+}
+
+const cell: React.CSSProperties = {
+  border: '1px solid black',
+  padding: '3px 8px',
+  verticalAlign: 'top',
+  fontSize: '0.875rem'
+}
+
+const hdrCell: React.CSSProperties = {
+  ...cell,
+  fontWeight: 'bold',
+  textAlign: 'center'
+}
+
+const numCell: React.CSSProperties = {
+  ...cell,
+  fontWeight: 'bold',
+  textAlign: 'center'
+}
+
+const dashCell: React.CSSProperties = {
+  ...cell,
+  textAlign: 'center'
+}
+
+interface WeatherDataTableProps {
+  rows: SpotForecastOutput['tabular_weather']
+  issuedDate: string
+}
+
+const WeatherDataTable: React.FC<WeatherDataTableProps> = ({ rows, issuedDate }) => {
+  const sorted = [...rows].sort((a, b) => a.forecast_time.localeCompare(b.forecast_time))
+
+  return (
+    <table role="presentation" style={{ borderCollapse: 'collapse', width: '100%', marginTop: 12 }}>
+      <thead>
+        <tr>
+          <th style={{ ...hdrCell, textAlign: 'left' }}>Date/Time (PDT)</th>
+          <th style={hdrCell}>Temp (C)</th>
+          <th style={hdrCell}>RH</th>
+          <th style={hdrCell}>Wind (km/h)</th>
+          <th style={hdrCell}>Rain (mm)</th>
+          <th style={hdrCell}>Chance Rain</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((row, i) => (
+          <tr key={i}>
+            <td style={cell}>{formatDateLabel(row.forecast_time, issuedDate)}</td>
+            <td style={numCell}>{row.temperature ?? '-'}</td>
+            <td style={numCell}>{row.relative_humidity ?? '-'}</td>
+            <td style={numCell}>{row.wind ?? '-'}</td>
+            <td style={dashCell}>{row.precipitation_amount ?? '-'}</td>
+            <td style={dashCell}>{row.probability_of_precipitation ?? '-'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export default WeatherDataTable

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/WeatherDataTable.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/WeatherDataTable.tsx
@@ -75,8 +75,8 @@ const WeatherDataTable: React.FC<WeatherDataTableProps> = ({ rows, issuedDate, f
           {header}
         </div>
       ))}
-      {sorted.map((row, i) => (
-        <React.Fragment key={i}>
+      {sorted.map(row => (
+        <React.Fragment key={row.forecast_time}>
           <div style={cellWithSize}>{formatDateLabel(row.forecast_time, issuedDate)}</div>
           <div style={numCellWithSize}>{row.temperature ?? '-'}</div>
           <div style={numCellWithSize}>{row.relative_humidity ?? '-'}</div>

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/WeatherDataTable.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/WeatherDataTable.tsx
@@ -16,8 +16,20 @@ const formatDateLabel = (dateTimeStr: string, issuedDateISO: string): string => 
   return dateTimeStr
 }
 
+const COLUMNS = '2fr 1fr 1fr 2fr 1fr 1fr'
+
+const grid: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: COLUMNS,
+  borderTop: '1px solid black',
+  borderLeft: '1px solid black',
+  marginTop: 12,
+  width: '100%'
+}
+
 const cell: React.CSSProperties = {
-  border: '1px solid black',
+  borderRight: '1px solid black',
+  borderBottom: '1px solid black',
   padding: '3px 8px',
   verticalAlign: 'top',
   fontSize: '0.875rem'
@@ -40,39 +52,40 @@ const dashCell: React.CSSProperties = {
   textAlign: 'center'
 }
 
+const HEADERS = ['Date/Time (PDT)', 'Temp (C)', 'RH', 'Wind (km/h)', 'Rain (mm)', 'Chance Rain']
+
 interface WeatherDataTableProps {
   rows: SpotForecastOutput['tabular_weather']
   issuedDate: string
+  fontSize?: string
 }
 
-const WeatherDataTable: React.FC<WeatherDataTableProps> = ({ rows, issuedDate }) => {
+const WeatherDataTable: React.FC<WeatherDataTableProps> = ({ rows, issuedDate, fontSize = '0.875rem' }) => {
   const sorted = [...rows].sort((a, b) => a.forecast_time.localeCompare(b.forecast_time))
 
+  const cellWithSize: React.CSSProperties = { ...cell, fontSize }
+  const numCellWithSize: React.CSSProperties = { ...numCell, fontSize }
+  const dashCellWithSize: React.CSSProperties = { ...dashCell, fontSize }
+  const hdrCellWithSize: React.CSSProperties = { ...hdrCell, fontSize }
+
   return (
-    <table role="presentation" style={{ borderCollapse: 'collapse', width: '100%', marginTop: 12 }}>
-      <thead>
-        <tr>
-          <th style={{ ...hdrCell, textAlign: 'left' }}>Date/Time (PDT)</th>
-          <th style={hdrCell}>Temp (C)</th>
-          <th style={hdrCell}>RH</th>
-          <th style={hdrCell}>Wind (km/h)</th>
-          <th style={hdrCell}>Rain (mm)</th>
-          <th style={hdrCell}>Chance Rain</th>
-        </tr>
-      </thead>
-      <tbody>
-        {sorted.map((row, i) => (
-          <tr key={i}>
-            <td style={cell}>{formatDateLabel(row.forecast_time, issuedDate)}</td>
-            <td style={numCell}>{row.temperature ?? '-'}</td>
-            <td style={numCell}>{row.relative_humidity ?? '-'}</td>
-            <td style={numCell}>{row.wind ?? '-'}</td>
-            <td style={dashCell}>{row.precipitation_amount ?? '-'}</td>
-            <td style={dashCell}>{row.probability_of_precipitation ?? '-'}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div style={grid}>
+      {HEADERS.map((header, i) => (
+        <div key={header} style={i === 0 ? { ...hdrCellWithSize, textAlign: 'left' } : hdrCellWithSize}>
+          {header}
+        </div>
+      ))}
+      {sorted.map((row, i) => (
+        <React.Fragment key={i}>
+          <div style={cellWithSize}>{formatDateLabel(row.forecast_time, issuedDate)}</div>
+          <div style={numCellWithSize}>{row.temperature ?? '-'}</div>
+          <div style={numCellWithSize}>{row.relative_humidity ?? '-'}</div>
+          <div style={numCellWithSize}>{row.wind ?? '-'}</div>
+          <div style={dashCellWithSize}>{row.precipitation_amount ?? '-'}</div>
+          <div style={dashCellWithSize}>{row.probability_of_precipitation ?? '-'}</div>
+        </React.Fragment>
+      ))}
+    </div>
   )
 }
 

--- a/web/apps/wps-web/src/features/smurfi/constants/spotForecastDefaults.ts
+++ b/web/apps/wps-web/src/features/smurfi/constants/spotForecastDefaults.ts
@@ -4,12 +4,12 @@ import { DateTime } from 'luxon'
 export const defaultDateTimes = [
   DateTime.now().setZone('America/Vancouver').set({ hour: 16, minute: 0 }),
   DateTime.now().setZone('America/Vancouver').set({ hour: 19, minute: 0 }),
-  DateTime.now().setZone('America/Vancouver').set({ hour: 0, minute: 0 }),
+  DateTime.now().setZone('America/Vancouver').plus({ days: 1 }).set({ hour: 0, minute: 0 }),
   DateTime.now().setZone('America/Vancouver').plus({ days: 1 }).set({ hour: 10, minute: 0 }),
   DateTime.now().setZone('America/Vancouver').plus({ days: 1 }).set({ hour: 13, minute: 0 }),
   DateTime.now().setZone('America/Vancouver').plus({ days: 1 }).set({ hour: 16, minute: 0 }),
   DateTime.now().setZone('America/Vancouver').plus({ days: 1 }).set({ hour: 19, minute: 0 }),
-  DateTime.now().setZone('America/Vancouver').plus({ days: 1 }).set({ hour: 0, minute: 0 }),
+  DateTime.now().setZone('America/Vancouver').plus({ days: 2 }).set({ hour: 0, minute: 0 }),
   DateTime.now().setZone('America/Vancouver').plus({ days: 2 }).set({ hour: 16, minute: 0 })
 ]
 

--- a/web/apps/wps-web/src/features/smurfi/interfaces.ts
+++ b/web/apps/wps-web/src/features/smurfi/interfaces.ts
@@ -8,6 +8,12 @@ export const SpotRequestStatusColorMap = {
   [SpotRequestStatus.ARCHIVED]: { bgColor: '#e0e0e0', color: 'black', borderColor: 'black' }
 }
 
+export interface RepresentativeStation {
+  code: number
+  name: string
+  elevation?: number
+}
+
 export interface SpotForecastHistoryItem {
   id: number
   fire_id: string

--- a/web/apps/wps-web/src/features/smurfi/pages/PrintableSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/pages/PrintableSpotForecast.tsx
@@ -1,17 +1,15 @@
-import { CircularProgress, Typography } from '@mui/material'
+import { Box, CircularProgress, Typography } from '@mui/material'
 import { useParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
 import { fetchWxStations } from '@/features/stations/slices/stationsSlice'
 import { selectFireWeatherStations } from '@/app/rootReducer'
 import { getStations, StationSource } from '@wps/api/stationAPI'
-import { spotRequestTypeMap } from '@wps/api/SMURFIAPI'
-import MiniSpotForecast from '@/features/smurfi/components/forecasts/MiniSpotForecast'
+import PrintableFullSpotForecast from '@/features/smurfi/components/forecasts/PrintableFullSpotForecast'
 import { useEffect } from 'react'
 import { AppDispatch } from '@/app/store'
-import FullSpotForecast from '@/features/smurfi/components/forecasts/FullSpotForecast'
 
-const SpotForecast = () => {
+const PrintableSpotForecast = () => {
   const { id, forecastId } = useParams<{ id: string; forecastId: string }>()
   const dispatch = useDispatch<AppDispatch>()
   const { spotRequests, spotRequestsLoading, spotForecastsByRequestId, spotForecastsLoading } =
@@ -49,17 +47,15 @@ const SpotForecast = () => {
     return station ? [{ code, name: station.properties.name, elevation: station.properties.elevation }] : []
   })
 
-  if (spotRequest.request_type === spotRequestTypeMap['MINI_SPOT']) {
-    return <MiniSpotForecast forecast={spotForecast} />
-  }
-
   return (
-    <FullSpotForecast
-      forecast={spotForecast}
-      spotRequest={spotRequest}
-      representativeStations={representativeStations}
-    />
+    <Box sx={{ p: 3 }}>
+      <PrintableFullSpotForecast
+        forecast={spotForecast}
+        spotRequest={spotRequest}
+        representativeStations={representativeStations}
+      />
+    </Box>
   )
 }
 
-export default SpotForecast
+export default PrintableSpotForecast

--- a/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
+++ b/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
@@ -13,6 +13,7 @@ import SpotForecasts from '@/features/smurfi/components/forecasts/SpotForecasts'
 import SpotForecast from '@/features/smurfi/components/forecasts/SpotForecast'
 import SpotRequestFormPage from '@/features/smurfi/components/requestForm/SpotRequestFormPage'
 import SpotForecastFormPage from '@/features/smurfi/components/forecastForm/SpotForecastFormPage'
+import PrintableSpotForecast from '@/features/smurfi/pages/PrintableSpotForecast'
 import { AppDispatch } from '@/app/store'
 import { useDispatch } from 'react-redux'
 import { fetchSpotRequests } from '@/features/smurfi/slices/smurfiSlice'
@@ -43,11 +44,13 @@ const SMURFIPage = () => {
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-        <GeneralHeader isBeta={true} spacing={1} title="SMURFI" />
-        <Tabs value={currentTab} onChange={handleChange}>
-          <Tab label="Dashboard" onClick={() => navigate(SMURFI_DASHBOARD_ROUTE)} />
-          <Tab label="Map" />
-        </Tabs>
+        <Box sx={{ display: location.pathname.endsWith('/printable') ? 'none' : 'block' }}>
+          <GeneralHeader isBeta={true} spacing={1} title="SMURFI" />
+          <Tabs value={currentTab} onChange={handleChange}>
+            <Tab label="Dashboard" onClick={() => navigate(SMURFI_DASHBOARD_ROUTE)} />
+            <Tab label="Map" />
+          </Tabs>
+        </Box>
         <Box sx={{ flex: 1, minHeight: 0, display: 'flex' }}>
           <Routes>
             <Route
@@ -61,6 +64,7 @@ const SMURFIPage = () => {
                     <Route path=":id/forecasts" element={<SpotForecasts />} />
                     <Route path=":id/forecasts/new" element={<SpotForecastFormPage />} />
                     <Route path=":id/forecasts/:forecastId" element={<SpotForecast />} />
+                    <Route path=":id/forecasts/:forecastId/printable" element={<PrintableSpotForecast />} />
                   </Routes>
                 </RouteContent>
               }

--- a/web/apps/wps-web/src/features/smurfi/slices/smurfiSlice.ts
+++ b/web/apps/wps-web/src/features/smurfi/slices/smurfiSlice.ts
@@ -171,14 +171,12 @@ export const submitSpotForecast =
   }
 
 export const fetchSpotForecasts =
-  (spotRequestId: number): AppThunk<Promise<SpotForecastOutput[]>> =>
+  (spotRequestId: number): AppThunk =>
   async dispatch => {
     try {
       dispatch(getSpotForecastsStart())
-
       const response = await getSpotForecasts(spotRequestId)
       dispatch(getSpotForecastsSuccess({ spotRequestId, spotForecasts: response.spot_forecasts }))
-      return response.spot_forecasts
     } catch (err) {
       dispatch(getSpotForecastsFailed((err as Error).toString()))
       return []

--- a/web/packages/api/src/SMURFIAPI.ts
+++ b/web/packages/api/src/SMURFIAPI.ts
@@ -3,6 +3,10 @@ import { SpotFormData } from './schema/spotForecastSchema'
 import { SpotRequestFormData } from './schema/spotRequestSchema'
 import { DateTime } from 'luxon'
 
+const COMPASS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'] as const
+
+const degreesToCompass = (degrees: number): string => COMPASS[Math.round((((degrees % 360) + 360) % 360) / 45) % 8]
+
 export enum SpotRequestStatus {
   REQUESTED = 'Requested',
   STARTED = 'Started',
@@ -56,7 +60,7 @@ export interface SpotForecastInput {
   tabular_weather: SpotTabularWeatherInput[]
 }
 
-interface SpotDescriptiveWeatherOutput extends SpotDescriptiveWeatherInput {
+export interface SpotDescriptiveWeatherOutput extends SpotDescriptiveWeatherInput {
   id: number
 }
 
@@ -199,7 +203,7 @@ export interface SpotRequestsResponse {
   spot_requests: SpotRequestOutput[]
 }
 
-const spotRequestTypeMap: Record<SpotRequestFormData['forecastType'], string> = {
+export const spotRequestTypeMap: Record<SpotRequestFormData['forecastType'], string> = {
   MINI_SPOT: 'Mini',
   FULL_SPOT: 'Full'
 }


### PR DESCRIPTION
- adds a pretty Full Spot Forecast component
- adds a printable Full Spot Forecast component
- fixes small logic bug in generation of datetimes in forecast form

## Testing
To reach the FullSpotForecast form:
1. Create a spot request
2. Create a forecast for that request
3. From the request table click the Forecasts button which takes you to a placeholder page
4. Append the id of your forecast to the url so your have `/smurfi/requests/:id/forecasts/:forecastId
5. Hit the Print Version button as well