### PR TITLE
Mini forecast detail pages

### DIFF
--- a/web/apps/wps-web/src/features/smurfi/components/forecastForm/SpotForecastForm.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecastForm/SpotForecastForm.tsx
@@ -12,7 +12,6 @@ import SpotForecastSummaries from '@/features/smurfi/components/forecastForm/Spo
 import SpotForecastSections from '@/features/smurfi/components/forecastForm/SpotForecastSections'
 import { SpotRequestOutput } from '@wps/api/SMURFIAPI'
 import { createSchema, SpotFormData } from '@wps/api/schema/spotForecastSchema'
-import { getStations, StationSource } from '@wps/api/stationAPI'
 import { clearSpotForecastSubmitState, submitSpotForecast, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
 
 const toFormString = (value: number | string | null | undefined) =>

--- a/web/apps/wps-web/src/features/smurfi/components/forecastForm/SpotForecastForm.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecastForm/SpotForecastForm.tsx
@@ -3,7 +3,6 @@ import { useForm, useFieldArray } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useDispatch, useSelector } from 'react-redux'
 import { Alert, Grid, Button, Box, FormControlLabel, FormControl, FormLabel, RadioGroup, Radio } from '@mui/material'
-import { fetchWxStations } from '@/features/stations/slices/stationsSlice'
 import { AppDispatch } from '@/app/store'
 import { getDefaultValues, defaultWeatherRows } from '@/features/smurfi/constants/spotForecastDefaults'
 import SpotForecastHeader from '@/features/smurfi/components/forecastForm/SpotForecastHeader'
@@ -87,10 +86,6 @@ const SpotForecastForm: React.FC<SpotForecastFormProps> = ({ spotRequest, onSubm
   useEffect(() => {
     reset(defaultValues)
   }, [defaultValues, reset])
-
-  useEffect(() => {
-    dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
-  }, [dispatch])
 
   useEffect(() => {
     return () => {

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
-import { Box, Button, Divider, Paper, Typography } from '@mui/material'
+import { Box, Divider, Paper, Typography } from '@mui/material'
 import { DateTime } from 'luxon'
-import { useNavigate } from 'react-router-dom'
 import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
 import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'
 import { RepresentativeStation } from '@/features/smurfi/interfaces'
-import { SMURFI_DASHBOARD_ROUTE } from '@wps/utils/constants'
 
 const TIMEZONE = 'America/Vancouver'
 
@@ -54,24 +52,16 @@ export interface FullSpotForecastProps {
 }
 
 const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotRequest, representativeStations }) => {
-  const navigate = useNavigate()
   const afternoonForecast = forecast.descriptive_weather.find(dw => dw.period === 'Today')
   const tonightForecast = forecast.descriptive_weather.find(dw => dw.period === 'Tonight')
   const tomorrowForecast = forecast.descriptive_weather.find(dw => dw.period === 'Tomorrow')
   const stationsStr =
     representativeStations.length > 0
-      ? representativeStations.map(s => `${s.name}${s.elevation != null ? ` (${s.elevation}m)` : ''}`).join(', ')
+      ? representativeStations.map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation}m)`)).join(', ')
       : '—'
-
-  const printableUrl = `${SMURFI_DASHBOARD_ROUTE}/${spotRequest.id}/forecasts/${forecast.id}/printable`
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Box>
-        <Button variant="outlined" size="small" onClick={() => navigate(printableUrl)}>
-          Printable Version
-        </Button>
-      </Box>
       <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2 }}>
         <Section title="Forecast Info">
           <Field label="Fire Number(s)" value={spotRequest.fire_number?.join(', ') ?? '—'} />

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
@@ -1,49 +1,14 @@
 import React from 'react'
-import { Box, Divider, Paper, Typography } from '@mui/material'
-import { DateTime } from 'luxon'
+import { Box, Typography } from '@mui/material'
 import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
-import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'
 import { RepresentativeStation } from '@/features/smurfi/interfaces'
-
-const TIMEZONE = 'America/Vancouver'
-
-const formatDateTime = (iso: string) => {
-  const dt = DateTime.fromISO(iso).setZone(TIMEZONE)
-  return dt.isValid ? `${dt.toFormat('HHmm')} ${dt.offsetNameShort} ${dt.toFormat('EEE, MMM d, yyyy')}` : iso
-}
-
-const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
-  <Box>
-    <Typography
-      variant="caption"
-      color="text.secondary"
-      sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8 }}
-    >
-      {label}
-    </Typography>
-    <Typography variant="body1">{value ?? '—'}</Typography>
-  </Box>
-)
-
-const Section = ({ title, children, contentSx }: { title: string; children: React.ReactNode; contentSx?: object }) => (
-  <Paper variant="outlined" sx={{ p: 2.5, display: 'flex', flexDirection: 'column' }}>
-    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
-      {title}
-    </Typography>
-    <Divider sx={{ mt: 0.5, mb: 2 }} />
-    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2, ...contentSx }}>{children}</Box>
-  </Paper>
-)
-
-const TextSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
-  <Paper variant="outlined" sx={{ p: 2.5 }}>
-    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
-      {title}
-    </Typography>
-    <Divider sx={{ mt: 0.5, mb: 2 }} />
-    <Typography variant="body1">{children}</Typography>
-  </Paper>
-)
+import {
+  Field,
+  Section,
+  TextSection,
+  WeatherDataSection
+} from '@/features/smurfi/components/forecasts/SpotForecastComponents'
+import { formatDateTime, formatStationsStr } from '@/features/smurfi/utils/spotForecastUtils'
 
 export interface FullSpotForecastProps {
   forecast: SpotForecastOutput
@@ -55,10 +20,7 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
   const afternoonForecast = forecast.descriptive_weather.find(dw => dw.period === 'Today')
   const tonightForecast = forecast.descriptive_weather.find(dw => dw.period === 'Tonight')
   const tomorrowForecast = forecast.descriptive_weather.find(dw => dw.period === 'Tomorrow')
-  const stationsStr =
-    representativeStations.length > 0
-      ? representativeStations.map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation}m)`)).join(', ')
-      : '—'
+  const stationsStr = formatStationsStr(representativeStations)
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -125,15 +87,7 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
         </Section>
       )}
 
