### PR TITLE
forecast list

### DIFF
--- a/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecasts.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/forecasts/SpotForecasts.tsx
@@ -1,14 +1,26 @@
 import { AppDispatch } from '@/app/store'
+import { selectFireCentres } from '@/app/rootReducer'
 import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
-import { Box, CircularProgress, Typography } from '@mui/material'
+import { formatDateTime, TIMEZONE } from '@/features/smurfi/utils/spotForecastUtils'
+import { DateTime } from 'luxon'
+import useSpotPermissions from '@/features/smurfi/hooks/useSpotPermissions'
+import { SpotRequestStatusColorMap } from '@/features/smurfi/interfaces'
+import { Field } from '@/features/smurfi/components/forecasts/SpotForecastComponents'
+import { formatRequestFrequency, formatSpotRequestDate } from '@/features/smurfi/utils/spotRequestFormatters'
+import { Box, Button, CircularProgress, Divider, Paper, Typography } from '@mui/material'
+import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro'
+import { SpotRequestStatus } from '@wps/api/SMURFIAPI'
+import { SMURFI_DASHBOARD_ROUTE } from '@wps/utils/constants'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 
 const SpotForecasts = () => {
   const { id } = useParams<{ id: string }>()
   const dispatch = useDispatch<AppDispatch>()
-  const { spotForecastsByRequestId, spotForecastsLoading } = useSelector(selectSmurfi)
+  const navigate = useNavigate()
+  const { spotRequests, spotForecastsByRequestId, spotForecastsLoading } = useSelector(selectSmurfi)
+  const { fireCentres } = useSelector(selectFireCentres)
 
   const spotRequestId = Number(id)
 
@@ -18,17 +30,146 @@ const SpotForecasts = () => {
     }
   }, [dispatch, spotRequestId, spotForecastsByRequestId])
 
+  const spotRequest = spotRequests.find(sr => sr.id === spotRequestId)
+  const { isForecaster } = useSpotPermissions(spotRequest)
+
   if (spotForecastsLoading) {
     return <CircularProgress />
   }
 
