### PR TITLE
SMURFI: Data Model rework

### DIFF
--- a/backend/packages/wps-api/alembic/versions/6f1d8d4c2a90_split_smurfi_request_instances.py
+++ b/backend/packages/wps-api/alembic/versions/6f1d8d4c2a90_split_smurfi_request_instances.py
@@ -1,0 +1,265 @@
+"""split smurfi request instances
+
+Revision ID: 6f1d8d4c2a90
+Revises: 3b9310ff54f5
+Create Date: 2026-05-26 10:24:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from geoalchemy2 import Geometry
+from wps_shared.db.models.common import TZTimeStamp
+
+# revision identifiers, used by Alembic.
+revision = "6f1d8d4c2a90"
+down_revision = "3b9310ff54f5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table("spot_request", "spot_request_base")
+
+    op.create_table(
+        "spot_request_instance",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("spot_request_base_id", sa.Integer(), nullable=False),
+        sa.Column("latitude", sa.Float(), nullable=False),
+        sa.Column("longitude", sa.Float(), nullable=False),
+        sa.Column(
+            "geom",
+            Geometry(
+                geometry_type="POINT",
+                srid=3005,
+                dimension=2,
+                spatial_index=False,
+                from_text="ST_GeomFromEWKT",
+                name="geometry",
+            ),
+            nullable=False,
+        ),
+        sa.Column("geographic_description", sa.String(), nullable=False),
+        sa.Column("aspect", sa.String(), nullable=True),
+        sa.Column("elevation", sa.Integer(), nullable=True),
+        sa.Column("valley", sa.String(), nullable=True),
+        sa.Column("created_at", TZTimeStamp(), nullable=False),
+        sa.Column("updated_at", TZTimeStamp(), nullable=False),
+        sa.ForeignKeyConstraint(["spot_request_base_id"], ["spot_request_base.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        comment="Tracks geographic instances used by spot requests and forecasts.",
+    )
+    op.create_index(
+        op.f("ix_spot_request_instance_spot_request_base_id"),
+        "spot_request_instance",
+        ["spot_request_base_id"],
+        unique=False,
+    )
+
+    op.execute(
+        """
+        INSERT INTO spot_request_instance (
+            spot_request_base_id,
+            latitude,
+            longitude,
+            geom,
+            geographic_description,
+            aspect,
+            elevation,
+            valley,
+            created_at,
+            updated_at
+        )
+        SELECT
+            id,
+            ST_Y(ST_Transform(geom, 4326)),
+            ST_X(ST_Transform(geom, 4326)),
+            geom,
+            geographic_description,
+            aspect,
+            elevation,
+            NULL,
+            created_at,
+            updated_at
+        FROM spot_request_base
+        """
+    )
+
+    op.drop_constraint("spot_forecast_spot_request_id_fkey", "spot_forecast", type_="foreignkey")
+    op.drop_index(op.f("ix_spot_forecast_spot_request_id"), table_name="spot_forecast")
+    op.execute(
+        """
+        ALTER TABLE spot_forecast
+        ALTER COLUMN fire_size TYPE FLOAT[]
+        USING CASE
+            WHEN fire_size IS NULL THEN NULL
+            ELSE ARRAY[fire_size]
+        END
+        """
+    )
+    op.add_column("spot_forecast", sa.Column("spot_request_base_id", sa.Integer(), nullable=True))
+    op.add_column(
+        "spot_forecast", sa.Column("spot_request_instance_id", sa.Integer(), nullable=True)
+    )
+    op.execute(
+        """
+        UPDATE spot_forecast forecast
+        SET
+            spot_request_base_id = forecast.spot_request_id,
+            spot_request_instance_id = instance.id
+        FROM spot_request_instance instance
+        WHERE instance.spot_request_base_id = forecast.spot_request_id
+        """
+    )
+    op.alter_column("spot_forecast", "spot_request_base_id", nullable=False)
+    op.alter_column("spot_forecast", "spot_request_instance_id", nullable=False)
+    op.create_foreign_key(
+        "spot_forecast_spot_request_base_id_fkey",
+        "spot_forecast",
+        "spot_request_base",
+        ["spot_request_base_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "spot_forecast_spot_request_instance_id_fkey",
+        "spot_forecast",
+        "spot_request_instance",
+        ["spot_request_instance_id"],
+        ["id"],
+    )
+    op.create_index(
+        op.f("ix_spot_forecast_spot_request_base_id"),
+        "spot_forecast",
+        ["spot_request_base_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_spot_forecast_spot_request_instance_id"),
+        "spot_forecast",
+        ["spot_request_instance_id"],
+        unique=False,
+    )
+    op.drop_column("spot_forecast", "spot_request_id")
+
+    op.drop_constraint(
+        "spot_subscriber_spot_request_id_fkey", "spot_subscriber", type_="foreignkey"
+    )
+    op.drop_index(op.f("ix_spot_subscriber_spot_request_id"), table_name="spot_subscriber")
+    op.alter_column("spot_subscriber", "spot_request_id", new_column_name="spot_request_base_id")
+    op.create_foreign_key(
+        "spot_subscriber_spot_request_base_id_fkey",
+        "spot_subscriber",
+        "spot_request_base",
+        ["spot_request_base_id"],
+        ["id"],
+    )
+    op.create_index(
+        op.f("ix_spot_subscriber_spot_request_base_id"),
+        "spot_subscriber",
+        ["spot_request_base_id"],
+        unique=False,
+    )
+
+    op.drop_constraint("chk_aspect_spot_request", "spot_request_base", type_="check")
+    op.drop_column("spot_request_base", "geom")
+    op.drop_column("spot_request_base", "geographic_description")
+    op.drop_column("spot_request_base", "elevation")
+    op.drop_column("spot_request_base", "aspect")
+
+
+def downgrade():
+    op.add_column("spot_request_base", sa.Column("aspect", sa.String(), nullable=True))
+    op.add_column("spot_request_base", sa.Column("elevation", sa.Integer(), nullable=True))
+    op.add_column(
+        "spot_request_base",
+        sa.Column("geographic_description", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "spot_request_base",
+        sa.Column(
+            "geom",
+            Geometry(
+                geometry_type="POINT",
+                srid=3005,
+                dimension=2,
+                spatial_index=False,
+                from_text="ST_GeomFromEWKT",
+                name="geometry",
+            ),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        """
+        UPDATE spot_request_base base
+        SET
+            aspect = instance.aspect,
+            elevation = instance.elevation,
+            geographic_description = instance.geographic_description,
+            geom = instance.geom
+        FROM spot_request_instance instance
+        WHERE instance.spot_request_base_id = base.id
+        """
+    )
+    op.alter_column("spot_request_base", "geographic_description", nullable=False)
+    op.alter_column("spot_request_base", "geom", nullable=False)
+
+    op.drop_index(op.f("ix_spot_subscriber_spot_request_base_id"), table_name="spot_subscriber")
+    op.drop_constraint(
+        "spot_subscriber_spot_request_base_id_fkey", "spot_subscriber", type_="foreignkey"
+    )
+    op.alter_column("spot_subscriber", "spot_request_base_id", new_column_name="spot_request_id")
+    op.create_foreign_key(
+        "spot_subscriber_spot_request_id_fkey",
+        "spot_subscriber",
+        "spot_request_base",
+        ["spot_request_id"],
+        ["id"],
+    )
+    op.create_index(
+        op.f("ix_spot_subscriber_spot_request_id"),
+        "spot_subscriber",
+        ["spot_request_id"],
+        unique=False,
+    )
+
+    op.add_column("spot_forecast", sa.Column("spot_request_id", sa.Integer(), nullable=True))
+    op.execute("UPDATE spot_forecast SET spot_request_id = spot_request_base_id")
+    op.alter_column("spot_forecast", "spot_request_id", nullable=False)
+    op.execute(
+        """
+        ALTER TABLE spot_forecast
+        ALTER COLUMN fire_size TYPE FLOAT
+        USING fire_size[1]
+        """
+    )
+    op.drop_index(op.f("ix_spot_forecast_spot_request_instance_id"), table_name="spot_forecast")
+    op.drop_index(op.f("ix_spot_forecast_spot_request_base_id"), table_name="spot_forecast")
+    op.drop_constraint(
+        "spot_forecast_spot_request_instance_id_fkey", "spot_forecast", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "spot_forecast_spot_request_base_id_fkey", "spot_forecast", type_="foreignkey"
+    )
+    op.drop_column("spot_forecast", "spot_request_instance_id")
+    op.drop_column("spot_forecast", "spot_request_base_id")
+    op.create_foreign_key(
+        "spot_forecast_spot_request_id_fkey",
+        "spot_forecast",
+        "spot_request_base",
+        ["spot_request_id"],
+        ["id"],
+    )
+    op.create_index(
+        op.f("ix_spot_forecast_spot_request_id"),
+        "spot_forecast",
+        ["spot_request_id"],
+        unique=False,
+    )
+
+    op.drop_index(
+        op.f("ix_spot_request_instance_spot_request_base_id"),
+        table_name="spot_request_instance",
+    )
+    op.drop_table("spot_request_instance")
+    op.rename_table("spot_request_base", "spot_request")

--- a/backend/packages/wps-api/src/app/routers/smurfi.py
+++ b/backend/packages/wps-api/src/app/routers/smurfi.py
@@ -147,11 +147,11 @@ def _get_latest_forecast(spot_request: SpotRequestBase) -> SpotForecast | None:
     )
 
 
-def _get_current_instance(spot_request: SpotRequestBase) -> SpotRequestInstance:
-    latest_forecast = _get_latest_forecast(spot_request)
+def _get_current_instance(spot_request_base: SpotRequestBase) -> SpotRequestInstance:
+    latest_forecast = _get_latest_forecast(spot_request_base)
     if latest_forecast is not None:
         return latest_forecast.spot_request_instance
-    return _get_initial_instance(spot_request)
+    return _get_initial_instance(spot_request_base)
 
 
 def _latest_forecast_to_schema(spot_request_base: SpotRequestBase) -> SpotLatestForecastData | None:
@@ -193,7 +193,7 @@ async def upsert_spot_request_endpoint(
                 detail=f"SpotRequestBase {spot_request_base.id} not found",
             )
 
-        initial_instance = await create_spot_request_instance(
+        instance = await create_spot_request_instance(
             session, _build_spot_request_instance(result.id, spot_request_input.initial_instance)
         )
 
@@ -206,14 +206,14 @@ async def upsert_spot_request_endpoint(
             SpotSubscriberData(id=s.id, email=s.email, subscriber_status=s.subscriber_status)
             for s in subscribers
         ]
-        initial_instance_data = _spot_request_instance_to_schema(initial_instance)
+        spot_request_instance = _spot_request_instance_to_schema(instance)
 
     return SpotRequestResponse(
         spot_request=SpotRequestData(
             **spot_request_input.model_dump(exclude={"id", "initial_instance", "subscribers"}),
             id=spot_request_base_id,
-            initial_instance=initial_instance_data,
-            current_instance=initial_instance_data,
+            initial_instance=spot_request_instance,
+            current_instance=spot_request_instance,
             subscribers=subscriber_data,
             requestor_name=requestor.name,
             requestor_idir=requestor.idir,

--- a/backend/packages/wps-api/src/app/routers/smurfi.py
+++ b/backend/packages/wps-api/src/app/routers/smurfi.py
@@ -4,12 +4,13 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
-from geoalchemy2.shape import to_shape
 from wps_shared.auth import authentication_required
 from wps_shared.db.crud.smurfi import (
     create_spot_descriptive_weather,
     create_spot_forecast,
+    create_spot_request_instance,
     create_spot_tabular_weather,
+    get_or_create_spot_request_instance,
     get_spot_forecasts_for_request,
     get_spot_requests_for_year,
     get_subscribed_spot_request_ids,
@@ -24,7 +25,8 @@ from wps_shared.db.database import get_async_read_session_scope, get_async_write
 from wps_shared.db.models.smurfi import (
     SpotDescriptiveWeather,
     SpotForecast,
-    SpotRequest,
+    SpotRequestBase,
+    SpotRequestInstance,
     SpotSubscriberStatusEnum,
     SpotTabularWeather,
 )
@@ -42,6 +44,8 @@ from wps_shared.schemas.smurfi import (
     SpotLatestForecastData,
     SpotRequestData,
     SpotRequestInput,
+    SpotRequestInstanceData,
+    SpotRequestInstanceInput,
     SpotRequestListResponse,
     SpotRequestResponse,
     SpotSubscriberData,
@@ -91,44 +95,63 @@ def _get_bc_albers_point(latitude: float, longitude: float) -> str:
     return f"POINT({x} {y})"
 
 
-def _build_spot_request(data: SpotRequestInput, requestor: SpotRequestor) -> SpotRequest:
+def _build_spot_request_base(data: SpotRequestInput, requestor: SpotRequestor) -> SpotRequestBase:
     now = get_utc_now()
-    return SpotRequest(
-        **data.model_dump(exclude={"latitude", "longitude", "subscribers"}),
+    return SpotRequestBase(
+        **data.model_dump(exclude={"initial_instance", "subscribers"}),
         requestor_name=requestor.name,
         requestor_idir=requestor.idir,
         requestor_email=requestor.email,
-        geom=_get_bc_albers_point(data.latitude, data.longitude),
         created_at=now,
         updated_at=now,
     )
 
 
-def _build_spot_request_response(
-    data: SpotRequestInput,
-    requestor: SpotRequestor,
-    spot_request_id: int,
-    subscribers: list[SpotSubscriberData],
-) -> SpotRequestResponse:
-    spot_request_response = SpotRequestData(
+def _build_spot_request_instance(
+    spot_request_base_id: int, data: SpotRequestInstanceInput
+) -> SpotRequestInstance:
+    return SpotRequestInstance(
         **data.model_dump(),
-        requestor_name=requestor.name,
-        requestor_idir=requestor.idir,
-        requestor_email=requestor.email,
-    )
-    return SpotRequestResponse(
-        spot_request=spot_request_response.model_copy(
-            update={"id": spot_request_id, "subscribers": subscribers}
-        )
+        spot_request_base_id=spot_request_base_id,
+        geom=_get_bc_albers_point(data.latitude, data.longitude),
     )
 
 
-def _latest_forecast_to_schema(spot_request: SpotRequest) -> SpotLatestForecastData | None:
-    latest_forecast = max(
+def _spot_request_instance_to_schema(
+    spot_request_instance: SpotRequestInstance,
+) -> SpotRequestInstanceData:
+    return SpotRequestInstanceData(
+        id=spot_request_instance.id,
+        geographic_description=spot_request_instance.geographic_description,
+        aspect=spot_request_instance.aspect,
+        elevation=spot_request_instance.elevation,
+        valley=spot_request_instance.valley,
+        latitude=spot_request_instance.latitude,
+        longitude=spot_request_instance.longitude,
+    )
+
+
+def _get_initial_instance(spot_request: SpotRequestBase) -> SpotRequestInstance:
+    return min(spot_request.spot_request_instances, key=lambda instance: instance.created_at)
+
+
+def _get_latest_forecast(spot_request: SpotRequestBase) -> SpotForecast | None:
+    return max(
         spot_request.spot_forecasts,
         key=lambda forecast: forecast.created_at,
         default=None,
     )
+
+
+def _get_current_instance(spot_request: SpotRequestBase) -> SpotRequestInstance:
+    latest_forecast = _get_latest_forecast(spot_request)
+    if latest_forecast is not None:
+        return latest_forecast.spot_request_instance
+    return _get_initial_instance(spot_request)
+
+
+def _latest_forecast_to_schema(spot_request: SpotRequestBase) -> SpotLatestForecastData | None:
+    latest_forecast = _get_latest_forecast(spot_request)
     if latest_forecast is None:
         return None
 
@@ -151,32 +174,48 @@ async def upsert_spot_request_endpoint(
     data: SpotRequestInput, token: Annotated[dict, Depends(authentication_required)]
 ):
     requestor = _get_spot_user(token)
-    spot_request = _build_spot_request(data, requestor)
+    spot_request_base = _build_spot_request_base(data, requestor)
 
     async with get_async_write_session_scope() as session:
-        if spot_request.id is None:
-            logger.info("Creating a new SpotRequest.")
+        if spot_request_base.id is None:
+            logger.info("Creating a new SpotRequestBase.")
         else:
-            logger.info("Updating an existing SpotRequest with id: %s.", spot_request.id)
+            logger.info("Updating an existing SpotRequestBase with id: %s.", spot_request_base.id)
 
-        result = await upsert_spot_request(session, spot_request)
+        result = await upsert_spot_request(session, spot_request_base)
         if result is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"SpotRequest {spot_request.id} not found",
+                detail=f"SpotRequestBase {spot_request_base.id} not found",
             )
 
-        logger.info("Syncing subscribers for SpotRequest id: %s", result.id)
+        initial_instance = await create_spot_request_instance(
+            session, _build_spot_request_instance(result.id, data.initial_instance)
+        )
+
+        logger.info("Syncing subscribers for SpotRequestBase id: %s", result.id)
         subscribers = await sync_spot_subscribers(
             session, result.id, [s.email for s in data.subscribers]
         )
-        spot_request_id = result.id
+        spot_request_base_id = result.id
         subscriber_data = [
             SpotSubscriberData(id=s.id, email=s.email, subscriber_status=s.subscriber_status)
             for s in subscribers
         ]
+        initial_instance_data = _spot_request_instance_to_schema(initial_instance)
 
-    return _build_spot_request_response(data, requestor, spot_request_id, subscriber_data)
+    return SpotRequestResponse(
+        spot_request=SpotRequestData(
+            **data.model_dump(exclude={"id", "initial_instance", "subscribers"}),
+            id=spot_request_base_id,
+            initial_instance=initial_instance_data,
+            current_instance=initial_instance_data,
+            subscribers=subscriber_data,
+            requestor_name=requestor.name,
+            requestor_idir=requestor.idir,
+            requestor_email=requestor.email,
+        )
+    )
 
 
 async def _create_descriptive_weather(
@@ -248,40 +287,51 @@ async def create_spot_forecast_endpoint(
     forecaster = _get_spot_user(token)
     if not forecaster.email:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=MISSING_TOKEN_MESSAGE)
-    spot_forecast = SpotForecast(
-        spot_request_id=data.spot_request_id,
-        forecaster_name=forecaster.name,
-        forecaster_email=forecaster.email,
-        forecaster_phone=None,
-        synopsis=data.synopsis,
-        inversion_and_venting=data.inversion_and_venting,
-        outlook=data.outlook,
-        confidence=data.confidence,
-        fire_size=data.fire_size,
-        representative_station_codes=data.representative_station_codes,
-        issued_at=data.issued_at,
-        expires_at=data.expires_at,
-        created_at=now,
-    )
     async with get_async_write_session_scope() as session:
+        spot_request_instance = await get_or_create_spot_request_instance(
+            session,
+            _build_spot_request_instance(data.spot_request_base_id, data.spot_request_instance),
+        )
+        spot_forecast = SpotForecast(
+            spot_request_base_id=data.spot_request_base_id,
+            spot_request_instance_id=spot_request_instance.id,
+            forecaster_name=forecaster.name,
+            forecaster_email=forecaster.email,
+            forecaster_phone=None,
+            synopsis=data.synopsis,
+            inversion_and_venting=data.inversion_and_venting,
+            outlook=data.outlook,
+            confidence=data.confidence,
+            fire_size=data.fire_size,
+            representative_station_codes=data.representative_station_codes,
+            issued_at=data.issued_at,
+            expires_at=data.expires_at,
+            created_at=now,
+        )
         logger.info("Creating a new SpotForecast.")
         result = await create_spot_forecast(session, spot_forecast)
 
         spot_forecast_id = result.id
         descriptive_weather = await _create_descriptive_weather(session, spot_forecast_id, data)
         tabular_weather = await _create_tabular_weather(session, spot_forecast_id, data)
-        await start_requested_spot_request(session, data.spot_request_id)
+        await start_requested_spot_request(session, data.spot_request_base_id)
+        spot_request_instance_id = spot_request_instance.id
+        spot_request_instance_data = _spot_request_instance_to_schema(spot_request_instance)
 
     payload = SpotUpdatePayload(
-        spot_request_id=data.spot_request_id, spot_forecast_id=spot_forecast_id
+        spot_request_id=data.spot_request_base_id, spot_forecast_id=spot_forecast_id
     )
     await publish(
         stream=stream_name, subject=smurfi_spot_update_subject, payload=payload, subjects=subjects
     )
     return SpotForecastResponse(
         spot_forecast=SpotForecastData(
-            **data.model_dump(exclude={"descriptive_weather", "tabular_weather"}),
+            **data.model_dump(
+                exclude={"descriptive_weather", "tabular_weather", "spot_request_instance"}
+            ),
             id=spot_forecast_id,
+            spot_request_instance_id=spot_request_instance_id,
+            spot_request_instance=spot_request_instance_data,
             created_at=now,
             forecaster_name=forecaster.name,
             forecaster_email=forecaster.email,
@@ -301,7 +351,9 @@ def _spot_forecast_to_schema(spot_forecast: SpotForecast) -> SpotForecastData:
 
     return SpotForecastData(
         id=spot_forecast.id,
-        spot_request_id=spot_forecast.spot_request_id,
+        spot_request_base_id=spot_forecast.spot_request_base_id,
+        spot_request_instance_id=spot_forecast.spot_request_instance_id,
+        spot_request_instance=_spot_request_instance_to_schema(spot_forecast.spot_request_instance),
         forecaster_name=spot_forecast.forecaster_name,
         forecaster_email=spot_forecast.forecaster_email,
         forecaster_phone=spot_forecast.forecaster_phone,
@@ -351,11 +403,9 @@ async def get_spot_forecasts(spot_request_id: int):
         )
 
 
-def _spot_request_to_schema(spot_request: SpotRequest) -> SpotRequestData:
-    shape = to_shape(spot_request.geom)
-    lat, lon = PointTransformer(
-        NAD83_BC_ALBERS, SpatialReferenceSystem.WGS84.code
-    ).transform_coordinate(shape.x, shape.y)
+def _spot_request_to_schema(spot_request: SpotRequestBase) -> SpotRequestData:
+    initial_instance = _get_initial_instance(spot_request)
+    current_instance = _get_current_instance(spot_request)
     return SpotRequestData(
         id=spot_request.id,
         request_reference=spot_request.request_reference,
@@ -367,12 +417,9 @@ def _spot_request_to_schema(spot_request: SpotRequest) -> SpotRequestData:
         requestor_email=spot_request.requestor_email,
         request_frequency=spot_request.request_frequency,
         request_type=spot_request.request_type,
-        aspect=spot_request.aspect,
-        elevation=spot_request.elevation,
-        geographic_description=spot_request.geographic_description,
         additional_information=spot_request.additional_information,
-        latitude=lat,
-        longitude=lon,
+        initial_instance=_spot_request_instance_to_schema(initial_instance),
+        current_instance=_spot_request_instance_to_schema(current_instance),
         requested_at=spot_request.requested_at,
         start_at=spot_request.start_at,
         end_at=spot_request.end_at,

--- a/backend/packages/wps-api/src/app/routers/smurfi.py
+++ b/backend/packages/wps-api/src/app/routers/smurfi.py
@@ -95,10 +95,12 @@ def _get_bc_albers_point(latitude: float, longitude: float) -> str:
     return f"POINT({x} {y})"
 
 
-def _build_spot_request_base(data: SpotRequestInput, requestor: SpotRequestor) -> SpotRequestBase:
+def _build_spot_request_base(
+    spot_request_input: SpotRequestInput, requestor: SpotRequestor
+) -> SpotRequestBase:
     now = get_utc_now()
     return SpotRequestBase(
-        **data.model_dump(exclude={"initial_instance", "subscribers"}),
+        **spot_request_input.model_dump(exclude={"initial_instance", "subscribers"}),
         requestor_name=requestor.name,
         requestor_idir=requestor.idir,
         requestor_email=requestor.email,
@@ -108,12 +110,14 @@ def _build_spot_request_base(data: SpotRequestInput, requestor: SpotRequestor) -
 
 
 def _build_spot_request_instance(
-    spot_request_base_id: int, data: SpotRequestInstanceInput
+    spot_request_base_id: int, spot_request_instance_input: SpotRequestInstanceInput
 ) -> SpotRequestInstance:
     return SpotRequestInstance(
-        **data.model_dump(),
+        **spot_request_instance_input.model_dump(),
         spot_request_base_id=spot_request_base_id,
-        geom=_get_bc_albers_point(data.latitude, data.longitude),
+        geom=_get_bc_albers_point(
+            spot_request_instance_input.latitude, spot_request_instance_input.longitude
+        ),
     )
 
 
@@ -150,8 +154,8 @@ def _get_current_instance(spot_request: SpotRequestBase) -> SpotRequestInstance:
     return _get_initial_instance(spot_request)
 
 
-def _latest_forecast_to_schema(spot_request: SpotRequestBase) -> SpotLatestForecastData | None:
-    latest_forecast = _get_latest_forecast(spot_request)
+def _latest_forecast_to_schema(spot_request_base: SpotRequestBase) -> SpotLatestForecastData | None:
+    latest_forecast = _get_latest_forecast(spot_request_base)
     if latest_forecast is None:
         return None
 
@@ -171,10 +175,10 @@ def _latest_forecast_to_schema(spot_request: SpotRequestBase) -> SpotLatestForec
 
 @router.post("/spot_request", response_model=SpotRequestResponse)
 async def upsert_spot_request_endpoint(
-    data: SpotRequestInput, token: Annotated[dict, Depends(authentication_required)]
+    spot_request_input: SpotRequestInput, token: Annotated[dict, Depends(authentication_required)]
 ):
     requestor = _get_spot_user(token)
-    spot_request_base = _build_spot_request_base(data, requestor)
+    spot_request_base = _build_spot_request_base(spot_request_input, requestor)
 
     async with get_async_write_session_scope() as session:
         if spot_request_base.id is None:
@@ -190,12 +194,12 @@ async def upsert_spot_request_endpoint(
             )
 
         initial_instance = await create_spot_request_instance(
-            session, _build_spot_request_instance(result.id, data.initial_instance)
+            session, _build_spot_request_instance(result.id, spot_request_input.initial_instance)
         )
 
         logger.info("Syncing subscribers for SpotRequestBase id: %s", result.id)
         subscribers = await sync_spot_subscribers(
-            session, result.id, [s.email for s in data.subscribers]
+            session, result.id, [s.email for s in spot_request_input.subscribers]
         )
         spot_request_base_id = result.id
         subscriber_data = [
@@ -206,7 +210,7 @@ async def upsert_spot_request_endpoint(
 
     return SpotRequestResponse(
         spot_request=SpotRequestData(
-            **data.model_dump(exclude={"id", "initial_instance", "subscribers"}),
+            **spot_request_input.model_dump(exclude={"id", "initial_instance", "subscribers"}),
             id=spot_request_base_id,
             initial_instance=initial_instance_data,
             current_instance=initial_instance_data,
@@ -281,7 +285,7 @@ async def _create_tabular_weather(
 
 @router.post("/spot_forecast", response_model=SpotForecastResponse)
 async def create_spot_forecast_endpoint(
-    data: SpotForecastInput, token: Annotated[dict, Depends(authentication_required)]
+    spot_forecast_input: SpotForecastInput, token: Annotated[dict, Depends(authentication_required)]
 ):
     now = get_utc_now()
     forecaster = _get_spot_user(token)
@@ -290,43 +294,49 @@ async def create_spot_forecast_endpoint(
     async with get_async_write_session_scope() as session:
         spot_request_instance = await get_or_create_spot_request_instance(
             session,
-            _build_spot_request_instance(data.spot_request_base_id, data.spot_request_instance),
+            _build_spot_request_instance(
+                spot_forecast_input.spot_request_base_id, spot_forecast_input.spot_request_instance
+            ),
         )
         spot_forecast = SpotForecast(
-            spot_request_base_id=data.spot_request_base_id,
+            spot_request_base_id=spot_forecast_input.spot_request_base_id,
             spot_request_instance_id=spot_request_instance.id,
             forecaster_name=forecaster.name,
             forecaster_email=forecaster.email,
             forecaster_phone=None,
-            synopsis=data.synopsis,
-            inversion_and_venting=data.inversion_and_venting,
-            outlook=data.outlook,
-            confidence=data.confidence,
-            fire_size=data.fire_size,
-            representative_station_codes=data.representative_station_codes,
-            issued_at=data.issued_at,
-            expires_at=data.expires_at,
+            synopsis=spot_forecast_input.synopsis,
+            inversion_and_venting=spot_forecast_input.inversion_and_venting,
+            outlook=spot_forecast_input.outlook,
+            confidence=spot_forecast_input.confidence,
+            fire_size=spot_forecast_input.fire_size,
+            representative_station_codes=spot_forecast_input.representative_station_codes,
+            issued_at=spot_forecast_input.issued_at,
+            expires_at=spot_forecast_input.expires_at,
             created_at=now,
         )
         logger.info("Creating a new SpotForecast.")
         result = await create_spot_forecast(session, spot_forecast)
 
         spot_forecast_id = result.id
-        descriptive_weather = await _create_descriptive_weather(session, spot_forecast_id, data)
-        tabular_weather = await _create_tabular_weather(session, spot_forecast_id, data)
-        await start_requested_spot_request(session, data.spot_request_base_id)
+        descriptive_weather = await _create_descriptive_weather(
+            session, spot_forecast_id, spot_forecast_input
+        )
+        tabular_weather = await _create_tabular_weather(
+            session, spot_forecast_id, spot_forecast_input
+        )
+        await start_requested_spot_request(session, spot_forecast_input.spot_request_base_id)
         spot_request_instance_id = spot_request_instance.id
         spot_request_instance_data = _spot_request_instance_to_schema(spot_request_instance)
 
     payload = SpotUpdatePayload(
-        spot_request_id=data.spot_request_base_id, spot_forecast_id=spot_forecast_id
+        spot_request_id=spot_forecast_input.spot_request_base_id, spot_forecast_id=spot_forecast_id
     )
     await publish(
         stream=stream_name, subject=smurfi_spot_update_subject, payload=payload, subjects=subjects
     )
     return SpotForecastResponse(
         spot_forecast=SpotForecastData(
-            **data.model_dump(
+            **spot_forecast_input.model_dump(
                 exclude={"descriptive_weather", "tabular_weather", "spot_request_instance"}
             ),
             id=spot_forecast_id,

--- a/backend/packages/wps-api/src/app/smurfi/email.py
+++ b/backend/packages/wps-api/src/app/smurfi/email.py
@@ -1,9 +1,11 @@
 import html
 import logging
-from datetime import date
+from collections.abc import Sequence
+from datetime import date, datetime
 
 import httpx
 from wps_shared import config
+from wps_shared.db.models.smurfi import SpotForecast, SpotRequestInstance
 from wps_shared.utils.time import vancouver_tz
 
 logger = logging.getLogger(__name__)
@@ -30,7 +32,12 @@ def _to_ddm(decimal: float) -> str:
     return f"{sign}{degrees} {minutes:.3f}"
 
 
-def _get_coords(spot_request) -> str:
+def _get_coords(spot_location: SpotRequestInstance) -> str:
+    latitude = getattr(spot_location, "latitude", None)
+    longitude = getattr(spot_location, "longitude", None)
+    if latitude is not None and longitude is not None:
+        return f"{_to_ddm(latitude)},{_to_ddm(longitude)}"
+
     try:
         from geoalchemy2.shape import to_shape
         from wps_shared.geospatial.geospatial import (
@@ -39,7 +46,7 @@ def _get_coords(spot_request) -> str:
             SpatialReferenceSystem,
         )
 
-        shape = to_shape(spot_request.geom)
+        shape = to_shape(spot_location.geom)
         lat, lon = PointTransformer(
             NAD83_BC_ALBERS, SpatialReferenceSystem.WGS84.code
         ).transform_coordinate(shape.x, shape.y)
@@ -48,7 +55,7 @@ def _get_coords(spot_request) -> str:
         return "—"
 
 
-def _format_date_label(forecast_time, issued_at) -> str:
+def _format_date_label(forecast_time: datetime, issued_at: datetime) -> str:
     ft = forecast_time.astimezone(vancouver_tz)
     issued_day: date = issued_at.astimezone(vancouver_tz).date()
     day_diff = (ft.date() - issued_day).days
@@ -69,7 +76,18 @@ def _ensure_period(text: str | None) -> str:
     return text if text.endswith(".") else f"{text}."
 
 
-def build_spot_forecast_email(spot_forecast, spot_detail_url: str) -> tuple[str, str]:
+def _format_fire_size(fire_size: Sequence[float | None] | float | None) -> str:
+    if not fire_size:
+        return ""
+
+    if isinstance(fire_size, Sequence) and not isinstance(fire_size, str):
+        fire_sizes = [str(size) for size in fire_size if size is not None]
+        return f"Size:&nbsp;&nbsp;&nbsp;{', '.join(fire_sizes)} ha" if fire_sizes else ""
+
+    return f"Size:&nbsp;&nbsp;&nbsp;{fire_size} ha"
+
+
+def build_spot_forecast_email(spot_forecast: SpotForecast, spot_detail_url: str) -> tuple[str, str]:
     """Return (subject, html_body) for a spot forecast notification email."""
     sr = spot_forecast.spot_request_base
     instance = spot_forecast.spot_request_instance
@@ -90,17 +108,15 @@ def build_spot_forecast_email(spot_forecast, spot_detail_url: str) -> tuple[str,
     )
     expiry_str = expiry_dt.strftime("%A %B %-d") if expiry_dt else "—"
 
-    coords_str = _get_coords(sr)
-    aspect_str = html.escape(sr.aspect or "—")
-    elevation_str = f"{sr.elevation} m" if sr.elevation else "—"
-    geo_str = html.escape(sr.geographic_description or "")
+    coords_str = _get_coords(instance)
+    aspect_str = html.escape(instance.aspect or "—")
+    elevation_str = f"{instance.elevation} m" if instance.elevation else "—"
+    geo_str = html.escape(instance.geographic_description or "")
     forecaster_name = html.escape(spot_forecast.forecaster_name or "")
     forecaster_email = html.escape(spot_forecast.forecaster_email or "")
     forecaster_phone = html.escape(spot_forecast.forecaster_phone or "—")
     requestor_name = html.escape(sr.requestor_name or "")
-    fire_size_str = (
-        f"Size:&nbsp;&nbsp;&nbsp;{spot_forecast.fire_size} ha" if spot_forecast.fire_size else ""
-    )
+    fire_size_str = _format_fire_size(spot_forecast.fire_size)
 
     station_codes = spot_forecast.representative_station_codes
     stations_str = ", ".join(str(c) for c in station_codes) if station_codes else "—"

--- a/backend/packages/wps-api/src/app/smurfi/email.py
+++ b/backend/packages/wps-api/src/app/smurfi/email.py
@@ -17,7 +17,8 @@ WEB_BASE_URL = config.get("WEB_BASE_URL")
 
 def build_spot_forecast_email(spot_forecast, spot_detail_url: str) -> tuple[str, str]:
     """Return (subject, html_body) for a spot forecast notification email."""
-    sr = spot_forecast.spot_request
+    sr = spot_forecast.spot_request_base
+    instance = spot_forecast.spot_request_instance
     fire_numbers = html.escape(", ".join(sr.fire_number)) if sr.fire_number else "N/A"
     subject = f"Spot Forecast Update: Fire {fire_numbers}"
 
@@ -45,7 +46,7 @@ def build_spot_forecast_email(spot_forecast, spot_detail_url: str) -> tuple[str,
 <html><body>
 <h2>Spot Forecast Update</h2>
 <p><strong>Fire Number(s):</strong> {fire_numbers}</p>
-<p><strong>Location:</strong> {html.escape(sr.geographic_description or "")}</p>
+<p><strong>Location:</strong> {html.escape(instance.geographic_description or "")}</p>
 
 <h3>Descriptive Forecast</h3>
 <table border="1" cellpadding="4" cellspacing="0">

--- a/backend/packages/wps-api/src/app/tests/smurfi/test_email.py
+++ b/backend/packages/wps-api/src/app/tests/smurfi/test_email.py
@@ -23,6 +23,10 @@ def _make_spot_request(fire_number=None, geographic_description="Test Area"):
 def _make_spot_request_instance(geographic_description="Test Area"):
     instance = MagicMock()
     instance.geographic_description = geographic_description
+    instance.aspect = "East"
+    instance.elevation = 1100
+    instance.latitude = 48.5
+    instance.longitude = -123.5
     return instance
 
 

--- a/backend/packages/wps-api/src/app/tests/smurfi/test_email.py
+++ b/backend/packages/wps-api/src/app/tests/smurfi/test_email.py
@@ -1,4 +1,5 @@
 """Unit tests for smurfi CHES email builder."""
+
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,9 +14,18 @@ def _make_spot_request(fire_number=None, geographic_description="Test Area"):
     return sr
 
 
+def _make_spot_request_instance(geographic_description="Test Area"):
+    instance = MagicMock()
+    instance.geographic_description = geographic_description
+    return instance
+
+
 def _make_spot_forecast(spot_request, descriptive_weather=None, tabular_weather=None):
     sf = MagicMock()
-    sf.spot_request = spot_request
+    sf.spot_request_base = spot_request
+    sf.spot_request_instance = _make_spot_request_instance(
+        geographic_description=getattr(spot_request, "geographic_description", "Test Area")
+    )
     sf.descriptive_weather = descriptive_weather or []
     sf.tabular_weather = tabular_weather or []
     return sf
@@ -30,7 +40,14 @@ def _make_descriptive(period, conditions="Sunny", temperature=18.0, relative_hum
     return dw
 
 
-def _make_tabular(forecast_time, temperature=18.0, relative_humidity=40.0, wind="NW 20", probability_of_precipitation=10.0, precipitation_amount=0.0):
+def _make_tabular(
+    forecast_time,
+    temperature=18.0,
+    relative_humidity=40.0,
+    wind="NW 20",
+    probability_of_precipitation=10.0,
+    precipitation_amount=0.0,
+):
     tw = MagicMock()
     tw.forecast_time = forecast_time
     tw.temperature = temperature
@@ -51,8 +68,9 @@ def test_build_email_subject_includes_fire_number():
 
 def test_build_email_body_contains_geographic_description():
     """Email body contains the geographic description."""
-    sr = _make_spot_request(geographic_description="Clearwater Valley")
+    sr = _make_spot_request()
     sf = _make_spot_forecast(sr)
+    sf.spot_request_instance.geographic_description = "Clearwater Valley"
     _, html = build_spot_forecast_email(sf, spot_detail_url="http://example.com/smurfi/spots/1")
     assert "Clearwater Valley" in html
 
@@ -60,7 +78,9 @@ def test_build_email_body_contains_geographic_description():
 def test_build_email_body_contains_descriptive_period():
     """Email body contains descriptive weather period."""
     sr = _make_spot_request()
-    dw = _make_descriptive(period="Today", conditions="Partly cloudy", temperature=22.0, relative_humidity=35.0)
+    dw = _make_descriptive(
+        period="Today", conditions="Partly cloudy", temperature=22.0, relative_humidity=35.0
+    )
     sf = _make_spot_forecast(sr, descriptive_weather=[dw])
     _, html = build_spot_forecast_email(sf, spot_detail_url="http://example.com/smurfi/spots/1")
     assert "Today" in html

--- a/backend/packages/wps-api/src/app/tests/smurfi/test_subscribe_router.py
+++ b/backend/packages/wps-api/src/app/tests/smurfi/test_subscribe_router.py
@@ -14,11 +14,27 @@ SUBSCRIBE = "app.routers.smurfi.subscribe_to_spot_request"
 UNSUBSCRIBE = "app.routers.smurfi.unsubscribe_from_spot_request"
 GET_IDS = "app.routers.smurfi.get_subscribed_spot_request_ids"
 GET_FORECASTS = "app.routers.smurfi.get_spot_forecasts_for_request"
-GET_FORECASTS = "app.routers.smurfi.get_spot_forecasts_for_request"
+GET_OR_CREATE_INSTANCE = "app.routers.smurfi.get_or_create_spot_request_instance"
 
 
 def _make_subscriber(status: str):
     return type("SpotSubscriber", (), {"subscriber_status": status})()
+
+
+def _make_spot_request_instance(instance_id: int = 3):
+    return type(
+        "SpotRequestInstance",
+        (),
+        {
+            "id": instance_id,
+            "geographic_description": "Clearwater Valley",
+            "aspect": "North",
+            "elevation": 1000,
+            "valley": None,
+            "latitude": 48.5,
+            "longitude": -123.5,
+        },
+    )()
 
 
 @pytest.mark.usefixtures("mock_jwt_decode")
@@ -122,7 +138,9 @@ def test_get_spot_forecasts_returns_saved_forecasts():
         (),
         {
             "id": 99,
-            "spot_request_id": 42,
+            "spot_request_base_id": 42,
+            "spot_request_instance_id": 3,
+            "spot_request_instance": _make_spot_request_instance(),
             "forecaster_name": "Test Forecaster",
             "forecaster_email": "forecaster@example.com",
             "forecaster_phone": "250-555-0100",
@@ -130,7 +148,7 @@ def test_get_spot_forecasts_returns_saved_forecasts():
             "inversion_and_venting": "Good venting.",
             "outlook": "Dry.",
             "confidence": "High.",
-            "fire_size": 12.5,
+            "fire_size": [12.5],
             "representative_station_codes": [1, 2],
             "created_at": forecast_time,
             "issued_at": forecast_time,
@@ -158,7 +176,15 @@ CREATE_TW = "app.routers.smurfi._create_tabular_weather"
 START_REQUEST = "app.routers.smurfi.start_requested_spot_request"
 
 FORECAST_PAYLOAD = {
-    "spot_request_id": 1,
+    "spot_request_base_id": 1,
+    "spot_request_instance": {
+        "geographic_description": "Clearwater Valley",
+        "aspect": "North",
+        "elevation": 1000,
+        "valley": None,
+        "latitude": 48.5,
+        "longitude": -123.5,
+    },
     "issued_at": "2026-05-21T16:00:00Z",
     "expires_at": None,
     "descriptive_weather": [],
@@ -176,6 +202,11 @@ def test_create_spot_forecast_publishes_nats_message():
         patch(
             CREATE_FORECAST, new_callable=AsyncMock, return_value=mock_result
         ) as mock_create_forecast,
+        patch(
+            GET_OR_CREATE_INSTANCE,
+            new_callable=AsyncMock,
+            return_value=_make_spot_request_instance(),
+        ),
         patch(CREATE_DW, new_callable=AsyncMock, return_value=[]),
         patch(CREATE_TW, new_callable=AsyncMock, return_value=[]),
         patch(START_REQUEST, new_callable=AsyncMock) as mock_start_request,
@@ -186,7 +217,7 @@ def test_create_spot_forecast_publishes_nats_message():
     saved_forecast = mock_create_forecast.call_args.args[1]
     assert saved_forecast.forecaster_name == "test_username"
     assert saved_forecast.forecaster_email == "test@email.com"
-    mock_start_request.assert_awaited_once_with(ANY, FORECAST_PAYLOAD["spot_request_id"])
+    mock_start_request.assert_awaited_once_with(ANY, FORECAST_PAYLOAD["spot_request_base_id"])
     mock_publish.assert_called_once_with(
         stream=stream_name,
         subject=smurfi_spot_update_subject,

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/smurfi.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/smurfi.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import selectinload
 from wps_shared.db.models.smurfi import (
     SpotDescriptiveWeather,
     SpotForecast,
-    SpotRequest,
+    SpotRequestBase,
+    SpotRequestInstance,
     SpotRequestStatusEnum,
     SpotSubscriber,
     SpotSubscriberStatusEnum,
@@ -15,16 +16,51 @@ from wps_shared.db.models.smurfi import (
 )
 
 
-async def create_spot_request(session: AsyncSession, spot_request: SpotRequest):
+async def create_spot_request(session: AsyncSession, spot_request: SpotRequestBase):
     session.add(spot_request)
     await session.flush()
     return spot_request
 
 
-async def upsert_spot_request(session: AsyncSession, spot_request: SpotRequest):
+async def upsert_spot_request(session: AsyncSession, spot_request: SpotRequestBase):
     if spot_request.id is None:
         return await create_spot_request(session, spot_request)
     return await update_spot_request(session, spot_request)
+
+
+async def create_spot_request_instance(
+    session: AsyncSession, spot_request_instance: SpotRequestInstance
+) -> SpotRequestInstance:
+    session.add(spot_request_instance)
+    await session.flush()
+    return spot_request_instance
+
+
+async def get_matching_spot_request_instance(
+    session: AsyncSession, spot_request_instance: SpotRequestInstance
+) -> SpotRequestInstance | None:
+    result = await session.execute(
+        select(SpotRequestInstance).where(
+            SpotRequestInstance.spot_request_base_id == spot_request_instance.spot_request_base_id,
+            SpotRequestInstance.latitude == spot_request_instance.latitude,
+            SpotRequestInstance.longitude == spot_request_instance.longitude,
+            SpotRequestInstance.geographic_description
+            == spot_request_instance.geographic_description,
+            SpotRequestInstance.aspect == spot_request_instance.aspect,
+            SpotRequestInstance.elevation == spot_request_instance.elevation,
+            SpotRequestInstance.valley == spot_request_instance.valley,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_or_create_spot_request_instance(
+    session: AsyncSession, spot_request_instance: SpotRequestInstance
+) -> SpotRequestInstance:
+    existing = await get_matching_spot_request_instance(session, spot_request_instance)
+    if existing is not None:
+        return existing
+    return await create_spot_request_instance(session, spot_request_instance)
 
 
 async def create_spot_forecast(session: AsyncSession, spot_forecast: SpotForecast):
@@ -34,10 +70,10 @@ async def create_spot_forecast(session: AsyncSession, spot_forecast: SpotForecas
 
 
 async def sync_spot_subscribers(
-    session: AsyncSession, spot_request_id: int, emails: list[str]
+    session: AsyncSession, spot_request_base_id: int, emails: list[str]
 ) -> list[SpotSubscriber]:
     result = await session.execute(
-        select(SpotSubscriber).where(SpotSubscriber.spot_request_id == spot_request_id)
+        select(SpotSubscriber).where(SpotSubscriber.spot_request_base_id == spot_request_base_id)
     )
     existing = result.scalars().all()
 
@@ -58,7 +94,7 @@ async def sync_spot_subscribers(
 
     for email in active_emails:
         if email not in existing_by_email:
-            new_subscriber = SpotSubscriber(spot_request_id=spot_request_id, email=email)
+            new_subscriber = SpotSubscriber(spot_request_base_id=spot_request_base_id, email=email)
             session.add(new_subscriber)
             active_subscribers.append(new_subscriber)
 
@@ -82,20 +118,20 @@ async def create_spot_descriptive_weather(
     return spot_descriptive_weather
 
 
-async def start_requested_spot_request(session: AsyncSession, spot_request_id: int):
+async def start_requested_spot_request(session: AsyncSession, spot_request_base_id: int):
     await session.execute(
-        update(SpotRequest)
+        update(SpotRequestBase)
         .where(
-            SpotRequest.id == spot_request_id,
-            SpotRequest.status == SpotRequestStatusEnum.REQUESTED.value,
+            SpotRequestBase.id == spot_request_base_id,
+            SpotRequestBase.status == SpotRequestStatusEnum.REQUESTED.value,
         )
         .values(status=SpotRequestStatusEnum.STARTED.value)
     )
     await session.flush()
 
 
-async def update_spot_request(session: AsyncSession, updated: SpotRequest):
-    result = await session.execute(select(SpotRequest).where(SpotRequest.id == updated.id))
+async def update_spot_request(session: AsyncSession, updated: SpotRequestBase):
+    result = await session.execute(select(SpotRequestBase).where(SpotRequestBase.id == updated.id))
     existing = result.scalar_one_or_none()
     if existing is not None:
         existing.request_reference = updated.request_reference
@@ -107,11 +143,7 @@ async def update_spot_request(session: AsyncSession, updated: SpotRequest):
         existing.requestor_email = updated.requestor_email
         existing.request_frequency = updated.request_frequency
         existing.request_type = updated.request_type
-        existing.aspect = updated.aspect
-        existing.elevation = updated.elevation
-        existing.geographic_description = updated.geographic_description
         existing.additional_information = updated.additional_information
-        existing.geom = updated.geom
         existing.requested_at = updated.requested_at
         existing.start_at = updated.start_at
         existing.end_at = updated.end_at
@@ -123,11 +155,15 @@ async def get_spot_requests_for_year(session: AsyncSession, year: int):
     year_start = datetime(year, 1, 1, tzinfo=timezone.utc)
     year_end = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
     result = await session.execute(
-        select(SpotRequest)
-        .where(SpotRequest.start_at >= year_start, SpotRequest.start_at < year_end)
+        select(SpotRequestBase)
+        .where(SpotRequestBase.start_at >= year_start, SpotRequestBase.start_at < year_end)
         .options(
-            selectinload(SpotRequest.spot_subscribers),
-            selectinload(SpotRequest.spot_forecasts).selectinload(SpotForecast.tabular_weather),
+            selectinload(SpotRequestBase.spot_subscribers),
+            selectinload(SpotRequestBase.spot_request_instances),
+            selectinload(SpotRequestBase.spot_forecasts).selectinload(SpotForecast.tabular_weather),
+            selectinload(SpotRequestBase.spot_forecasts).selectinload(
+                SpotForecast.spot_request_instance
+            ),
         )
     )
     return result.scalars().all()
@@ -145,18 +181,18 @@ async def update_spot_subscriber_status(
 
 
 async def subscribe_to_spot_request(
-    session: AsyncSession, spot_request_id: int, email: str
+    session: AsyncSession, spot_request_base_id: int, email: str
 ) -> SpotSubscriber:
     result = await session.execute(
         select(SpotSubscriber).where(
-            SpotSubscriber.spot_request_id == spot_request_id,
+            SpotSubscriber.spot_request_base_id == spot_request_base_id,
             SpotSubscriber.email == email,
         )
     )
     subscriber = result.scalar_one_or_none()
     if subscriber is None:
         subscriber = SpotSubscriber(
-            spot_request_id=spot_request_id,
+            spot_request_base_id=spot_request_base_id,
             email=email,
             subscriber_status=SpotSubscriberStatusEnum.ACTIVE.value,
         )
@@ -168,11 +204,11 @@ async def subscribe_to_spot_request(
 
 
 async def unsubscribe_from_spot_request(
-    session: AsyncSession, spot_request_id: int, email: str
+    session: AsyncSession, spot_request_base_id: int, email: str
 ) -> SpotSubscriber | None:
     result = await session.execute(
         select(SpotSubscriber).where(
-            SpotSubscriber.spot_request_id == spot_request_id,
+            SpotSubscriber.spot_request_base_id == spot_request_base_id,
             SpotSubscriber.email == email,
         )
     )
@@ -185,7 +221,7 @@ async def unsubscribe_from_spot_request(
 
 async def get_subscribed_spot_request_ids(session: AsyncSession, email: str) -> list[int]:
     result = await session.execute(
-        select(SpotSubscriber.spot_request_id).where(
+        select(SpotSubscriber.spot_request_base_id).where(
             SpotSubscriber.email == email,
             SpotSubscriber.subscriber_status == SpotSubscriberStatusEnum.ACTIVE.value,
         )
@@ -194,11 +230,11 @@ async def get_subscribed_spot_request_ids(session: AsyncSession, email: str) -> 
 
 
 async def get_active_subscribers_for_spot(
-    session: AsyncSession, spot_request_id: int
+    session: AsyncSession, spot_request_base_id: int
 ) -> list[SpotSubscriber]:
     result = await session.execute(
         select(SpotSubscriber).where(
-            SpotSubscriber.spot_request_id == spot_request_id,
+            SpotSubscriber.spot_request_base_id == spot_request_base_id,
             SpotSubscriber.subscriber_status == SpotSubscriberStatusEnum.ACTIVE.value,
         )
     )
@@ -214,21 +250,23 @@ async def get_spot_forecast_with_weather(
         .options(
             selectinload(SpotForecast.descriptive_weather),
             selectinload(SpotForecast.tabular_weather),
-            selectinload(SpotForecast.spot_request),
+            selectinload(SpotForecast.spot_request_base),
+            selectinload(SpotForecast.spot_request_instance),
         )
     )
     return result.scalar_one_or_none()
 
 
 async def get_spot_forecasts_for_request(
-    session: AsyncSession, spot_request_id: int
+    session: AsyncSession, spot_request_base_id: int
 ) -> list[SpotForecast]:
     result = await session.execute(
         select(SpotForecast)
-        .where(SpotForecast.spot_request_id == spot_request_id)
+        .where(SpotForecast.spot_request_base_id == spot_request_base_id)
         .options(
             selectinload(SpotForecast.descriptive_weather),
             selectinload(SpotForecast.tabular_weather),
+            selectinload(SpotForecast.spot_request_instance),
         )
         .order_by(SpotForecast.created_at.desc())
     )

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/smurfi.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/smurfi.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -14,6 +14,9 @@ from wps_shared.db.models.smurfi import (
     SpotSubscriberStatusEnum,
     SpotTabularWeather,
 )
+
+# roughly 20m in degrees, which is sufficient for matching spot request instances to forecasts without requiring exact coordinate matches
+COORDINATE_MATCH_TOLERANCE = 0.0002
 
 
 async def create_spot_request(session: AsyncSession, spot_request_base: SpotRequestBase):
@@ -42,8 +45,10 @@ async def get_matching_spot_request_instance(
     result = await session.execute(
         select(SpotRequestInstance).where(
             SpotRequestInstance.spot_request_base_id == spot_request_instance.spot_request_base_id,
-            SpotRequestInstance.latitude == spot_request_instance.latitude,
-            SpotRequestInstance.longitude == spot_request_instance.longitude,
+            func.abs(SpotRequestInstance.latitude - spot_request_instance.latitude)
+            <= COORDINATE_MATCH_TOLERANCE,
+            func.abs(SpotRequestInstance.longitude - spot_request_instance.longitude)
+            <= COORDINATE_MATCH_TOLERANCE,
             SpotRequestInstance.geographic_description
             == spot_request_instance.geographic_description,
             SpotRequestInstance.aspect == spot_request_instance.aspect,

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/smurfi.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/smurfi.py
@@ -16,16 +16,16 @@ from wps_shared.db.models.smurfi import (
 )
 
 
-async def create_spot_request(session: AsyncSession, spot_request: SpotRequestBase):
-    session.add(spot_request)
+async def create_spot_request(session: AsyncSession, spot_request_base: SpotRequestBase):
+    session.add(spot_request_base)
     await session.flush()
-    return spot_request
+    return spot_request_base
 
 
-async def upsert_spot_request(session: AsyncSession, spot_request: SpotRequestBase):
-    if spot_request.id is None:
-        return await create_spot_request(session, spot_request)
-    return await update_spot_request(session, spot_request)
+async def upsert_spot_request(session: AsyncSession, spot_request_base: SpotRequestBase):
+    if spot_request_base.id is None:
+        return await create_spot_request(session, spot_request_base)
+    return await update_spot_request(session, spot_request_base)
 
 
 async def create_spot_request_instance(

--- a/backend/packages/wps-shared/src/wps_shared/db/models/__init__.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/models/__init__.py
@@ -44,7 +44,6 @@ from wps_shared.db.models.sfms_run import SFMSRunLog
 from wps_shared.db.models.fcm import DeviceToken
 from wps_shared.db.models.smurfi import (
     SpotRequestBase,
-    SpotRequestBase,
     SpotRequestInstance,
     SpotSubscriber,
     SpotForecast,

--- a/backend/packages/wps-shared/src/wps_shared/db/models/__init__.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/models/__init__.py
@@ -43,7 +43,9 @@ from wps_shared.db.models.fire_watch import FireWatch, FireWatchWeather, Prescri
 from wps_shared.db.models.sfms_run import SFMSRunLog
 from wps_shared.db.models.fcm import DeviceToken
 from wps_shared.db.models.smurfi import (
-    SpotRequest,
+    SpotRequestBase,
+    SpotRequestBase,
+    SpotRequestInstance,
     SpotSubscriber,
     SpotForecast,
     SpotDescriptiveWeather,

--- a/backend/packages/wps-shared/src/wps_shared/db/models/smurfi.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/models/smurfi.py
@@ -103,10 +103,10 @@ subscriber_status_values = (
 )
 
 
-class SpotRequest(Base):
-    """A class representing requests for spot forecasts."""
+class SpotRequestBase(Base):
+    """A durable administrative request for spot forecasts."""
 
-    __tablename__ = "spot_request"
+    __tablename__ = "spot_request_base"
 
     id = Column(Integer, primary_key=True)
     request_reference = Column(String, nullable=False)
@@ -125,11 +125,7 @@ class SpotRequest(Base):
     requestor_email = Column(String, nullable=False)
     request_frequency = Column(ARRAY(Enum(FrequencyDayEnum)), nullable=True)
     request_type = Column(String, nullable=False, default=RequestTypeEnum.FULL.value)
-    aspect = Column(String, nullable=True)
-    elevation = Column(Integer, nullable=True)
-    geographic_description = Column(String, nullable=False)
     additional_information = Column(Text, nullable=True)
-    geom = Column(Geometry("POINT", spatial_index=False, srid=NAD83_BC_ALBERS), nullable=False)
     requested_at = Column(TZTimeStamp, nullable=False)
     start_at = Column(TZTimeStamp, nullable=False, index=True)
     end_at = Column(TZTimeStamp, nullable=False, index=True)
@@ -139,16 +135,46 @@ class SpotRequest(Base):
     )
 
     # Relationships
-    spot_forecasts = relationship("SpotForecast", back_populates="spot_request")
-    spot_subscribers = relationship("SpotSubscriber", back_populates="spot_request")
+    spot_forecasts = relationship("SpotForecast", back_populates="spot_request_base")
+    spot_request_instances = relationship("SpotRequestInstance", back_populates="spot_request_base")
+    spot_subscribers = relationship("SpotSubscriber", back_populates="spot_request_base")
 
     __table_args__ = (
-        CheckConstraint(status.in_(request_status_values), name="chk_status_spot_request"),
+        CheckConstraint(status.in_(request_status_values), name="chk_status_spot_request_base"),
         CheckConstraint(
-            request_type.in_(request_type_values), name="chk_request_type_spot_request"
+            request_type.in_(request_type_values), name="chk_request_type_spot_request_base"
         ),
-        CheckConstraint(aspect.in_(cardinal_direction_values), name="chk_aspect_spot_request"),
-        {"comment": "Tracks requests for spot weather forecasts."},
+        {"comment": "Tracks administrative requests for spot weather forecasts."},
+    )
+
+
+class SpotRequestInstance(Base):
+    """An instance of a spot_request containing geographic and terrain context for a spot request or forecast."""
+
+    __tablename__ = "spot_request_instance"
+
+    id = Column(Integer, primary_key=True)
+    spot_request_base_id = Column(
+        Integer, ForeignKey("spot_request_base.id"), nullable=False, index=True
+    )
+    latitude = Column(Float, nullable=False)
+    longitude = Column(Float, nullable=False)
+    geom = Column(Geometry("POINT", spatial_index=False, srid=NAD83_BC_ALBERS), nullable=False)
+    geographic_description = Column(String, nullable=False)
+    aspect = Column(String, nullable=True)
+    elevation = Column(Integer, nullable=True)
+    valley = Column(String, nullable=True)
+    created_at = Column(TZTimeStamp, nullable=False, default=time_utils.get_utc_now)
+    updated_at = Column(
+        TZTimeStamp, nullable=False, onupdate=time_utils.get_utc_now, default=time_utils.get_utc_now
+    )
+
+    # Relationships
+    spot_request_base = relationship("SpotRequestBase", back_populates="spot_request_instances")
+    spot_forecasts = relationship("SpotForecast", back_populates="spot_request_instance")
+
+    __table_args__ = (
+        {"comment": "Tracks geographic instances used by spot requests and forecasts."},
     )
 
 
@@ -158,7 +184,9 @@ class SpotSubscriber(Base):
     __tablename__ = "spot_subscriber"
 
     id = Column(Integer, primary_key=True)
-    spot_request_id = Column(Integer, ForeignKey(SpotRequest.id), nullable=False, index=True)
+    spot_request_base_id = Column(
+        Integer, ForeignKey("spot_request_base.id"), nullable=False, index=True
+    )
     email = Column(String, nullable=False, index=True)
     subscriber_status = Column(
         String, nullable=False, default=SpotSubscriberStatusEnum.ACTIVE.value
@@ -169,7 +197,7 @@ class SpotSubscriber(Base):
     )
 
     # Relationships
-    spot_request = relationship("SpotRequest", back_populates="spot_subscribers")
+    spot_request_base = relationship("SpotRequestBase", back_populates="spot_subscribers")
 
     __table_args__ = (
         CheckConstraint(
@@ -187,7 +215,12 @@ class SpotForecast(Base):
     __table_args__ = {"comment": "Spot forecasts for spot requests."}
 
     id = Column(Integer, primary_key=True)
-    spot_request_id = Column(Integer, ForeignKey("spot_request.id"), nullable=False, index=True)
+    spot_request_base_id = Column(
+        Integer, ForeignKey("spot_request_base.id"), nullable=False, index=True
+    )
+    spot_request_instance_id = Column(
+        Integer, ForeignKey("spot_request_instance.id"), nullable=False, index=True
+    )
 
     # forecaster info
     forecaster_name = Column(String, nullable=False, index=True)
@@ -198,14 +231,15 @@ class SpotForecast(Base):
     inversion_and_venting = Column(Text, nullable=True)
     outlook = Column(Text, nullable=True)
     confidence = Column(Text, nullable=True)
-    fire_size = Column(Float, nullable=True)
+    fire_size = Column(ARRAY(Float), nullable=True)
     representative_station_codes = Column(ARRAY(Integer), nullable=True)
     created_at = Column(TZTimeStamp, nullable=False, default=time_utils.get_utc_now)
     issued_at = Column(TZTimeStamp, nullable=False)
     expires_at = Column(TZTimeStamp, nullable=True)
 
     # Relationships
-    spot_request = relationship("SpotRequest", back_populates="spot_forecasts")
+    spot_request_base = relationship("SpotRequestBase", back_populates="spot_forecasts")
+    spot_request_instance = relationship("SpotRequestInstance", back_populates="spot_forecasts")
     tabular_weather = relationship("SpotTabularWeather", back_populates="spot_forecast")
     descriptive_weather = relationship("SpotDescriptiveWeather", back_populates="spot_forecast")
 

--- a/backend/packages/wps-shared/src/wps_shared/schemas/smurfi.py
+++ b/backend/packages/wps-shared/src/wps_shared/schemas/smurfi.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class PullFromChefsResponse(BaseModel):
@@ -27,6 +27,19 @@ class SpotLatestForecastData(BaseModel):
     forecaster_name: str | None = None
 
 
+class SpotRequestInstanceInput(BaseModel):
+    geographic_description: str
+    aspect: str | None = None
+    elevation: int | None = None
+    valley: str | None = None
+    latitude: float
+    longitude: float
+
+
+class SpotRequestInstanceData(SpotRequestInstanceInput):
+    id: int
+
+
 class SpotRequestInput(BaseModel):
     id: int | None = None
     request_reference: str
@@ -35,22 +48,20 @@ class SpotRequestInput(BaseModel):
     status: str = "Requested"
     request_frequency: list[str] | None = None
     request_type: str = "Full"
-    aspect: str | None = None
-    elevation: int | None = None
-    geographic_description: str
     additional_information: str | None = None
-    latitude: float
-    longitude: float
+    initial_instance: SpotRequestInstanceInput
     requested_at: datetime
     start_at: datetime
     end_at: datetime
-    subscribers: list[SpotSubscriberData] = []
+    subscribers: list[SpotSubscriberData] = Field(default_factory=list)
 
 
 class SpotRequestData(SpotRequestInput):
     requestor_name: str
     requestor_idir: str
     requestor_email: str
+    initial_instance: SpotRequestInstanceData
+    current_instance: SpotRequestInstanceData
     latest_forecast: SpotLatestForecastData | None = None
 
 
@@ -87,27 +98,30 @@ class SpotTabularWeatherData(SpotTabularWeatherInput):
 
 
 class SpotForecastInput(BaseModel):
-    spot_request_id: int
+    spot_request_base_id: int
+    spot_request_instance: SpotRequestInstanceInput
     issued_at: datetime
     expires_at: datetime | None = None
     synopsis: str | None = None
     inversion_and_venting: str | None = None
     outlook: str | None = None
     confidence: str | None = None
-    fire_size: float | None = None
+    fire_size: list[float | None] | None = None
     representative_station_codes: list[int] | None = None
-    descriptive_weather: list[SpotDescriptiveWeatherInput] = []
-    tabular_weather: list[SpotTabularWeatherInput] = []
+    descriptive_weather: list[SpotDescriptiveWeatherInput] = Field(default_factory=list)
+    tabular_weather: list[SpotTabularWeatherInput] = Field(default_factory=list)
 
 
 class SpotForecastData(SpotForecastInput):
     id: int | None = None
+    spot_request_instance_id: int
+    spot_request_instance: SpotRequestInstanceData
     created_at: datetime | None = None
     forecaster_name: str | None = None
     forecaster_email: str | None = None
     forecaster_phone: str | None = None
-    descriptive_weather: list[SpotDescriptiveWeatherData] = []
-    tabular_weather: list[SpotTabularWeatherData] = []
+    descriptive_weather: list[SpotDescriptiveWeatherData] = Field(default_factory=list)
+    tabular_weather: list[SpotTabularWeatherData] = Field(default_factory=list)
 
 
 class SpotForecastResponse(BaseModel):
@@ -162,7 +176,7 @@ class SmurfiSpotVersionData(BaseModel):
     geographic_area_name: str | None = None
     fire_centre: str | None = None
     elevation: float | None = None
-    fire_size: float | None = None
+    fire_size: list[float | None] | None = None
     slope: float | None = None
     aspect: str | None = None
     valley: str | None = None

--- a/web/apps/wps-web/src/features/smurfi/components/forecastForm/SpotForecastForm.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecastForm/SpotForecastForm.tsx
@@ -15,11 +15,13 @@ import { SpotRequestOutput } from '@wps/api/SMURFIAPI'
 import { createSchema, SpotFormData } from '@wps/api/schema/spotForecastSchema'
 import { getStations, StationSource } from '@wps/api/stationAPI'
 import { clearSpotForecastSubmitState, submitSpotForecast, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
+import { fetchCurrentFireSizesByFireNumbers } from '@/features/smurfi/components/map/currentFirePolygonsLayer'
 
 const toFormString = (value: number | string | null | undefined) =>
   value === null || value === undefined ? '' : String(value)
 
 const formatFireNumbers = (fireNumbers: string[] | null | undefined) => fireNumbers?.join(', ') ?? ''
+const getEmptyFireSizes = (fireNumbers: string[] | null | undefined) => fireNumbers?.map(() => '') ?? []
 
 interface SpotForecastFormProps {
   spotRequest: SpotRequestOutput
@@ -35,23 +37,29 @@ const SpotForecastForm: React.FC<SpotForecastFormProps> = ({ spotRequest, onSubm
 
   const defaultValues = useMemo<Partial<SpotFormData>>(() => {
     const baseDefaults = getDefaultValues()
+    const requestInstance = spotRequest.current_instance
 
     return {
       ...baseDefaults,
       fireProj: formatFireNumbers(spotRequest.fire_number),
       requestBy: spotRequest.requestor_name,
-      latitude: toFormString(spotRequest.latitude.toFixed(4)),
-      longitude: toFormString(spotRequest.longitude.toFixed(4)),
-      slopeAspect: spotRequest.aspect ?? baseDefaults.slopeAspect,
-      elevation: toFormString(spotRequest.elevation),
+      latitude: toFormString(requestInstance.latitude.toFixed(4)),
+      longitude: toFormString(requestInstance.longitude.toFixed(4)),
+      geographicDescription: requestInstance.geographic_description,
+      slopeAspect: requestInstance.aspect ?? baseDefaults.slopeAspect,
+      valley: requestInstance.valley ?? baseDefaults.valley,
+      elevation: toFormString(requestInstance.elevation),
+      fireSizes: getEmptyFireSizes(spotRequest.fire_number),
       weatherData: defaultWeatherRows
     }
   }, [spotRequest])
 
   const {
     control,
+    getValues,
     handleSubmit,
     reset,
+    setValue,
     formState: { errors, submitCount }
   } = useForm<SpotFormData>({
     resolver,
@@ -89,6 +97,30 @@ const SpotForecastForm: React.FC<SpotForecastFormProps> = ({ spotRequest, onSubm
   }, [defaultValues, reset])
 
   useEffect(() => {
+    const fireNumbers = spotRequest.fire_number ?? []
+    if (fireNumbers.length === 0) {
+      return
+    }
+
+    let cancelled = false
+    fetchCurrentFireSizesByFireNumbers(fireNumbers)
+      .then(fireSizes => {
+        const currentFireSizes = getValues('fireSizes') ?? []
+        const hasExistingFireSizes = currentFireSizes.some(fireSize => fireSize?.trim())
+        if (!cancelled && !hasExistingFireSizes) {
+          setValue('fireSizes', fireSizes.map(toFormString), { shouldValidate: true })
+        }
+      })
+      .catch(() => {
+        // keep fire sizes editable when the public fire layer cannot provide values
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [getValues, setValue, spotRequest.fire_number])
+
+  useEffect(() => {
     dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
   }, [dispatch])
 
@@ -112,7 +144,12 @@ const SpotForecastForm: React.FC<SpotForecastFormProps> = ({ spotRequest, onSubm
 
       <form onSubmit={handleSubmit(onSubmit)}>
         <Grid container spacing={3}>
-          <SpotForecastHeader control={control} errors={errors} />
+          <SpotForecastHeader
+            control={control}
+            errors={errors}
+            fireNumbers={spotRequest.fire_number}
+            setValue={setValue}
+          />
           <SpotForecastSynopsis control={control} errors={errors} />
           {!isMini && <SpotForecastSummaries control={control} errors={errors} />}
           <WeatherDataTable control={control} errors={errors} fields={fields} append={append} remove={remove} />

--- a/web/apps/wps-web/src/features/smurfi/components/forecastForm/SpotForecastHeader.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecastForm/SpotForecastHeader.tsx
@@ -1,17 +1,36 @@
 import React from 'react'
-import { Controller, Control, FieldErrors } from 'react-hook-form'
-import { Grid, Card, CardContent, InputAdornment } from '@mui/material'
+import { Controller, Control, FieldErrors, UseFormSetValue, useWatch } from 'react-hook-form'
+import { Grid, Card, CardContent, InputAdornment, Typography } from '@mui/material'
 import StationSelector from '@/features/smurfi/components/StationSelector'
 import { SpotFormData } from '@wps/api/schema/spotForecastSchema'
 import ControlledForecastTextField from '@/features/smurfi/components/forecastForm/ControlledForecastTextField'
 import ControlledForecastDateTimePicker from '@/features/smurfi/components/forecastForm/ControlledForecastDateTimePicker'
+import SpotRequestLocationMap from '@/features/smurfi/components/requestForm/SpotRequestLocationMap'
 
 interface SpotForecastHeaderProps {
   control: Control<SpotFormData>
   errors: FieldErrors<SpotFormData>
+  fireNumbers: string[] | null | undefined
+  setValue: UseFormSetValue<SpotFormData>
 }
 
-const SpotForecastHeader: React.FC<SpotForecastHeaderProps> = ({ control, errors }) => {
+const toNumericLocation = (latitude: string | undefined, longitude: string | undefined) => {
+  const lat = Number(latitude)
+  const lon = Number(longitude)
+  return Number.isFinite(lat) && Number.isFinite(lon) ? { latitude: lat, longitude: lon } : null
+}
+
+const getFireSizeErrorMessage = (errors: FieldErrors<SpotFormData>, index: number) => {
+  const fireSizesError = errors.fireSizes
+  return Array.isArray(fireSizesError) ? fireSizesError[index]?.message : undefined
+}
+
+const SpotForecastHeader: React.FC<SpotForecastHeaderProps> = ({ control, errors, fireNumbers, setValue }) => {
+  const latitude = useWatch({ control, name: 'latitude' })
+  const longitude = useWatch({ control, name: 'longitude' })
+  const selectedLocation = toNumericLocation(latitude, longitude)
+  const fireSizeLabels = fireNumbers?.length ? fireNumbers : ['Fire Size']
+
   return (
     <Grid size={12}>
       <Card>
@@ -67,7 +86,6 @@ const SpotForecastHeader: React.FC<SpotForecastHeaderProps> = ({ control, errors
                 control={control}
                 label="Latitude"
                 fullWidth
-                disabled
                 errorMessage={errors.latitude?.message}
               />
             </Grid>
@@ -77,8 +95,29 @@ const SpotForecastHeader: React.FC<SpotForecastHeaderProps> = ({ control, errors
                 control={control}
                 label="Longitude"
                 fullWidth
-                disabled
                 errorMessage={errors.longitude?.message}
+              />
+            </Grid>
+            <Grid size={12}>
+              <SpotRequestLocationMap
+                value={selectedLocation}
+                existingSpotRequests={[]}
+                onChange={location => {
+                  if (!location) {
+                    return
+                  }
+                  setValue('latitude', location.latitude.toFixed(6), { shouldValidate: true, shouldDirty: true })
+                  setValue('longitude', location.longitude.toFixed(6), { shouldValidate: true, shouldDirty: true })
+                }}
+              />
+            </Grid>
+            <Grid size={12}>
+              <ControlledForecastTextField
+                name="geographicDescription"
+                control={control}
+                label="Geographic Description"
+                fullWidth
+                errorMessage={errors.geographicDescription?.message}
               />
             </Grid>
             <Grid size={{ xs: 6, sm: 3 }}>
@@ -87,12 +126,11 @@ const SpotForecastHeader: React.FC<SpotForecastHeaderProps> = ({ control, errors
                 control={control}
                 label="Slope/Aspect"
                 fullWidth
-                disabled
                 errorMessage={errors.slopeAspect?.message}
               />
             </Grid>
             <Grid size={{ xs: 6, sm: 3 }}>
-              <ControlledForecastTextField name="valley" control={control} label="Valley" fullWidth disabled />
+              <ControlledForecastTextField name="valley" control={control} label="Valley" fullWidth />
             </Grid>
             <Grid size={6}>
               <ControlledForecastTextField
@@ -100,19 +138,27 @@ const SpotForecastHeader: React.FC<SpotForecastHeaderProps> = ({ control, errors
                 control={control}
                 label="Elevation"
                 fullWidth
-                disabled
                 endAdornment={<InputAdornment position="end">m</InputAdornment>}
               />
             </Grid>
-            <Grid size={{ xs: 12, sm: 6 }}>
-              <ControlledForecastTextField
-                name="size"
-                control={control}
-                label="Size (ha)"
-                fullWidth
-                disabled
-                endAdornment={<InputAdornment position="end">ha</InputAdornment>}
-              />
+            <Grid size={12}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                Fire Size(s)
+              </Typography>
+              <Grid container spacing={2}>
+                {fireSizeLabels.map((fireNumber, index) => (
+                  <Grid key={`${fireNumber}-${index}`} size={{ xs: 12, sm: 6 }}>
+                    <ControlledForecastTextField
+                      name={`fireSizes.${index}`}
+                      control={control}
+                      label={`${fireNumber} Size`}
+                      fullWidth
+                      errorMessage={getFireSizeErrorMessage(errors, index)}
+                      endAdornment={<InputAdornment position="end">ha</InputAdornment>}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
             </Grid>
           </Grid>
         </CardContent>

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/FullSpotForecast.tsx
@@ -27,6 +27,11 @@ const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
   </Box>
 )
 
+const formatFireSizes = (fireSizes: (number | null)[] | null | undefined) =>
+  fireSizes?.some(fireSize => fireSize !== null)
+    ? fireSizes.map(fireSize => (fireSize === null ? '—' : `${fireSize} ha`)).join(', ')
+    : null
+
 const Section = ({ title, children, contentSx }: { title: string; children: React.ReactNode; contentSx?: object }) => (
   <Paper variant="outlined" sx={{ p: 2.5, display: 'flex', flexDirection: 'column' }}>
     <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
@@ -62,6 +67,7 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
     representativeStations.length > 0
       ? representativeStations.map(s => `${s.name}${s.elevation != null ? ` (${s.elevation}m)` : ''}`).join(', ')
       : '—'
+  const forecastInstance = forecast.spot_request_instance
 
   const printableUrl = `${SMURFI_DASHBOARD_ROUTE}/${spotRequest.id}/forecasts/${forecast.id}/printable`
 
@@ -81,7 +87,7 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
           <Field label="Forecaster" value={forecast.forecaster_name} />
           <Field label="Email" value={forecast.forecaster_email} />
           {forecast.forecaster_phone && <Field label="Phone" value={forecast.forecaster_phone} />}
-          {forecast.fire_size != null && <Field label="Fire Size" value={`${forecast.fire_size} ha`} />}
+          {forecast.fire_size != null && <Field label="Fire Size(s)" value={formatFireSizes(forecast.fire_size)} />}
           <Box sx={{ gridColumn: '1 / -1' }}>
             <Field label="Representative Stations" value={stationsStr} />
           </Box>
@@ -89,12 +95,12 @@ const FullSpotForecast: React.FC<FullSpotForecastProps> = ({ forecast, spotReque
 
         <Section title="Location">
           <Box sx={{ gridColumn: '1 / -1' }}>
-            <Field label="Geographic Description" value={spotRequest.geographic_description} />
+            <Field label="Geographic Description" value={forecastInstance.geographic_description} />
           </Box>
-          <Field label="Latitude" value={spotRequest.latitude.toFixed(4)} />
-          <Field label="Longitude" value={spotRequest.longitude.toFixed(4)} />
-          <Field label="Elevation" value={spotRequest.elevation ? `${spotRequest.elevation} m` : '—'} />
-          <Field label="Slope / Aspect" value={spotRequest.aspect ?? '—'} />
+          <Field label="Latitude" value={forecastInstance.latitude.toFixed(4)} />
+          <Field label="Longitude" value={forecastInstance.longitude.toFixed(4)} />
+          <Field label="Elevation" value={forecastInstance.elevation ? `${forecastInstance.elevation} m` : '—'} />
+          <Field label="Slope / Aspect" value={forecastInstance.aspect ?? '—'} />
         </Section>
       </Box>
 

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/MiniSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/MiniSpotForecast.tsx
@@ -18,6 +18,7 @@ export interface MiniSpotForecastProps {
 
 const MiniSpotForecast: React.FC<MiniSpotForecastProps> = ({ forecast, spotRequest, representativeStations }) => {
   const stationsStr = formatStationsStr(representativeStations)
+  const forecastInstance = forecast.spot_request_instance
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -37,10 +38,10 @@ const MiniSpotForecast: React.FC<MiniSpotForecastProps> = ({ forecast, spotReque
 
         <Section title="Location">
           <Box sx={{ gridColumn: '1 / -1' }}>
-            <Field label="Geographic Description" value={spotRequest.geographic_description} />
+            <Field label="Geographic Description" value={forecastInstance.geographic_description} />
           </Box>
-          <Field label="Latitude" value={spotRequest.latitude.toFixed(4)} />
-          <Field label="Longitude" value={spotRequest.longitude.toFixed(4)} />
+          <Field label="Latitude" value={forecastInstance.latitude.toFixed(4)} />
+          <Field label="Longitude" value={forecastInstance.longitude.toFixed(4)} />
         </Section>
       </Box>
 

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableMiniSpotForecast.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/PrintableMiniSpotForecast.tsx
@@ -32,6 +32,7 @@ const PrintableMiniSpotForecast: React.FC<PrintableMiniSpotForecastProps> = ({
   const stationsStr = representativeStations
     .map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation} m)`))
     .join(', ')
+  const forecastInstance = forecast.spot_request_instance
 
   return (
     <Box sx={{ p: 3 }}>
@@ -41,11 +42,11 @@ const PrintableMiniSpotForecast: React.FC<PrintableMiniSpotForecastProps> = ({
       <Typography sx={{ fontSize: FONT_SIZE, textAlign: 'center', mb: 3 }}>{issuedDateStr}</Typography>
 
       <Typography sx={{ fontSize: FONT_SIZE, fontWeight: 'bold', lineHeight: 1.4 }}>
-        {spotRequest.geographic_description}
+        {forecastInstance.geographic_description}
       </Typography>
       <Typography sx={{ fontSize: FONT_SIZE, fontWeight: 'bold', mb: 2 }}>
-        <span style={{ textDecoration: 'underline' }}>Lat/Long:</span>{' '}
-        {spotRequest.latitude.toFixed(4)}, {spotRequest.longitude.toFixed(4)}
+        <span style={{ textDecoration: 'underline' }}>Lat/Long:</span> {forecastInstance.latitude.toFixed(4)},{' '}
+        {forecastInstance.longitude.toFixed(4)}
       </Typography>
 
       {stationsStr && (

--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastHeaderTable.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecastHeaderTable.tsx
@@ -13,6 +13,11 @@ const toDDM = (decimal: number): string => {
   return `${decimal < 0 ? '-' : ''}${degrees} ${minutes}`
 }
 
+const formatFireSizes = (fireSizes: (number | null)[] | null | undefined) =>
+  fireSizes?.some(fireSize => fireSize !== null)
+    ? fireSizes.map(fireSize => (fireSize === null ? '—' : `${fireSize} ha`)).join(', ')
+    : null
+
 const COLUMNS = '145px 210px 1fr 190px'
 
 const grid: React.CSSProperties = {
@@ -41,7 +46,11 @@ interface SpotForecastHeaderTableProps {
   representativeStations: RepresentativeStation[]
 }
 
-const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({ forecast, spotRequest, representativeStations }) => {
+const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({
+  forecast,
+  spotRequest,
+  representativeStations
+}) => {
   const issuedDt = DateTime.fromISO(forecast.issued_at).setZone(TIMEZONE)
   const expiryDt = forecast.expires_at ? DateTime.fromISO(forecast.expires_at).setZone(TIMEZONE) : null
 
@@ -53,6 +62,8 @@ const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({ forec
       ? representativeStations.map(s => s.name + (s.elevation == null ? '' : ` (${s.elevation}m)`)).join(', ')
       : '—'
   const fireNumberStr = spotRequest.fire_number?.join(', ') ?? '—'
+  const forecastInstance = forecast.spot_request_instance
+  const fireSizeStr = formatFireSizes(forecast.fire_size)
 
   return (
     <Box>
@@ -81,7 +92,7 @@ const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({ forec
         <div style={cell}>Phone: {forecast.forecaster_phone ?? '—'}</div>
 
         <div style={cell}>Geographic</div>
-        <div style={cell}>{spotRequest.geographic_description}</div>
+        <div style={cell}>{forecastInstance.geographic_description}</div>
         <div style={span2}>
           Representative <span style={{ textDecoration: 'underline' }}>Stations</span>: {stationsStr}
         </div>
@@ -90,17 +101,17 @@ const SpotForecastHeaderTable: React.FC<SpotForecastHeaderTableProps> = ({ forec
           Coordinates (<span style={{ textDecoration: 'underline' }}>approx</span>)
         </div>
         <div style={cell}>
-          {toDDM(spotRequest.latitude)},{toDDM(spotRequest.longitude)}
+          {toDDM(forecastInstance.latitude)},{toDDM(forecastInstance.longitude)}
         </div>
         <div style={cell}>
           Slope/aspect:{'  '}
-          {spotRequest.aspect ?? '—'}
+          {forecastInstance.aspect ?? '—'}
         </div>
         <div style={cell} />
 
         <div style={cell}>Elevation</div>
-        <div style={cell}>{spotRequest.elevation ? `${spotRequest.elevation} m` : '—'}</div>
-        <div style={cell}>{forecast.fire_size ? `Size:   ${forecast.fire_size} ha` : ''}</div>
+        <div style={cell}>{forecastInstance.elevation ? `${forecastInstance.elevation} m` : '—'}</div>
+        <div style={cell}>{fireSizeStr ? `Size:   ${fireSizeStr}` : ''}</div>
         <div style={cell} />
       </div>
     </Box>

--- a/web/apps/wps-web/src/features/smurfi/components/map/SMURFIMap.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/map/SMURFIMap.tsx
@@ -79,8 +79,8 @@ const COORDINATE_TOLERANCE = 0.0001
 const formatFireNumbers = (fireNumbers: string[] | null | undefined) => fireNumbers?.join(', ') ?? ''
 
 const buildSpotFeature = (spotRequest: SpotRequestOutput): SpotFeature => ({
-  lon: spotRequest.longitude,
-  lat: spotRequest.latitude,
+  lon: spotRequest.current_instance.longitude,
+  lat: spotRequest.current_instance.latitude,
   status: spotRequest.status,
   id: String(spotRequest.id),
   spotId: spotRequest.id,

--- a/web/apps/wps-web/src/features/smurfi/components/map/SmurfiRequestsMap.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/map/SmurfiRequestsMap.tsx
@@ -2,7 +2,7 @@ import { BASEMAP_LAYER_NAME } from '@/features/sfmsInsights/components/map/layer
 import { BASEMAP_STYLE_URL, BASEMAP_TILE_URL } from '@wps/utils/env'
 import { BC_EXTENT } from '@wps/utils/constants'
 import { createVectorTileLayer, getStyleJson } from '@wps/utils/vectorLayerUtils'
-import { SpotRequestOutput, SpotRequestStatus } from '@wps/api/SMURFIAPI'
+import { SpotRequestInstanceOutput, SpotRequestOutput, SpotRequestStatus } from '@wps/api/SMURFIAPI'
 import { Box } from '@mui/material'
 import { boundingExtent } from 'ol/extent'
 import { Feature, Map, View } from 'ol'
@@ -24,6 +24,7 @@ import { createSpotStatusIcon } from '@/features/smurfi/components/map/SpotStatu
 
 interface SmurfiRequestsMapProps {
   spotRequest: SpotRequestOutput
+  spotRequestInstance?: SpotRequestInstanceOutput
 }
 
 const bcExtent = boundingExtent(BC_EXTENT.map(coord => fromLonLat(coord)))
@@ -33,15 +34,16 @@ const getMarkerStyle = (status: SpotRequestStatus) =>
     image: createSpotStatusIcon(status)
   })
 
-const SmurfiRequestsMap = ({ spotRequest }: SmurfiRequestsMapProps) => {
+const SmurfiRequestsMap = ({ spotRequest, spotRequestInstance }: SmurfiRequestsMapProps) => {
   const mapRef = useRef<HTMLDivElement | null>(null)
   const popupRef = useRef<HTMLDivElement | null>(null)
   const [firePopupAttributes, setFirePopupAttributes] = useState<CurrentFirePolygonAttributes | null>(null)
+  const spotInstance = spotRequestInstance ?? spotRequest.current_instance
 
   useEffect(() => {
     if (!mapRef.current) return
 
-    const coord = fromLonLat([Number(spotRequest.longitude), Number(spotRequest.latitude)])
+    const coord = fromLonLat([Number(spotInstance.longitude), Number(spotInstance.latitude)])
 
     const marker = new Feature({ geometry: new Point(coord) })
     marker.setStyle(getMarkerStyle(spotRequest.status as SpotRequestStatus))
@@ -102,7 +104,7 @@ const SmurfiRequestsMap = ({ spotRequest }: SmurfiRequestsMapProps) => {
     return () => {
       mapObject.setTarget('')
     }
-  }, [spotRequest.latitude, spotRequest.longitude])
+  }, [spotInstance.latitude, spotInstance.longitude, spotRequest.status])
 
   return (
     <Box sx={{ position: 'relative', width: '100%', height: '100%', minHeight: 300 }}>

--- a/web/apps/wps-web/src/features/smurfi/components/map/SpotPopup.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/map/SpotPopup.tsx
@@ -43,6 +43,7 @@ const SpotPopup: React.FC<SpotPopupProps> = ({
   const isLoading = useSelector(selectSubscriptionsLoading)
   const isSubscribed = subscribedIds.includes(spotId)
   const statusColors = SpotRequestStatusColorMap[status]
+  const locationLabel = spotRequest.latest_forecast ? 'Last forecasted location' : 'Requested location'
 
   const handleRequestClick = (event: React.MouseEvent) => {
     event.stopPropagation()
@@ -111,9 +112,14 @@ const SpotPopup: React.FC<SpotPopupProps> = ({
           </Button>
         </Box>
       </Box>
-      <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
-        Lat: {lat.toFixed(6)}, Lng: {lng.toFixed(6)}
-      </Typography>
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase' }}>
+          {locationLabel}
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          Lat: {lat.toFixed(6)}, Lng: {lng.toFixed(6)}
+        </Typography>
+      </Box>
       <Box sx={{ display: 'flex', gap: 1 }}>
         <Button variant="outlined" color="primary" size="small" fullWidth onClick={handleRequestClick}>
           View Request

--- a/web/apps/wps-web/src/features/smurfi/components/map/currentFirePolygonsLayer.ts
+++ b/web/apps/wps-web/src/features/smurfi/components/map/currentFirePolygonsLayer.ts
@@ -27,6 +27,34 @@ currentFirePolygonsUrl.search = new URLSearchParams({
   CQL_FILTER: ACTIVE_FIRE_FILTER
 }).toString()
 
+const buildCurrentFirePolygonsUrl = (cqlFilter: string) => {
+  const url = new URL(CURRENT_FIRE_POLYS_WFS_URL)
+  url.search = new URLSearchParams({
+    service: 'WFS',
+    version: '2.0.0',
+    request: 'GetFeature',
+    typeNames: CURRENT_FIRE_POLYS_TYPE_NAME,
+    outputFormat: 'application/json',
+    srsName: 'EPSG:4326',
+    CQL_FILTER: cqlFilter
+  }).toString()
+  return url.toString()
+}
+
+export const fetchCurrentFireSizeByFireNumber = async (fireNumber: string): Promise<number | null> => {
+  const escapedFireNumber = fireNumber.replaceAll("'", "''")
+  const response = await fetch(
+    buildCurrentFirePolygonsUrl(`${ACTIVE_FIRE_FILTER} AND FIRE_NUMBER = '${escapedFireNumber}'`)
+  )
+  const data = await response.json()
+  const fireSize = data?.features?.[0]?.properties?.FIRE_SIZE_HECTARES
+  const numericFireSize = Number(fireSize)
+  return Number.isFinite(numericFireSize) ? numericFireSize : null
+}
+
+export const fetchCurrentFireSizesByFireNumbers = async (fireNumbers: string[]): Promise<(number | null)[]> =>
+  Promise.all(fireNumbers.map(fetchCurrentFireSizeByFireNumber))
+
 const createFireLabel = (feature: { get: (property: string) => string | undefined }, resolution: number) => {
   if (resolution > FIRE_LABEL_MAX_RESOLUTION) {
     return undefined

--- a/web/apps/wps-web/src/features/smurfi/components/requestForm/SpotRequestForm.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/requestForm/SpotRequestForm.tsx
@@ -28,7 +28,6 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { DatePicker } from '@mui/x-date-pickers-pro'
 import {
   requestedFrequencyOptions,
-  slopeAspectOptions,
   spotForecastTypes,
   spotRequestSchema,
   SpotRequestFormData,
@@ -133,7 +132,7 @@ const defaultValues: SpotRequestFormValues = {
   requestedFrequency: [],
   location: null,
   geographicDescription: '',
-  slopeAspect: 'North',
+  slopeAspect: '',
   elevation: '',
   additionalInformation: ''
 }
@@ -439,17 +438,13 @@ const SpotRequestForm: React.FC<SpotRequestFormProps> = ({ onCancel, onSubmit })
             name="slopeAspect"
             control={control}
             render={({ field }) => (
-              <FormControl fullWidth error={!!errors.slopeAspect}>
-                <InputLabel id="slope-aspect-label">Slope/Aspect</InputLabel>
-                <Select {...field} labelId="slope-aspect-label" label="Slope/Aspect">
-                  {slopeAspectOptions.map(option => (
-                    <MenuItem key={option} value={option}>
-                      {option}
-                    </MenuItem>
-                  ))}
-                </Select>
-                <FormHelperText>{errors.slopeAspect?.message}</FormHelperText>
-              </FormControl>
+              <TextField
+                {...field}
+                label="Slope/Aspect"
+                fullWidth
+                error={!!errors.slopeAspect}
+                helperText={errors.slopeAspect?.message ?? 'Optional'}
+              />
             )}
           />
         </Grid>
@@ -464,7 +459,7 @@ const SpotRequestForm: React.FC<SpotRequestFormProps> = ({ onCancel, onSubmit })
                 type="number"
                 fullWidth
                 error={!!errors.elevation}
-                helperText={errors.elevation?.message}
+                helperText={errors.elevation?.message ?? 'Optional'}
                 slotProps={{
                   input: {
                     endAdornment: <InputAdornment position="end">m</InputAdornment>

--- a/web/apps/wps-web/src/features/smurfi/components/requestForm/SpotRequestLocationMap.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/requestForm/SpotRequestLocationMap.tsx
@@ -153,7 +153,9 @@ const SpotRequestLocationMap: React.FC<SpotRequestLocationMapProps> = ({ value, 
         .map(
           spotRequest =>
             new Feature({
-              geometry: new Point(fromLonLat([spotRequest.longitude, spotRequest.latitude])),
+              geometry: new Point(
+                fromLonLat([spotRequest.current_instance.longitude, spotRequest.current_instance.latitude])
+              ),
               status: spotRequest.status
             })
         )

--- a/web/apps/wps-web/src/features/smurfi/components/requests/SpotRequest.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/requests/SpotRequest.tsx
@@ -81,6 +81,7 @@ const SpotRequest = () => {
     String(spotRequest.fire_centre)
 
   const statusColors = SpotRequestStatusColorMap[spotRequest.status as SpotRequestStatus]
+  const requestInstance = spotRequest.initial_instance
 
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2, alignItems: 'stretch' }}>
@@ -89,11 +90,7 @@ const SpotRequest = () => {
           title="Request Details"
           action={
             <Box sx={{ display: 'flex', gap: 1 }}>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={() => dispatch(toggleSpotSubscription(spotRequest.id))}
-              >
+              <Button variant="outlined" size="small" onClick={() => dispatch(toggleSpotSubscription(spotRequest.id))}>
                 {isSubscribed ? 'Unsubscribe' : 'Subscribe'}
               </Button>
               <Button
@@ -104,97 +101,93 @@ const SpotRequest = () => {
                 View Forecasts
               </Button>
               {(isOwner || isForecaster) && (
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={() => console.log(spotRequest.requestor_idir)}
-                >
+                <Button variant="outlined" size="small" onClick={() => console.log(spotRequest.requestor_idir)}>
                   Edit Request
                 </Button>
               )}
             </Box>
           }
         >
-        <Box>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, display: 'block' }}
-          >
-            Status
-          </Typography>
-          <Box
-            sx={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              backgroundColor: statusColors?.bgColor,
-              borderRadius: '4px',
-              px: 1.5,
-              py: 0.25,
-              border: 1,
-              borderColor: statusColors?.borderColor,
-              mt: 0.25
-            }}
-          >
-            <Typography variant="body2" sx={{ color: statusColors?.color, fontWeight: 500 }}>
-              {spotRequest.status}
-            </Typography>
-          </Box>
-        </Box>
-        <Box>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, display: 'block' }}
-          >
-            Fire Number(s)
-          </Typography>
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
-            {spotRequest.fire_number.map(fn => (
-              <Chip key={fn} label={fn} size="small" />
-            ))}
-          </Box>
-        </Box>
-        <Field label="Fire Centre" value={fireCentreName} />
-        <Field label="Forecast Type" value={spotRequest.request_type} />
-        <Field label="Start Date" value={formatDate(spotRequest.start_at)} />
-        <Field label="End Date" value={formatDate(spotRequest.end_at)} />
-        <Box>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, display: 'block' }}
-          >
-            Requested Frequency
-          </Typography>
-          <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(4, max-content)', gap: 0.5, mt: 0.5 }}>
-            {spotRequest.request_frequency.map(day => (
-              <Chip key={day} label={day} size="small" />
-            ))}
-          </Box>
-        </Box>
-        <Field label="Geographic Description" value={spotRequest.geographic_description} />
-        <Field label="Elevation" value={`${spotRequest.elevation} m`} />
-        <Field label="Slope / Aspect" value={spotRequest.aspect} />
-        {spotRequest.additional_information && (
-          <Field label="Additional Info" value={spotRequest.additional_information} />
-        )}
-        {spotRequest.subscribers.length > 0 && (
           <Box>
             <Typography
               variant="caption"
               color="text.secondary"
               sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, display: 'block' }}
             >
-              Subscribers
+              Status
+            </Typography>
+            <Box
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                backgroundColor: statusColors?.bgColor,
+                borderRadius: '4px',
+                px: 1.5,
+                py: 0.25,
+                border: 1,
+                borderColor: statusColors?.borderColor,
+                mt: 0.25
+              }}
+            >
+              <Typography variant="body2" sx={{ color: statusColors?.color, fontWeight: 500 }}>
+                {spotRequest.status}
+              </Typography>
+            </Box>
+          </Box>
+          <Box>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, display: 'block' }}
+            >
+              Fire Number(s)
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
-              {spotRequest.subscribers.map(sub => (
-                <Chip key={sub.email} label={sub.email} size="small" />
+              {spotRequest.fire_number.map(fn => (
+                <Chip key={fn} label={fn} size="small" />
               ))}
             </Box>
           </Box>
-        )}
+          <Field label="Fire Centre" value={fireCentreName} />
+          <Field label="Forecast Type" value={spotRequest.request_type} />
+          <Field label="Start Date" value={formatDate(spotRequest.start_at)} />
+          <Field label="End Date" value={formatDate(spotRequest.end_at)} />
+          <Box>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, display: 'block' }}
+            >
+              Requested Frequency
+            </Typography>
+            <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(4, max-content)', gap: 0.5, mt: 0.5 }}>
+              {spotRequest.request_frequency.map(day => (
+                <Chip key={day} label={day} size="small" />
+              ))}
+            </Box>
+          </Box>
+          <Field label="Geographic Description" value={requestInstance.geographic_description} />
+          <Field label="Elevation" value={requestInstance.elevation ? `${requestInstance.elevation} m` : '—'} />
+          <Field label="Slope / Aspect" value={requestInstance.aspect ?? '—'} />
+          {spotRequest.additional_information && (
+            <Field label="Additional Info" value={spotRequest.additional_information} />
+          )}
+          {spotRequest.subscribers.length > 0 && (
+            <Box>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, display: 'block' }}
+              >
+                Subscribers
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+                {spotRequest.subscribers.map(sub => (
+                  <Chip key={sub.email} label={sub.email} size="small" />
+                ))}
+              </Box>
+            </Box>
+          )}
         </Section>
         <Section title="Requestor Details">
           <Field label="Requestor Name" value={spotRequest.requestor_name} />
@@ -205,10 +198,10 @@ const SpotRequest = () => {
       </Box>
 
       <Section title="Location" sx={{ height: '100%' }} contentSx={{ gridTemplateRows: 'auto 1fr' }}>
-        <Field label="Latitude" value={Number(spotRequest.latitude).toFixed(4)} />
-        <Field label="Longitude" value={Number(spotRequest.longitude).toFixed(4)} />
+        <Field label="Latitude" value={Number(requestInstance.latitude).toFixed(4)} />
+        <Field label="Longitude" value={Number(requestInstance.longitude).toFixed(4)} />
         <Box sx={{ gridColumn: '1 / -1', minHeight: 0, border: '1px solid black' }}>
-          <SmurfiRequestsMap spotRequest={spotRequest} />
+          <SmurfiRequestsMap spotRequest={spotRequest} spotRequestInstance={requestInstance} />
         </Box>
       </Section>
     </Box>

--- a/web/apps/wps-web/src/features/smurfi/constants/spotForecastDefaults.ts
+++ b/web/apps/wps-web/src/features/smurfi/constants/spotForecastDefaults.ts
@@ -30,10 +30,11 @@ export const getDefaultValues = (): Partial<SpotFormData> => ({
   stns: [],
   latitude: '',
   longitude: '',
+  geographicDescription: '',
   slopeAspect: '',
   valley: '',
   elevation: '',
-  size: '',
+  fireSizes: [],
   synopsis: '',
   afternoonForecast: {
     description: '',

--- a/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
+++ b/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
@@ -6,7 +6,6 @@ import { ErrorBoundary } from '@wps/ui/ErrorBoundary'
 import { AdapterLuxon } from '@mui/x-date-pickers-pro/AdapterLuxon'
 import { LocalizationProvider } from '@mui/x-date-pickers-pro/LocalizationProvider'
 import { SMURFI_DASHBOARD_ROUTE, SMURFI_MAP_ROUTE, SMURFI_MANAGEMENT_ROUTE } from '@wps/utils/constants'
-import SMURFIMap from '@/features/smurfi/components/map/SMURFIMap'
 import SpotRequests from '@/features/smurfi/components/requests/SpotRequests'
 import SpotRequest from '@/features/smurfi/components/requests/SpotRequest'
 import SpotForecasts from '@/features/smurfi/components/forecasts/SpotForecasts'
@@ -18,6 +17,7 @@ import { AppDispatch } from '@/app/store'
 import { useDispatch } from 'react-redux'
 import { fetchSpotRequests } from '@/features/smurfi/slices/smurfiSlice'
 import { fetchFireCentres } from '@/commonSlices/fireCentresSlice'
+import SMURFIMap from '@/features/smurfi/components/map/SMURFIMap'
 
 const TAB_ROUTES = [SMURFI_DASHBOARD_ROUTE, SMURFI_MAP_ROUTE, SMURFI_MANAGEMENT_ROUTE]
 
@@ -48,7 +48,7 @@ const SMURFIPage = () => {
           <GeneralHeader isBeta={true} spacing={1} title="SMURFI" />
           <Tabs value={currentTab} onChange={handleChange}>
             <Tab label="Dashboard" onClick={() => navigate(SMURFI_DASHBOARD_ROUTE)} />
-            <Tab label="Map" />
+            <Tab label="Map" onClick={() => navigate(SMURFI_MAP_ROUTE)} />
           </Tabs>
         </Box>
         <Box sx={{ flex: 1, minHeight: 0, display: 'flex' }}>

--- a/web/apps/wps-web/src/features/smurfi/slices/smurfiSlice.ts
+++ b/web/apps/wps-web/src/features/smurfi/slices/smurfiSlice.ts
@@ -73,9 +73,9 @@ const smurfiSlice = createSlice({
       state.spotForecastSubmitting = false
       state.spotForecastSubmitError = null
       state.submittedSpotForecast = action.payload.spotForecast
-      state.spotForecastsByRequestId[action.payload.spotForecast.spot_request_id] = [
+      state.spotForecastsByRequestId[action.payload.spotForecast.spot_request_base_id] = [
         action.payload.spotForecast,
-        ...(state.spotForecastsByRequestId[action.payload.spotForecast.spot_request_id] ?? [])
+        ...(state.spotForecastsByRequestId[action.payload.spotForecast.spot_request_base_id] ?? [])
       ]
     },
     clearSpotForecastSubmitState(state: SmurfiState) {

--- a/web/packages/api/src/SMURFIAPI.ts
+++ b/web/packages/api/src/SMURFIAPI.ts
@@ -47,14 +47,15 @@ interface SpotTabularWeatherInput {
 }
 
 export interface SpotForecastInput {
-  spot_request_id: number
+  spot_request_base_id: number
+  spot_request_instance: SpotRequestInstanceInput
   issued_at: string
   expires_at?: string | null
   synopsis?: string
   inversion_and_venting?: string
   outlook?: string
   confidence?: string
-  fire_size?: number | null
+  fire_size?: (number | null)[] | null
   representative_station_codes?: number[]
   descriptive_weather: SpotDescriptiveWeatherInput[]
   tabular_weather: SpotTabularWeatherInput[]
@@ -70,6 +71,8 @@ interface SpotTabularWeatherOutput extends SpotTabularWeatherInput {
 
 export interface SpotForecastOutput extends Omit<SpotForecastInput, 'descriptive_weather' | 'tabular_weather'> {
   id: number
+  spot_request_instance_id: number
+  spot_request_instance: SpotRequestInstanceOutput
   created_at: string
   forecaster_name: string
   forecaster_email: string
@@ -84,6 +87,20 @@ const toNullableNumber = (value: string | undefined): number | null => {
   }
   const numberValue = Number(value)
   return Number.isFinite(numberValue) ? numberValue : null
+}
+
+const toNullableNumberList = (values: (string | undefined)[] | undefined): (number | null)[] | null => {
+  if (!values?.length) {
+    return null
+  }
+
+  const numberValues = values.map(toNullableNumber)
+  return numberValues.some(value => value !== null) ? numberValues : null
+}
+
+const toNullableInteger = (value: string | undefined): number | null => {
+  const numberValue = toNullableNumber(value)
+  return numberValue === null ? null : Math.trunc(numberValue)
 }
 
 const toForecastTimeISO = (dateTime: string) => {
@@ -120,12 +137,20 @@ const marshalFormDataToSpotForecastInput = (formData: SpotFormData, spotRequestI
   ].filter(weather => weather !== undefined)
 
   return {
-    spot_request_id: spotRequestId,
+    spot_request_base_id: spotRequestId,
+    spot_request_instance: {
+      geographic_description: formData.geographicDescription,
+      aspect: formData.slopeAspect,
+      elevation: toNullableInteger(formData.elevation),
+      valley: formData.valley || null,
+      latitude: Number(formData.latitude),
+      longitude: Number(formData.longitude)
+    },
     synopsis: formData.synopsis,
     inversion_and_venting: formData.inversionVenting,
     outlook: formData.outlook,
     confidence: formData.confidenceDiscussion,
-    fire_size: toNullableNumber(formData.size),
+    fire_size: toNullableNumberList(formData.fireSizes),
     representative_station_codes: formData.stns,
     issued_at: formData.issuedDate.toISO()!,
     expires_at: formData.expiryDate.toISO(),
@@ -164,19 +189,27 @@ export interface SpotLatestForecast {
   forecaster_name?: string | null
 }
 
-interface SpotRequestBase {
+export interface SpotRequestInstanceInput {
+  geographic_description: string
+  aspect?: string | null
+  elevation?: number | null
+  valley?: string | null
+  latitude: number
+  longitude: number
+}
+
+export interface SpotRequestInstanceOutput extends SpotRequestInstanceInput {
+  id: number
+}
+
+interface SpotRequestFields {
   request_reference: string
   fire_number: string[]
   fire_centre: number
   status: SpotRequestStatus
   request_frequency: string[]
   request_type: string
-  aspect: string
-  elevation: number
-  geographic_description: string
   additional_information?: string
-  latitude: number
-  longitude: number
   requested_at: string
   start_at: string
   end_at: string
@@ -184,12 +217,15 @@ interface SpotRequestBase {
   latest_forecast?: SpotLatestForecast | null
 }
 
-export interface SpotRequestInput extends SpotRequestBase {
+export interface SpotRequestInput extends SpotRequestFields {
   id: number | null
+  initial_instance: SpotRequestInstanceInput
 }
 
-export interface SpotRequestOutput extends SpotRequestBase {
+export interface SpotRequestOutput extends SpotRequestFields {
   id: number
+  initial_instance: SpotRequestInstanceOutput
+  current_instance: SpotRequestInstanceOutput
   requestor_name: string
   requestor_idir: string
   requestor_email: string
@@ -224,12 +260,15 @@ const marshalFormDataToSpotRequestInput = (formData: SpotRequestFormData): SpotR
     status: SpotRequestStatus.REQUESTED,
     request_frequency: formData.requestedFrequency,
     request_type: spotRequestTypeMap[formData.forecastType],
-    aspect: formData.slopeAspect,
-    elevation: Number(formData.elevation),
-    geographic_description: formData.geographicDescription,
     additional_information: formData.additionalInformation || undefined,
-    latitude: formData.location.latitude,
-    longitude: formData.location.longitude,
+    initial_instance: {
+      geographic_description: formData.geographicDescription,
+      aspect: formData.slopeAspect || null,
+      elevation: toNullableInteger(formData.elevation),
+      valley: null,
+      latitude: formData.location.latitude,
+      longitude: formData.location.longitude
+    },
     requested_at: new Date().toISOString(),
     start_at: toStartOfDayISO(formData.forecastStartDate),
     end_at: toEndOfDayISO(formData.forecastEndDate),

--- a/web/packages/api/src/schema/spotForecastSchema.ts
+++ b/web/packages/api/src/schema/spotForecastSchema.ts
@@ -24,6 +24,11 @@ const requiredNumericString = (rangeMessage: string, isInRange: (value: number) 
     return Number.isFinite(num) && isInRange(num)
   }, rangeMessage)
 
+const requiredWholeNumberString = (numberMessage: string, integerMessage: string) =>
+  requiredString()
+    .refine(value => Number.isFinite(Number(value)), numberMessage)
+    .refine(value => Number.isInteger(Number(value)), integerMessage)
+
 const requiredTabularWeatherDateTime = () =>
   requiredString('Date/Time required').refine(value => {
     const parsedDateTime = DateTime.fromFormat(value, tabularWeatherDateTimeFormat, { zone: 'America/Vancouver' })
@@ -55,10 +60,11 @@ export const createSchema = (isMini: boolean) => {
       'Longitude must be a negative number between -180 and 0',
       num => num >= -180 && num <= 0
     ),
+    geographicDescription: requiredString(),
     slopeAspect: requiredString(),
     valley: z.string().optional(),
-    elevation: z.string().optional(),
-    size: z.string().optional(),
+    elevation: requiredWholeNumberString('Elevation must be a number', 'Elevation must be a whole number'),
+    fireSizes: z.array(optionalNumericString('Must be a number')).optional(),
     synopsis: requiredString(),
     afternoonForecast: z
       .object({

--- a/web/packages/api/src/schema/spotRequestSchema.ts
+++ b/web/packages/api/src/schema/spotRequestSchema.ts
@@ -13,18 +13,8 @@ export const requestedFrequencyOptions = [
   'Saturday'
 ] as const
 
-export const slopeAspectOptions = [
-  'Northwest',
-  'North',
-  'Northeast',
-  'East',
-  'Southeast',
-  'South',
-  'Southwest',
-  'West'
-] as const
-
 const requiredString = (message = 'Required') => z.string().trim().min(1, message)
+const optionalString = () => z.string().trim().optional()
 
 const validDateTime = (message = 'Invalid date/time') =>
   z.custom<DateTime>((val): val is DateTime => DateTime.isDateTime(val) && val.isValid, {
@@ -54,12 +44,10 @@ export const spotRequestSchema = z
       })
       .transform(value => value as SpotRequestCoordinate),
     geographicDescription: requiredString(),
-    slopeAspect: z.enum(slopeAspectOptions, {
-      errorMap: () => ({ message: 'Required' })
-    }),
-    elevation: requiredString()
-      .refine(value => Number.isFinite(Number(value)), 'Elevation must be a number')
-      .refine(value => Number.isInteger(Number(value)), 'Elevation must be a whole number'),
+    slopeAspect: optionalString(),
+    elevation: optionalString()
+      .refine(value => !value || Number.isFinite(Number(value)), 'Elevation must be a number')
+      .refine(value => !value || Number.isInteger(Number(value)), 'Elevation must be a whole number'),
     additionalInformation: z.string().optional()
   })
   .refine(data => data.forecastEndDate.toMillis() >= data.forecastStartDate.toMillis(), {


### PR DESCRIPTION
- Models the backend data as `SpotRequestBase`, `SpotRequestInstance`, `SpotForecast`
- Changes slope/aspect to be a string field with no dropdown. In forecasts I've seen that values can be all over the place. ie 'Steep North face', 'Flat/variable', 'Variable'
   - These are optional on the request form, required on the forecast form
- Adds functionality to prepopulate fire sizes for the forecast form if they exist  