-      {forecast.tabular_weather.length > 0 && (
-        <Paper variant="outlined" sx={{ p: 2.5 }}>
-          <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
-            Weather Data
-          </Typography>
-          <Divider sx={{ mt: 0.5, mb: 2 }} />
-          <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} />
-        </Paper>
-      )}
+      <WeatherDataSection forecast={forecast} />
 
       <Box
         sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: forecast.outlook ? '1fr 1fr' : '1fr' }, gap: 2 }}

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/MiniSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/MiniSpotForecast.tsx
@@ -1,49 +1,14 @@
 import React from 'react'
-import { Box, Divider, Paper, Typography } from '@mui/material'
-import { DateTime } from 'luxon'
+import { Box } from '@mui/material'
 import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
 import { RepresentativeStation } from '@/features/smurfi/interfaces'
-import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'
-
-const TIMEZONE = 'America/Vancouver'
-
-const formatDateTime = (iso: string) => {
-  const dt = DateTime.fromISO(iso).setZone(TIMEZONE)
-  return dt.isValid ? `${dt.toFormat('HHmm')} ${dt.offsetNameShort} ${dt.toFormat('EEE, MMM d, yyyy')}` : iso
-}
-
-const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
-  <Box>
-    <Typography
-      variant="caption"
-      color="text.secondary"
-      sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8 }}
-    >
-      {label}
-    </Typography>
-    <Typography variant="body1">{value ?? '—'}</Typography>
-  </Box>
-)
-
-const Section = ({ title, children, contentSx }: { title: string; children: React.ReactNode; contentSx?: object }) => (
-  <Paper variant="outlined" sx={{ p: 2.5, display: 'flex', flexDirection: 'column' }}>
-    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
-      {title}
-    </Typography>
-    <Divider sx={{ mt: 0.5, mb: 2 }} />
-    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2, ...contentSx }}>{children}</Box>
-  </Paper>
-)
-
-const TextSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
-  <Paper variant="outlined" sx={{ p: 2.5 }}>
-    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
-      {title}
-    </Typography>
-    <Divider sx={{ mt: 0.5, mb: 2 }} />
-    <Typography variant="body1">{children}</Typography>
-  </Paper>
-)
+import {
+  Field,
+  Section,
+  TextSection,
+  WeatherDataSection
+} from '@/features/smurfi/components/forecasts/SpotForecastComponents'
+import { formatDateTime, formatStationsStr } from '@/features/smurfi/utils/spotForecastUtils'
 
 export interface MiniSpotForecastProps {
   forecast: SpotForecastOutput
@@ -52,10 +17,7 @@ export interface MiniSpotForecastProps {
 }
 
 const MiniSpotForecast: React.FC<MiniSpotForecastProps> = ({ forecast, spotRequest, representativeStations }) => {
-  const stationsStr =
-    representativeStations.length > 0
-      ? representativeStations.map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation}m)`)).join(', ')
-      : '—'
+  const stationsStr = formatStationsStr(representativeStations)
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -82,15 +44,7 @@ const MiniSpotForecast: React.FC<MiniSpotForecastProps> = ({ forecast, spotReque
         </Section>
       </Box>
 
-      {forecast.tabular_weather.length > 0 && (
-        <Paper variant="outlined" sx={{ p: 2.5 }}>
-          <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
-            Weather Data
-          </Typography>
-          <Divider sx={{ mt: 0.5, mb: 2 }} />
-          <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} />
-        </Paper>
-      )}
+      <WeatherDataSection forecast={forecast} />
 
       {forecast.synopsis && <TextSection title="Notes / Discussion">{forecast.synopsis}</TextSection>}
 

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/MiniSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/MiniSpotForecast.tsx
@@ -1,13 +1,108 @@
 import React from 'react'
-import { Box } from '@mui/material'
-import { SpotForecastOutput } from '@wps/api/SMURFIAPI'
+import { Box, Divider, Paper, Typography } from '@mui/material'
+import { DateTime } from 'luxon'
+import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
+import { RepresentativeStation } from '@/features/smurfi/interfaces'
+import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'
 
-interface MiniSpotForecastProps {
-  forecast: SpotForecastOutput
+const TIMEZONE = 'America/Vancouver'
+
+const formatDateTime = (iso: string) => {
+  const dt = DateTime.fromISO(iso).setZone(TIMEZONE)
+  return dt.isValid ? `${dt.toFormat('HHmm')} ${dt.offsetNameShort} ${dt.toFormat('EEE, MMM d, yyyy')}` : iso
 }
 
-const MiniSpotForecast: React.FC<MiniSpotForecastProps> = ({ forecast: _ }) => {
-  return <Box>Mini Spot Forecast placeholder</Box>
+const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <Box>
+    <Typography
+      variant="caption"
+      color="text.secondary"
+      sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8 }}
+    >
+      {label}
+    </Typography>
+    <Typography variant="body1">{value ?? '—'}</Typography>
+  </Box>
+)
+
+const Section = ({ title, children, contentSx }: { title: string; children: React.ReactNode; contentSx?: object }) => (
+  <Paper variant="outlined" sx={{ p: 2.5, display: 'flex', flexDirection: 'column' }}>
+    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+      {title}
+    </Typography>
+    <Divider sx={{ mt: 0.5, mb: 2 }} />
+    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2, ...contentSx }}>{children}</Box>
+  </Paper>
+)
+
+const TextSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <Paper variant="outlined" sx={{ p: 2.5 }}>
+    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+      {title}
+    </Typography>
+    <Divider sx={{ mt: 0.5, mb: 2 }} />
+    <Typography variant="body1">{children}</Typography>
+  </Paper>
+)
+
+export interface MiniSpotForecastProps {
+  forecast: SpotForecastOutput
+  spotRequest: SpotRequestOutput
+  representativeStations: RepresentativeStation[]
+}
+
+const MiniSpotForecast: React.FC<MiniSpotForecastProps> = ({ forecast, spotRequest, representativeStations }) => {
+  const stationsStr =
+    representativeStations.length > 0
+      ? representativeStations.map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation}m)`)).join(', ')
+      : '—'
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2 }}>
+        <Section title="Forecast Info">
+          <Field label="Fire Number(s)" value={spotRequest.fire_number?.join(', ') ?? '—'} />
+          <Field label="Requested By" value={spotRequest.requestor_name} />
+          <Field label="Issued" value={formatDateTime(forecast.issued_at)} />
+          <Field label="Expires" value={forecast.expires_at ? formatDateTime(forecast.expires_at) : '—'} />
+          <Field label="Forecaster" value={forecast.forecaster_name} />
+          <Field label="Email" value={forecast.forecaster_email} />
+          {forecast.forecaster_phone && <Field label="Phone" value={forecast.forecaster_phone} />}
+          <Box sx={{ gridColumn: '1 / -1' }}>
+            <Field label="Representative Stations" value={stationsStr} />
+          </Box>
+        </Section>
+
+        <Section title="Location">
+          <Box sx={{ gridColumn: '1 / -1' }}>
+            <Field label="Geographic Description" value={spotRequest.geographic_description} />
+          </Box>
+          <Field label="Latitude" value={spotRequest.latitude.toFixed(4)} />
+          <Field label="Longitude" value={spotRequest.longitude.toFixed(4)} />
+        </Section>
+      </Box>
+
+      {forecast.tabular_weather.length > 0 && (
+        <Paper variant="outlined" sx={{ p: 2.5 }}>
+          <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+            Weather Data
+          </Typography>
+          <Divider sx={{ mt: 0.5, mb: 2 }} />
+          <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} />
+        </Paper>
+      )}
+
+      {forecast.synopsis && <TextSection title="Notes / Discussion">{forecast.synopsis}</TextSection>}
+
+      {forecast.inversion_and_venting && (
+        <TextSection title="Venting / Inversions">{forecast.inversion_and_venting}</TextSection>
+      )}
+
+      {forecast.confidence && (
+        <TextSection title="Long Range Model Guidance and Discussion">{forecast.confidence}</TextSection>
+      )}
+    </Box>
+  )
 }
 
 export default MiniSpotForecast

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableMiniSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableMiniSpotForecast.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { Box, Typography } from '@mui/material'
+import { DateTime } from 'luxon'
+import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
+import { RepresentativeStation } from '@/features/smurfi/interfaces'
+import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'
+
+const TIMEZONE = 'America/Vancouver'
+const FONT_SIZE = '12px'
+
+const ordinal = (n: number): string => {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0])
+}
+
+export interface PrintableMiniSpotForecastProps {
+  forecast: SpotForecastOutput
+  spotRequest: SpotRequestOutput
+  representativeStations: RepresentativeStation[]
+}
+
+const PrintableMiniSpotForecast: React.FC<PrintableMiniSpotForecastProps> = ({
+  forecast,
+  spotRequest,
+  representativeStations
+}) => {
+  const issuedDt = DateTime.fromISO(forecast.issued_at).setZone(TIMEZONE)
+  const fireNumberStr = spotRequest.fire_number?.join(', ') ?? ''
+  const title = [fireNumberStr, 'Mini Spot Forecast'].filter(Boolean).join(' ')
+  const issuedDateStr = `${issuedDt.toFormat('EEEE, MMMM ')}${ordinal(issuedDt.day)}${issuedDt.toFormat(', yyyy')}`
+  const stationsStr = representativeStations
+    .map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation} m)`))
+    .join(', ')
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h6" sx={{ fontWeight: 'bold', textAlign: 'center' }}>
+        {title}
+      </Typography>
+      <Typography sx={{ fontSize: FONT_SIZE, textAlign: 'center', mb: 3 }}>{issuedDateStr}</Typography>
+
+      <Typography sx={{ fontSize: FONT_SIZE, fontWeight: 'bold', lineHeight: 1.4 }}>
+        {spotRequest.geographic_description}
+      </Typography>
+      <Typography sx={{ fontSize: FONT_SIZE, fontWeight: 'bold', mb: 2 }}>
+        <span style={{ textDecoration: 'underline' }}>Lat/Long:</span>{' '}
+        {spotRequest.latitude.toFixed(4)}, {spotRequest.longitude.toFixed(4)}
+      </Typography>
+
+      {stationsStr && (
+        <Typography sx={{ fontSize: FONT_SIZE, mb: 3 }}>
+          <strong style={{ textDecoration: 'underline' }}>Rep. Wx Station</strong>: {stationsStr}
+        </Typography>
+      )}
+
+      <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} fontSize={FONT_SIZE} />
+
+      {forecast.synopsis && (
+        <Box sx={{ mt: 3 }}>
+          <Typography sx={{ fontSize: FONT_SIZE, fontWeight: 'bold', textDecoration: 'underline' }}>
+            Notes/Discussion:
+          </Typography>
+          <Typography sx={{ fontSize: FONT_SIZE }}>{forecast.synopsis}</Typography>
+        </Box>
+      )}
+
+      {forecast.inversion_and_venting && (
+        <Box sx={{ mt: 2 }}>
+          <Typography sx={{ fontSize: FONT_SIZE, fontWeight: 'bold', textDecoration: 'underline' }}>
+            Venting/Inversions:
+          </Typography>
+          <Typography sx={{ fontSize: FONT_SIZE, mt: 1 }}>{forecast.inversion_and_venting}</Typography>
+        </Box>
+      )}
+
+      {forecast.confidence && (
+        <Box sx={{ mt: 2 }}>
+          <Typography sx={{ fontSize: FONT_SIZE, fontWeight: 'bold', textDecoration: 'underline' }}>
+            Long range model guidance and discussion:
+          </Typography>
+          <Typography sx={{ fontSize: FONT_SIZE, mt: 1 }}>{forecast.confidence}</Typography>
+        </Box>
+      )}
+
+      <Box sx={{ mt: 4 }}>
+        <Typography sx={{ fontSize: FONT_SIZE }}>{forecast.forecaster_name}</Typography>
+        {forecast.forecaster_phone && <Typography sx={{ fontSize: FONT_SIZE }}>{forecast.forecaster_phone}</Typography>}
+        <Typography sx={{ fontSize: FONT_SIZE }}>{forecast.forecaster_email}</Typography>
+      </Box>
+    </Box>
+  )
+}
+
+export default PrintableMiniSpotForecast

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecast.tsx
@@ -1,55 +1,26 @@
 import { Box, Button, CircularProgress, Typography } from '@mui/material'
-import { useParams, useNavigate } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
-import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
-import { fetchWxStations } from '@/features/stations/slices/stationsSlice'
-import { selectFireWeatherStations } from '@/app/rootReducer'
-import { getStations, StationSource } from '@wps/api/stationAPI'
+import { useNavigate, useParams } from 'react-router-dom'
 import { spotRequestTypeMap } from '@wps/api/SMURFIAPI'
 import MiniSpotForecast from '@/features/smurfi/components/forecasts/MiniSpotForecast'
-import { useEffect } from 'react'
-import { AppDispatch } from '@/app/store'
 import FullSpotForecast from '@/features/smurfi/components/forecasts/FullSpotForecast'
 import { SMURFI_DASHBOARD_ROUTE } from '@wps/utils/constants'
+import useSpotForecastData from '@/features/smurfi/hooks/useSpotForecastData'
 
 const SpotForecast = () => {
   const { id, forecastId } = useParams<{ id: string; forecastId: string }>()
-  const dispatch = useDispatch<AppDispatch>()
   const navigate = useNavigate()
-  const { spotRequests, spotRequestsLoading, spotForecastsByRequestId, spotForecastsLoading } =
-    useSelector(selectSmurfi)
-  const { stationsByCode, loading: stationsLoading } = useSelector(selectFireWeatherStations)
+  const { loading, spotRequest, spotForecast, representativeStations } = useSpotForecastData()
 
   const spotRequestId = Number(id)
   const spotForecastId = Number(forecastId)
 
-  useEffect(() => {
-    if (!spotForecastsByRequestId[spotRequestId]) {
-      dispatch(fetchSpotForecasts(spotRequestId))
-    }
-  }, [dispatch, spotRequestId, spotForecastsByRequestId])
-
-  useEffect(() => {
-    if (Object.keys(stationsByCode).length === 0) {
-      dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
-    }
-  }, [dispatch, stationsByCode])
-
-  if (spotRequestsLoading || spotForecastsLoading || stationsLoading) {
+  if (loading) {
     return <CircularProgress />
   }
-
-  const spotRequest = spotRequests.find(sr => sr.id === spotRequestId)
-  const spotForecast = (spotForecastsByRequestId[spotRequestId] ?? []).find(f => f.id === spotForecastId)
 
   if (!spotRequest || !spotForecast) {
     return <Typography>Forecast not found</Typography>
   }
-
-  const representativeStations = (spotForecast.representative_station_codes ?? []).flatMap(code => {
-    const station = stationsByCode[code]
-    return station ? [{ code, name: station.properties.name, elevation: station.properties.elevation }] : []
-  })
 
   const printUrl = `${SMURFI_DASHBOARD_ROUTE}/${spotRequestId}/forecasts/${spotForecastId}/print`
   const isMini = spotRequest.request_type === spotRequestTypeMap['MINI_SPOT']

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecast.tsx
@@ -1,5 +1,5 @@
-import { Box, CircularProgress, Typography } from '@mui/material'
-import { useParams } from 'react-router-dom'
+import { Box, Button, CircularProgress, Typography } from '@mui/material'
+import { useParams, useNavigate } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
 import { fetchWxStations } from '@/features/stations/slices/stationsSlice'
@@ -10,10 +10,12 @@ import MiniSpotForecast from '@/features/smurfi/components/forecasts/MiniSpotFor
 import { useEffect } from 'react'
 import { AppDispatch } from '@/app/store'
 import FullSpotForecast from '@/features/smurfi/components/forecasts/FullSpotForecast'
+import { SMURFI_DASHBOARD_ROUTE } from '@wps/utils/constants'
 
 const SpotForecast = () => {
   const { id, forecastId } = useParams<{ id: string; forecastId: string }>()
   const dispatch = useDispatch<AppDispatch>()
+  const navigate = useNavigate()
   const { spotRequests, spotRequestsLoading, spotForecastsByRequestId, spotForecastsLoading } =
     useSelector(selectSmurfi)
   const { stationsByCode, loading: stationsLoading } = useSelector(selectFireWeatherStations)
@@ -49,17 +51,29 @@ const SpotForecast = () => {
     return station ? [{ code, name: station.properties.name, elevation: station.properties.elevation }] : []
   })
 
-  if (spotRequest.request_type === spotRequestTypeMap['MINI_SPOT']) {
-    return <MiniSpotForecast forecast={spotForecast} />
-  }
+  const printableUrl = `${SMURFI_DASHBOARD_ROUTE}/${spotRequestId}/forecasts/${spotForecastId}/printable`
+  const isMini = spotRequest.request_type === spotRequestTypeMap['MINI_SPOT']
 
   return (
     <Box sx={{ pb: 4 }}>
-      <FullSpotForecast
-        forecast={spotForecast}
-        spotRequest={spotRequest}
-        representativeStations={representativeStations}
-      />
+      <Box sx={{ mb: 1 }}>
+        <Button variant="outlined" onClick={() => navigate(printableUrl)} size="small">
+          Printable Version
+        </Button>
+      </Box>
+      {isMini ? (
+        <MiniSpotForecast
+          forecast={spotForecast}
+          spotRequest={spotRequest}
+          representativeStations={representativeStations}
+        />
+      ) : (
+        <FullSpotForecast
+          forecast={spotForecast}
+          spotRequest={spotRequest}
+          representativeStations={representativeStations}
+        />
+      )}
     </Box>
   )
 }

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecast.tsx
@@ -51,13 +51,13 @@ const SpotForecast = () => {
     return station ? [{ code, name: station.properties.name, elevation: station.properties.elevation }] : []
   })
 
-  const printableUrl = `${SMURFI_DASHBOARD_ROUTE}/${spotRequestId}/forecasts/${spotForecastId}/printable`
+  const printUrl = `${SMURFI_DASHBOARD_ROUTE}/${spotRequestId}/forecasts/${spotForecastId}/print`
   const isMini = spotRequest.request_type === spotRequestTypeMap['MINI_SPOT']
 
   return (
     <Box sx={{ pb: 4 }}>
       <Box sx={{ mb: 1 }}>
-        <Button variant="outlined" onClick={() => navigate(printableUrl)} size="small">
+        <Button variant="outlined" onClick={() => navigate(printUrl)} size="small">
           Printable Version
         </Button>
       </Box>

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastComponents.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastComponents.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Box, Divider, Paper, Typography } from '@mui/material'
+import WeatherDataTable from '@/features/smurfi/components/forecasts/WeatherDataTable'
+import { SpotForecastOutput } from '@wps/api/SMURFIAPI'
+
+export const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <Box>
+    <Typography
+      variant="caption"
+      color="text.secondary"
+      sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8 }}
+    >
+      {label}
+    </Typography>
+    <Typography variant="body1">{value ?? '—'}</Typography>
+  </Box>
+)
+
+export const Section = ({
+  title,
+  children,
+  contentSx
+}: {
+  title: string
+  children: React.ReactNode
+  contentSx?: object
+}) => (
+  <Paper variant="outlined" sx={{ p: 2.5, display: 'flex', flexDirection: 'column' }}>
+    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+      {title}
+    </Typography>
+    <Divider sx={{ mt: 0.5, mb: 2 }} />
+    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2, ...contentSx }}>{children}</Box>
+  </Paper>
+)
+
+export const TextSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <Paper variant="outlined" sx={{ p: 2.5 }}>
+    <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+      {title}
+    </Typography>
+    <Divider sx={{ mt: 0.5, mb: 2 }} />
+    <Typography variant="body1">{children}</Typography>
+  </Paper>
+)
+
+export const WeatherDataSection = ({ forecast }: { forecast: SpotForecastOutput }) => {
+  if (forecast.tabular_weather.length === 0) return null
+  return (
+    <Paper variant="outlined" sx={{ p: 2.5 }}>
+      <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+        Weather Data
+      </Typography>
+      <Divider sx={{ mt: 0.5, mb: 2 }} />
+      <WeatherDataTable rows={forecast.tabular_weather} issuedDate={forecast.issued_at} />
+    </Paper>
+  )
+}

--- a/web/apps/wps-web/src/features/smurfi/hooks/useSpotForecastData.ts
+++ b/web/apps/wps-web/src/features/smurfi/hooks/useSpotForecastData.ts
@@ -1,17 +1,22 @@
-import { Box, CircularProgress, Typography } from '@mui/material'
+import { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
 import { fetchWxStations } from '@/features/stations/slices/stationsSlice'
 import { selectFireWeatherStations } from '@/app/rootReducer'
 import { getStations, StationSource } from '@wps/api/stationAPI'
-import { spotRequestTypeMap } from '@wps/api/SMURFIAPI'
-import PrintableFullSpotForecast from '@/features/smurfi/components/forecasts/PrintableFullSpotForecast'
-import PrintableMiniSpotForecast from '@/features/smurfi/components/forecasts/PrintableMiniSpotForecast'
-import { useEffect } from 'react'
 import { AppDispatch } from '@/app/store'
+import { RepresentativeStation } from '@/features/smurfi/interfaces'
+import { SpotForecastOutput, SpotRequestOutput } from '@wps/api/SMURFIAPI'
 
-const PrintableSpotForecast = () => {
+interface SpotForecastData {
+  loading: boolean
+  spotRequest: SpotRequestOutput | undefined
+  spotForecast: SpotForecastOutput | undefined
+  representativeStations: RepresentativeStation[]
+}
+
+const useSpotForecastData = (): SpotForecastData => {
   const { id, forecastId } = useParams<{ id: string; forecastId: string }>()
   const dispatch = useDispatch<AppDispatch>()
   const { spotRequests, spotRequestsLoading, spotForecastsByRequestId, spotForecastsLoading } =
@@ -33,33 +38,18 @@ const PrintableSpotForecast = () => {
     }
   }, [dispatch, stationsByCode])
 
-  if (spotRequestsLoading || spotForecastsLoading || stationsLoading) {
-    return <CircularProgress />
-  }
-
+  const loading = spotRequestsLoading || spotForecastsLoading || stationsLoading
   const spotRequest = spotRequests.find(sr => sr.id === spotRequestId)
   const spotForecast = (spotForecastsByRequestId[spotRequestId] ?? []).find(f => f.id === spotForecastId)
 
-  if (!spotRequest || !spotForecast) {
-    return <Typography>Forecast not found</Typography>
-  }
-
-  const representativeStations = (spotForecast.representative_station_codes ?? []).flatMap(code => {
-    const station = stationsByCode[code]
-    return station ? [{ code, name: station.properties.name, elevation: station.properties.elevation }] : []
-  })
-
-  const props = { forecast: spotForecast, spotRequest, representativeStations }
-
-  return (
-    <Box sx={{ p: 3 }}>
-      {spotRequest.request_type === spotRequestTypeMap['MINI_SPOT'] ? (
-        <PrintableMiniSpotForecast {...props} />
-      ) : (
-        <PrintableFullSpotForecast {...props} />
-      )}
-    </Box>
+  const representativeStations: RepresentativeStation[] = (spotForecast?.representative_station_codes ?? []).flatMap(
+    code => {
+      const station = stationsByCode[code]
+      return station ? [{ code, name: station.properties.name, elevation: station.properties.elevation }] : []
+    }
   )
+
+  return { loading, spotRequest, spotForecast, representativeStations }
 }
 
-export default PrintableSpotForecast
+export default useSpotForecastData

--- a/web/apps/wps-web/src/features/smurfi/pages/PrintableSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/pages/PrintableSpotForecast.tsx
@@ -1,53 +1,19 @@
 import { Box, CircularProgress, Typography } from '@mui/material'
-import { useParams } from 'react-router-dom'
-import { useDispatch, useSelector } from 'react-redux'
-import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
-import { fetchWxStations } from '@/features/stations/slices/stationsSlice'
-import { selectFireWeatherStations } from '@/app/rootReducer'
-import { getStations, StationSource } from '@wps/api/stationAPI'
 import { spotRequestTypeMap } from '@wps/api/SMURFIAPI'
 import PrintableFullSpotForecast from '@/features/smurfi/components/forecasts/PrintableFullSpotForecast'
 import PrintableMiniSpotForecast from '@/features/smurfi/components/forecasts/PrintableMiniSpotForecast'
-import { useEffect } from 'react'
-import { AppDispatch } from '@/app/store'
+import useSpotForecastData from '@/features/smurfi/hooks/useSpotForecastData'
 
 const PrintableSpotForecast = () => {
-  const { id, forecastId } = useParams<{ id: string; forecastId: string }>()
-  const dispatch = useDispatch<AppDispatch>()
-  const { spotRequests, spotRequestsLoading, spotForecastsByRequestId, spotForecastsLoading } =
-    useSelector(selectSmurfi)
-  const { stationsByCode, loading: stationsLoading } = useSelector(selectFireWeatherStations)
+  const { loading, spotRequest, spotForecast, representativeStations } = useSpotForecastData()
 
-  const spotRequestId = Number(id)
-  const spotForecastId = Number(forecastId)
-
-  useEffect(() => {
-    if (!spotForecastsByRequestId[spotRequestId]) {
-      dispatch(fetchSpotForecasts(spotRequestId))
-    }
-  }, [dispatch, spotRequestId, spotForecastsByRequestId])
-
-  useEffect(() => {
-    if (Object.keys(stationsByCode).length === 0) {
-      dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
-    }
-  }, [dispatch, stationsByCode])
-
-  if (spotRequestsLoading || spotForecastsLoading || stationsLoading) {
+  if (loading) {
     return <CircularProgress />
   }
-
-  const spotRequest = spotRequests.find(sr => sr.id === spotRequestId)
-  const spotForecast = (spotForecastsByRequestId[spotRequestId] ?? []).find(f => f.id === spotForecastId)
 
   if (!spotRequest || !spotForecast) {
     return <Typography>Forecast not found</Typography>
   }
-
-  const representativeStations = (spotForecast.representative_station_codes ?? []).flatMap(code => {
-    const station = stationsByCode[code]
-    return station ? [{ code, name: station.properties.name, elevation: station.properties.elevation }] : []
-  })
 
   const props = { forecast: spotForecast, spotRequest, representativeStations }
 

--- a/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
+++ b/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
@@ -44,7 +44,7 @@ const SMURFIPage = () => {
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-        <Box sx={{ display: location.pathname.endsWith('/printable') ? 'none' : 'block' }}>
+        <Box sx={{ display: location.pathname.endsWith('/print') ? 'none' : 'block' }}>
           <GeneralHeader isBeta={true} spacing={1} title="SMURFI" />
           <Tabs value={currentTab} onChange={handleChange}>
             <Tab label="Dashboard" onClick={() => navigate(SMURFI_DASHBOARD_ROUTE)} />
@@ -64,7 +64,7 @@ const SMURFIPage = () => {
                     <Route path=":id/forecasts" element={<SpotForecasts />} />
                     <Route path=":id/forecasts/new" element={<SpotForecastFormPage />} />
                     <Route path=":id/forecasts/:forecastId" element={<SpotForecast />} />
-                    <Route path=":id/forecasts/:forecastId/printable" element={<PrintableSpotForecast />} />
+                    <Route path=":id/forecasts/:forecastId/print" element={<PrintableSpotForecast />} />
                   </Routes>
                 </RouteContent>
               }

--- a/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
+++ b/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
@@ -1,23 +1,25 @@
-import React, { useEffect } from 'react'
-import { Box, Tabs, Tab } from '@mui/material'
-import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
-import { GeneralHeader } from '@wps/ui/GeneralHeader'
-import { ErrorBoundary } from '@wps/ui/ErrorBoundary'
+import { AppDispatch } from '@/app/store'
+import { fetchFireCentres } from '@/commonSlices/fireCentresSlice'
+import SpotForecastFormPage from '@/features/smurfi/components/forecastForm/SpotForecastFormPage'
+import SpotForecast from '@/features/smurfi/components/forecasts/SpotForecast'
+import SpotForecasts from '@/features/smurfi/components/forecasts/SpotForecasts'
+import SMURFIMap from '@/features/smurfi/components/map/SMURFIMap'
+import SpotRequestFormPage from '@/features/smurfi/components/requestForm/SpotRequestFormPage'
+import SpotRequest from '@/features/smurfi/components/requests/SpotRequest'
+import SpotRequests from '@/features/smurfi/components/requests/SpotRequests'
+import PrintableSpotForecast from '@/features/smurfi/pages/PrintableSpotForecast'
+import { fetchSpotRequests } from '@/features/smurfi/slices/smurfiSlice'
+import { fetchWxStations } from '@/features/stations/slices/stationsSlice'
+import { Box, Tab, Tabs } from '@mui/material'
 import { AdapterLuxon } from '@mui/x-date-pickers-pro/AdapterLuxon'
 import { LocalizationProvider } from '@mui/x-date-pickers-pro/LocalizationProvider'
-import { SMURFI_DASHBOARD_ROUTE, SMURFI_MAP_ROUTE, SMURFI_MANAGEMENT_ROUTE } from '@wps/utils/constants'
-import SMURFIMap from '@/features/smurfi/components/map/SMURFIMap'
-import SpotRequests from '@/features/smurfi/components/requests/SpotRequests'
-import SpotRequest from '@/features/smurfi/components/requests/SpotRequest'
-import SpotForecasts from '@/features/smurfi/components/forecasts/SpotForecasts'
-import SpotForecast from '@/features/smurfi/components/forecasts/SpotForecast'
-import SpotRequestFormPage from '@/features/smurfi/components/requestForm/SpotRequestFormPage'
-import SpotForecastFormPage from '@/features/smurfi/components/forecastForm/SpotForecastFormPage'
-import PrintableSpotForecast from '@/features/smurfi/pages/PrintableSpotForecast'
-import { AppDispatch } from '@/app/store'
+import { getStations, StationSource } from '@wps/api/stationAPI'
+import { ErrorBoundary } from '@wps/ui/ErrorBoundary'
+import { GeneralHeader } from '@wps/ui/GeneralHeader'
+import { SMURFI_DASHBOARD_ROUTE, SMURFI_MANAGEMENT_ROUTE, SMURFI_MAP_ROUTE } from '@wps/utils/constants'
+import React, { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
-import { fetchSpotRequests } from '@/features/smurfi/slices/smurfiSlice'
-import { fetchFireCentres } from '@/commonSlices/fireCentresSlice'
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 
 const TAB_ROUTES = [SMURFI_DASHBOARD_ROUTE, SMURFI_MAP_ROUTE, SMURFI_MANAGEMENT_ROUTE]
 
@@ -30,6 +32,7 @@ const SMURFIPage = () => {
   useEffect(() => {
     dispatch(fetchSpotRequests())
     dispatch(fetchFireCentres())
+    dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
   }, [])
   const location = useLocation()
   const navigate = useNavigate()

--- a/web/apps/wps-web/src/features/smurfi/utils/spotForecastUtils.ts
+++ b/web/apps/wps-web/src/features/smurfi/utils/spotForecastUtils.ts
@@ -1,0 +1,14 @@
+import { DateTime } from 'luxon'
+import { RepresentativeStation } from '@/features/smurfi/interfaces'
+
+export const TIMEZONE = 'America/Vancouver'
+
+export const formatDateTime = (iso: string): string => {
+  const dt = DateTime.fromISO(iso).setZone(TIMEZONE)
+  return dt.isValid ? `${dt.toFormat('HHmm')} ${dt.offsetNameShort} ${dt.toFormat('EEE, MMM d, yyyy')}` : iso
+}
+
+export const formatStationsStr = (stations: RepresentativeStation[]): string =>
+  stations.length > 0
+    ? stations.map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation}m)`)).join(', ')
+    : '—'


### PR DESCRIPTION
- adds pretty and printable components for mini spot forecasts
- creates a hook that provides data to the forecast display components to dedupe code
- renames printable to print