-  const forecasts = spotForecastsByRequestId[spotRequestId] ?? []
+  const fireNumber = spotRequest?.fire_number?.join(', ') ?? '—'
+  const fireCentreName = spotRequest
+    ? (fireCentres.find(fc => fc.id === spotRequest.fire_centre)?.name ?? String(spotRequest.fire_centre)).replace(
+        / Fire Centre$/,
+        ''
+      )
+    : '—'
+  const status = spotRequest?.status
+  const statusBadge = status ? (
+    <Box
+      sx={{
+        backgroundColor: SpotRequestStatusColorMap[status as SpotRequestStatus].bgColor,
+        borderRadius: '4px',
+        display: 'inline-flex',
+        alignItems: 'center',
+        px: 1,
+        py: 0.25,
+        borderWidth: 1,
+        borderStyle: 'solid',
+        borderColor: SpotRequestStatusColorMap[status as SpotRequestStatus].borderColor
+      }}
+    >
+      <Typography variant="body2" sx={{ color: SpotRequestStatusColorMap[status as SpotRequestStatus].color }}>
+        {status}
+      </Typography>
+    </Box>
+  ) : undefined
+
+  const rows = spotForecastsByRequestId[spotRequestId] ?? []
+
+  const columns: GridColDef<(typeof rows)[number]>[] = [
+    { field: 'id', headerName: 'ID', width: 80 },
+    {
+      field: 'issued_at',
+      headerName: 'Issued At',
+      width: 230,
+      renderCell: params => formatDateTime(params.value)
+    },
+    {
+      field: 'expires_at',
+      headerName: 'Expires At',
+      width: 230,
+      renderCell: params => {
+        if (!params.value) return '—'
+        const dt = DateTime.fromISO(params.value).setZone(TIMEZONE)
+        return dt.isValid ? dt.toFormat('EEE, MMM d, yyyy') : params.value
+      }
+    },
+    { field: 'forecaster_name', headerName: 'Forecaster', width: 180 },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      width: 160,
+      sortable: false,
+      renderCell: params => (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, height: '100%' }}>
+          <Button
+            size="small"
+            variant="text"
+            onClick={() => navigate(`${SMURFI_DASHBOARD_ROUTE}/${spotRequestId}/forecasts/${params.row.id}`)}
+          >
+            View
+          </Button>
+          {params.api.getSortedRowIds()[0] === params.id && (
+            <Button
+              size="small"
+              variant="text"
+              onClick={() => navigate(`${SMURFI_DASHBOARD_ROUTE}/${spotRequestId}/forecasts/${params.row.id}/edit`)}
+            >
+              Edit
+            </Button>
+          )}
+        </Box>
+      )
+    }
+  ]
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
-      <Typography>
-        Spot forecasts for request {id} — {forecasts.length} forecast(s)
-      </Typography>
+      <Paper variant="outlined" sx={{ p: 2.5, display: 'flex', flexDirection: 'column', mb: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 600, letterSpacing: 1.5 }}>
+            Request Info
+          </Typography>
+          {statusBadge}
+        </Box>
+        <Divider sx={{ mt: 0.5, mb: 2 }} />
+        <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 2 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Field label="Start Date" value={formatSpotRequestDate(spotRequest?.start_at) ?? '—'} />
+            <Field label="End Date" value={formatSpotRequestDate(spotRequest?.end_at) ?? '—'} />
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Field label="Request Type" value={spotRequest?.request_type ?? '—'} />
+            <Field label="Request Frequency" value={formatRequestFrequency(spotRequest?.request_frequency)} />
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Field label="Fire Number" value={fireNumber} />
+            <Field label="Fire Centre" value={fireCentreName} />
+          </Box>
+        </Box>
+      </Paper>
+      {isForecaster && (
+        <Box sx={{ mb: 1 }}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => navigate(`${SMURFI_DASHBOARD_ROUTE}/${spotRequestId}/forecasts/new`)}
+          >
+            New Forecast
+          </Button>
+        </Box>
+      )}
+      <DataGridPro
+        columns={columns}
+        rows={rows}
+        disableColumnFilter
+        disableColumnPinning
+        disableColumnReorder
+        disableColumnSelector
+        disableRowSelectionOnClick
+        initialState={{
+          sorting: {
+            sortModel: [{ field: 'issued_at', sort: 'desc' }]
+          }
+        }}
+        getCellClassName={params => {
+          if (!params.row.expires_at) return ''
+          const expiry = DateTime.fromISO(params.row.expires_at).setZone(TIMEZONE)
+          return expiry.isValid && expiry < DateTime.now() ? 'expired-cell' : ''
+        }}
+        sx={{ '& .expired-cell': { opacity: 0.4 } }}
+      />
     </Box>
   )
 }

--- a/web/apps/wps-web/src/features/smurfi/components/requests/SpotRequests.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/requests/SpotRequests.tsx
@@ -12,16 +12,16 @@ import {
   TextField,
   Typography
 } from '@mui/material'
+import { LocalizationProvider } from '@mui/x-date-pickers-pro'
+import { AdapterLuxon } from '@mui/x-date-pickers-pro/AdapterLuxon'
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker'
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField'
 import { SpotRequestStatus } from '@wps/api/SMURFIAPI'
+import { SMURFI_DASHBOARD_ROUTE } from '@wps/utils/constants'
 import { DateTime } from 'luxon'
 import React, { useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
-import { LocalizationProvider } from '@mui/x-date-pickers-pro'
-import { AdapterLuxon } from '@mui/x-date-pickers-pro/AdapterLuxon'
 import { useNavigate } from 'react-router-dom'
-import { SMURFI_DASHBOARD_ROUTE } from '@wps/utils/constants'
 
 const SpotRequests: React.FC = () => {
   const navigate = useNavigate()

--- a/web/apps/wps-web/src/features/smurfi/components/requests/SpotRequestsTable.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/requests/SpotRequestsTable.tsx
@@ -97,8 +97,8 @@ const SpotRequestsTable = ({ rows }: SpotRequestsTableProps) => {
       ),
       sortComparator: (a, b) => {
         const order = [
-          SpotRequestStatus.STARTED,
           SpotRequestStatus.REQUESTED,
+          SpotRequestStatus.STARTED,
           SpotRequestStatus.SUSPENDED,
           SpotRequestStatus.COMPLETE,
           SpotRequestStatus.ARCHIVED

--- a/web/apps/wps-web/src/features/smurfi/pages/EditSpotForecastPage.tsx
+++ b/web/apps/wps-web/src/features/smurfi/pages/EditSpotForecastPage.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
+import { fetchSpotForecasts, selectSmurfi } from '@/features/smurfi/slices/smurfiSlice'
+import useSpotPermissions from '@/features/smurfi/hooks/useSpotPermissions'
+import { AppDispatch } from '@/app/store'
+import { Typography } from '@mui/material'
+import { DateTime } from 'luxon'
+
+const EditSpotForecastPage = () => {
+  const { id, forecastId } = useParams<{ id: string; forecastId: string }>()
+  const dispatch = useDispatch<AppDispatch>()
+  const { spotRequests, spotForecastsByRequestId } = useSelector(selectSmurfi)
+
+  const spotRequestId = Number(id)
+  const spotForecastId = Number(forecastId)
+
+  useEffect(() => {
+    if (!spotForecastsByRequestId[spotRequestId]) {
+      dispatch(fetchSpotForecasts(spotRequestId))
+    }
+  }, [dispatch, spotRequestId, spotForecastsByRequestId])
+
+  const spotRequest = spotRequests.find(sr => sr.id === spotRequestId)
+  const { isForecaster } = useSpotPermissions(spotRequest)
+
+  if (!isForecaster) {
+    return <Typography>You do not have permission to edit this forecast.</Typography>
+  }
+
+  const spotForecast = (spotForecastsByRequestId[spotRequestId] ?? []).find(f => f.id === spotForecastId)
+  if (spotForecast?.expires_at) {
+    const expiry = DateTime.fromISO(spotForecast.expires_at)
+    if (expiry.isValid && expiry < DateTime.now()) {
+      return <Typography>This forecast is expired and can&apos;t be edited.</Typography>
+    }
+  }
+
+  return <Typography>Edit Spot Forecast</Typography>
+}
+
+export default EditSpotForecastPage

--- a/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
+++ b/web/apps/wps-web/src/features/smurfi/pages/SMURFIPage.tsx
@@ -8,6 +8,7 @@ import SpotRequestFormPage from '@/features/smurfi/components/requestForm/SpotRe
 import SpotRequest from '@/features/smurfi/components/requests/SpotRequest'
 import SpotRequests from '@/features/smurfi/components/requests/SpotRequests'
 import PrintableSpotForecast from '@/features/smurfi/pages/PrintableSpotForecast'
+import EditSpotForecastPage from '@/features/smurfi/pages/EditSpotForecastPage'
 import { fetchSpotRequests } from '@/features/smurfi/slices/smurfiSlice'
 import { fetchWxStations } from '@/features/stations/slices/stationsSlice'
 import { Box, Tab, Tabs } from '@mui/material'
@@ -68,6 +69,7 @@ const SMURFIPage = () => {
                     <Route path=":id/forecasts/new" element={<SpotForecastFormPage />} />
                     <Route path=":id/forecasts/:forecastId" element={<SpotForecast />} />
                     <Route path=":id/forecasts/:forecastId/print" element={<PrintableSpotForecast />} />
+                    <Route path=":id/forecasts/:forecastId/edit" element={<EditSpotForecastPage />} />
                   </Routes>
                 </RouteContent>
               }

--- a/web/apps/wps-web/src/features/smurfi/utils/spotForecastUtils.ts
+++ b/web/apps/wps-web/src/features/smurfi/utils/spotForecastUtils.ts
@@ -5,7 +5,7 @@ export const TIMEZONE = 'America/Vancouver'
 
 export const formatDateTime = (iso: string): string => {
   const dt = DateTime.fromISO(iso).setZone(TIMEZONE)
-  return dt.isValid ? `${dt.toFormat('HHmm')} ${dt.offsetNameShort} ${dt.toFormat('EEE, MMM d, yyyy')}` : iso
+  return dt.isValid ? `${dt.toFormat('HH:mm')} ${dt.offsetNameShort} ${dt.toFormat('EEE, MMM d, yyyy')}` : iso
 }
 
 export const formatStationsStr = (stations: RepresentativeStation[]): string =>


### PR DESCRIPTION
- populates the `smurfi/requests/:id/forecasts` route with a some request details and a datagrid of all forecasts
- a forecast with `expired_at` exceeding the current date and time will appear greyed out but the `View` button will remain active
- wires up an edit button that routes to `smurfi/requests/:id/forecasts/:forecastId/edit` that renders a placeholder `EditSpotForecast` page
- the edit button is only visible on the most recent forecast that is not expired
- changes a sort comparator so that `SpotRequestStatus.REQUESTED` rows appear at the top of the datagrid on the `SpotRequests.tsx` page