### PR TITLE
Allow new request on map click

### DIFF
--- a/web/apps/wps-web/src/features/smurfi/components/map/NewRequestClickInteraction.ts
+++ b/web/apps/wps-web/src/features/smurfi/components/map/NewRequestClickInteraction.ts
@@ -1,0 +1,94 @@
+import { Interaction } from 'ol/interaction'
+import type { MapBrowserEvent } from 'ol'
+import type Map from 'ol/Map'
+import type Overlay from 'ol/Overlay'
+import Feature from 'ol/Feature'
+import { Point } from 'ol/geom'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+import { Circle as CircleStyle, Fill, Stroke, Style } from 'ol/style'
+import { toLonLat } from 'ol/proj'
+
+export interface NewRequestClickData {
+  lat: number
+  lon: number
+  coordinate: number[]
+}
+
+const PENDING_MARKER_STYLE = new Style({
+  image: new CircleStyle({
+    radius: 8,
+    fill: new Fill({ color: '#d32f2f' }),
+    stroke: new Stroke({ color: '#ffffff', width: 2 })
+  })
+})
+
+export class NewRequestClickInteraction extends Interaction {
+  private readonly overlay: Overlay
+  private readonly onEmptyClick: (data: NewRequestClickData) => void
+  private readonly onDismiss: () => void
+  private popupOpen = false
+
+  private readonly pendingMarkerSource = new VectorSource<Feature<Point>>()
+  private readonly pendingMarkerLayer = new VectorLayer({
+    source: this.pendingMarkerSource,
+    style: PENDING_MARKER_STYLE,
+    zIndex: 60
+  })
+
+  private readonly shouldIgnoreClick?: (event: MapBrowserEvent<UIEvent>) => boolean
+
+  constructor(options: {
+    overlay: Overlay
+    onEmptyClick: (data: NewRequestClickData) => void
+    onDismiss: () => void
+    shouldIgnoreClick?: (event: MapBrowserEvent<UIEvent>) => boolean
+  }) {
+    super()
+    this.overlay = options.overlay
+    this.onEmptyClick = options.onEmptyClick
+    this.onDismiss = options.onDismiss
+    this.shouldIgnoreClick = options.shouldIgnoreClick
+  }
+
+  override setMap(map: Map | null) {
+    this.getMap()?.removeLayer(this.pendingMarkerLayer)
+    super.setMap(map)
+    map?.addLayer(this.pendingMarkerLayer)
+  }
+
+  override handleEvent(event: MapBrowserEvent<UIEvent>): boolean {
+    if (event.type !== 'click') return true
+
+    if (this.popupOpen) {
+      this.clearPopup()
+      this.onDismiss()
+      // let the event through if a feature was clicked so other handlers can open its popup
+      return !!event.map.forEachFeatureAtPixel(event.pixel, () => true)
+    }
+
+    if (this.shouldIgnoreClick?.(event)) return true
+
+    const [lon, lat] = toLonLat(event.coordinate)
+    this.overlay.setPosition(event.coordinate)
+    this.pendingMarkerSource.addFeature(new Feature({ geometry: new Point(event.coordinate) }))
+    this.popupOpen = true
+    this.onEmptyClick({ lat, lon, coordinate: event.coordinate })
+    return false
+  }
+
+  close() {
+    this.clearPopup()
+  }
+
+  private clearPopup() {
+    this.overlay.setPosition(undefined)
+    this.pendingMarkerSource.clear()
+    this.popupOpen = false
+  }
+
+  override dispose() {
+    this.getMap()?.removeLayer(this.pendingMarkerLayer)
+    super.dispose()
+  }
+}

--- a/web/apps/wps-web/src/features/smurfi/components/map/NewRequestPopup.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/map/NewRequestPopup.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, Divider, Stack, Typography } from '@mui/material'
+
+interface NewRequestPopupProps {
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+const NewRequestPopup = ({ onConfirm, onCancel }: NewRequestPopupProps) => (
+  <Box
+    sx={{
+      p: 2,
+      background: 'white',
+      border: '1px solid #ddd',
+      borderRadius: 2,
+      boxShadow: 3,
+      minWidth: 280
+    }}
+  >
+    <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1, color: 'primary.main' }}>
+      New Spot Request
+    </Typography>
+    <Divider sx={{ mb: 2 }} />
+    <Typography variant="body2" sx={{ mb: 2, color: 'primary.main' }}>
+      Create new spot request at this location?
+    </Typography>
+    <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
+      <Button size="small" onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button variant="contained" size="small" onClick={onConfirm}>
+        Confirm
+      </Button>
+    </Stack>
+  </Box>
+)
+
+export default NewRequestPopup

--- a/web/apps/wps-web/src/features/smurfi/components/map/SMURFIMap.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/map/SMURFIMap.tsx
@@ -10,11 +10,13 @@ import VectorLayer from 'ol/layer/Vector'
 import { Circle as CircleStyle, Fill, Stroke, Style } from 'ol/style'
 import { Point } from 'ol/geom'
 import VectorSource from 'ol/source/Vector'
+import NewRequestPopup from './NewRequestPopup'
 import SpotPopup from './SpotPopup'
 import { FeatureLike } from 'ol/Feature'
 import {
   BC_EXTENT,
   CENTER_OF_BC,
+  SMURFI_NEW_REQUEST_ROUTE,
   getSmurfiForecastsRoute,
   getSmurfiNewForecastRoute,
   getSmurfiRequestRoute
@@ -79,6 +81,14 @@ type FirePopupData = {
   attributes: CurrentFireAttributes
 }
 
+type MapClickPopupData = {
+  type: 'map'
+  open: boolean
+  position: number[]
+  lat: number
+  lon: number
+}
+
 export const MapContext = React.createContext<Map | null>(null)
 const bcExtent = boundingExtent(BC_EXTENT.map(coord => fromLonLat(coord)))
 
@@ -115,7 +125,7 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
     getVisibleCurrentFireStatusDefaults
   )
   const [map, setMap] = useState<Map | null>(null)
-  const [popupData, setPopupData] = useState<SpotPopupData | FirePopupData | null>(null)
+  const [popupData, setPopupData] = useState<SpotPopupData | FirePopupData | MapClickPopupData | null>(null)
 
   // refs
   const mapRef = useRef<HTMLDivElement | null>(null)
@@ -123,6 +133,8 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
   const featureLayerRef = useRef<VectorLayer<VectorSource<Feature<Point>>> | null>(null)
   const currentFireLayerControllerRef = useRef<CurrentFireLayerController | null>(null)
   const currentFiresClickInteractionRef = useRef<CurrentFiresClickInteraction | null>(null)
+  const popupDataRef = useRef<SpotPopupData | FirePopupData | MapClickPopupData | null>(null)
+  const pendingMarkerSourceRef = useRef(new VectorSource<Feature<Point>>())
 
   // derived values
   const mapSpotRequests = propSpotRequests ?? spotRequests
@@ -217,6 +229,19 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
 
   // effects
   useEffect(() => {
+    popupDataRef.current = popupData
+  }, [popupData])
+
+  useEffect(() => {
+    pendingMarkerSourceRef.current.clear()
+    if (popupData?.type === 'map') {
+      pendingMarkerSourceRef.current.addFeature(
+        new Feature({ geometry: new Point(fromLonLat([popupData.lon, popupData.lat])) })
+      )
+    }
+  }, [popupData])
+
+  useEffect(() => {
     if (propSpotRequests === undefined) {
       dispatch(fetchSpotRequests())
     }
@@ -235,6 +260,17 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
     })
     const currentFirePolygonsLayer = createCurrentFirePolygonsLayer(selectedCurrentFireStatuses)
     const currentFirePointsLayer = createCurrentFirePointsLayer(selectedCurrentFireStatuses)
+    const pendingMarkerLayer = new VectorLayer({
+      source: pendingMarkerSourceRef.current,
+      style: new Style({
+        image: new CircleStyle({
+          radius: 8,
+          fill: new Fill({ color: '#d32f2f' }),
+          stroke: new Stroke({ color: '#ffffff', width: 2 })
+        })
+      }),
+      zIndex: 60
+    })
     featureLayerRef.current = featureLayer
     currentFireLayerControllerRef.current = new CurrentFireLayerController({
       pointsLayer: currentFirePointsLayer,
@@ -243,7 +279,7 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
 
     const mapObject = new Map({
       target: mapRef.current,
-      layers: [currentFirePolygonsLayer, currentFirePointsLayer, featureLayer],
+      layers: [currentFirePolygonsLayer, currentFirePointsLayer, featureLayer, pendingMarkerLayer],
       view: new View({
         zoom: 5,
         center: fromLonLat(CENTER_OF_BC)
@@ -262,6 +298,12 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
 
     // add click handler
     mapObject.on('click', event => {
+      if (popupDataRef.current) {
+        overlay.setPosition(undefined)
+        setPopupData(null)
+        return
+      }
+
       const feature = mapObject.forEachFeatureAtPixel(event.pixel, (f, layer) =>
         layer === featureLayer ? f : undefined
       )
@@ -287,6 +329,10 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
         overlay.setPosition(undefined)
         setPopupData(null)
       }
+
+      const [lon, lat] = toLonLat(event.coordinate)
+      overlay.setPosition(event.coordinate)
+      setPopupData({ type: 'map', open: true, position: event.coordinate, lat, lon })
     })
 
     const currentFiresClickInteraction = new CurrentFiresClickInteraction({
@@ -422,25 +468,53 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
         <div
           ref={popupRef}
           className="ol-popup"
-          style={{ display: popupData?.open ? 'block' : 'none', pointerEvents: 'auto' }}
+          style={{ display: popupData?.open ? 'block' : 'none', pointerEvents: 'auto', position: 'relative' }}
         >
-          {popupData?.type === 'spot' && (
-            <SpotPopup
-              lat={popupData.lat}
-              lng={popupData.lng}
-              status={popupData.status}
-              fireNumber={popupData.fireNumber}
-              spotId={popupData.spotId}
-              spotRequest={popupData.spotRequest}
-              canSubmitForecast={isForecaster}
-              onOpenRequest={handleOpenRequest}
-              onOpenForecast={handleOpenForecasts}
-              onSubmitForecast={handleSubmitForecast}
-            />
-          )}
-          {popupData?.type === 'fire' && (
-            <CurrentFirePolygonPopup attributes={popupData.attributes} onClose={() => setPopupData(null)} />
-          )}
+          {/* rotated square pointer */}
+          <Box
+            sx={{
+              position: 'absolute',
+              bottom: -7,
+              left: '50%',
+              width: 14,
+              height: 14,
+              transform: 'translateX(-50%) rotate(45deg)',
+              bgcolor: 'white',
+              borderBottom: '1px solid #ddd',
+              borderRight: '1px solid #ddd',
+              pointerEvents: 'none',
+              zIndex: 2
+            }}
+          />
+          <Box sx={{ position: 'relative', zIndex: 1 }}>
+            {popupData?.type === 'spot' && (
+              <SpotPopup
+                lat={popupData.lat}
+                lng={popupData.lng}
+                status={popupData.status}
+                fireNumber={popupData.fireNumber}
+                spotId={popupData.spotId}
+                spotRequest={popupData.spotRequest}
+                canSubmitForecast={isForecaster}
+                onOpenRequest={handleOpenRequest}
+                onOpenForecast={handleOpenForecasts}
+                onSubmitForecast={handleSubmitForecast}
+              />
+            )}
+            {popupData?.type === 'fire' && (
+              <CurrentFirePolygonPopup attributes={popupData.attributes} onClose={() => setPopupData(null)} />
+            )}
+            {popupData?.type === 'map' && (
+              <NewRequestPopup
+                onConfirm={() =>
+                  navigate(SMURFI_NEW_REQUEST_ROUTE, {
+                    state: { latitude: popupData.lat, longitude: popupData.lon }
+                  })
+                }
+                onCancel={() => setPopupData(null)}
+              />
+            )}
+          </Box>
         </div>
       </Box>
     </MapContext.Provider>

--- a/web/apps/wps-web/src/features/smurfi/components/map/SMURFIMap.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/map/SMURFIMap.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/features/currentFires/map/currentFireLayers'
 import { CurrentFiresClickInteraction } from '@/features/currentFires/map/CurrentFiresClickInteraction'
 import { CurrentFireLayerController } from '@/features/currentFires/map/currentFireLayerController'
+import { NewRequestClickInteraction } from '@/features/smurfi/components/map/NewRequestClickInteraction'
 import CurrentFirePolygonPopup from '@/features/smurfi/components/map/CurrentFirePolygonPopup'
 import SpotMapLayerSwitcher from '@/features/smurfi/components/map/SpotMapLayerSwitcher'
 import { createSpotStatusIcon } from '@/features/smurfi/components/map/SpotStatusMarkers'
@@ -133,8 +134,8 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
   const featureLayerRef = useRef<VectorLayer<VectorSource<Feature<Point>>> | null>(null)
   const currentFireLayerControllerRef = useRef<CurrentFireLayerController | null>(null)
   const currentFiresClickInteractionRef = useRef<CurrentFiresClickInteraction | null>(null)
+  const newRequestClickInteractionRef = useRef<NewRequestClickInteraction | null>(null)
   const popupDataRef = useRef<SpotPopupData | FirePopupData | MapClickPopupData | null>(null)
-  const pendingMarkerSourceRef = useRef(new VectorSource<Feature<Point>>())
 
   // derived values
   const mapSpotRequests = propSpotRequests ?? spotRequests
@@ -233,15 +234,6 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
   }, [popupData])
 
   useEffect(() => {
-    pendingMarkerSourceRef.current.clear()
-    if (popupData?.type === 'map') {
-      pendingMarkerSourceRef.current.addFeature(
-        new Feature({ geometry: new Point(fromLonLat([popupData.lon, popupData.lat])) })
-      )
-    }
-  }, [popupData])
-
-  useEffect(() => {
     if (propSpotRequests === undefined) {
       dispatch(fetchSpotRequests())
     }
@@ -260,17 +252,6 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
     })
     const currentFirePolygonsLayer = createCurrentFirePolygonsLayer(selectedCurrentFireStatuses)
     const currentFirePointsLayer = createCurrentFirePointsLayer(selectedCurrentFireStatuses)
-    const pendingMarkerLayer = new VectorLayer({
-      source: pendingMarkerSourceRef.current,
-      style: new Style({
-        image: new CircleStyle({
-          radius: 8,
-          fill: new Fill({ color: '#d32f2f' }),
-          stroke: new Stroke({ color: '#ffffff', width: 2 })
-        })
-      }),
-      zIndex: 60
-    })
     featureLayerRef.current = featureLayer
     currentFireLayerControllerRef.current = new CurrentFireLayerController({
       pointsLayer: currentFirePointsLayer,
@@ -279,7 +260,7 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
 
     const mapObject = new Map({
       target: mapRef.current,
-      layers: [currentFirePolygonsLayer, currentFirePointsLayer, featureLayer, pendingMarkerLayer],
+      layers: [currentFirePolygonsLayer, currentFirePointsLayer, featureLayer],
       view: new View({
         zoom: 5,
         center: fromLonLat(CENTER_OF_BC)
@@ -287,7 +268,7 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
     })
     mapObject.getView().fit(bcExtent, { padding: [50, 50, 50, 50] })
 
-    // add popup overlay
+    // add popup overlay (shared by all popup types)
     const overlay = new Overlay({
       element: popupRef.current!,
       positioning: 'bottom-center',
@@ -296,43 +277,55 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
     })
     mapObject.addOverlay(overlay)
 
-    // add click handler
-    mapObject.on('click', event => {
-      if (popupDataRef.current) {
-        overlay.setPosition(undefined)
+    const newRequestClickInteraction = new NewRequestClickInteraction({
+      overlay,
+      shouldIgnoreClick: event =>
+        Boolean(
+          mapObject.forEachFeatureAtPixel(
+            event.pixel,
+            (f, layer) =>
+              layer === featureLayer || layer === currentFirePointsLayer || layer === currentFirePolygonsLayer
+                ? f
+                : undefined
+          )
+        ),
+      onEmptyClick: ({ lat, lon, coordinate }) => {
+        // if any popup is already open, dismiss it rather than opening a new request
+        if (popupDataRef.current) {
+          newRequestClickInteraction.close()
+          setPopupData(null)
+          return
+        }
+        setPopupData({ type: 'map', open: true, position: coordinate, lat, lon })
+      },
+      onDismiss: () => {
         setPopupData(null)
-        return
       }
+    })
+    newRequestClickInteractionRef.current = newRequestClickInteraction
+    mapObject.addInteraction(newRequestClickInteraction)
 
+    // spot click handler — new request and fire clicks are handled by their interactions
+    mapObject.on('click', event => {
       const feature = mapObject.forEachFeatureAtPixel(event.pixel, (f, layer) =>
         layer === featureLayer ? f : undefined
       )
-      if (feature) {
-        const coord = event.coordinate
-        const [lng, lat] = toLonLat(coord)
-        overlay.setPosition(coord)
-        setPopupData({
-          type: 'spot',
-          open: true,
-          position: coord,
-          lat,
-          lng,
-          status: feature.get('status') as SpotRequestStatus,
-          fireNumber: feature.get('fireNumber'),
-          spotId: feature.get('spotId') as number,
-          spotRequest: feature.get('spotRequest') as SpotRequestOutput
-        })
-        return
-      }
-
-      if (!currentFirePolygonsLayer.getVisible()) {
-        overlay.setPosition(undefined)
-        setPopupData(null)
-      }
-
-      const [lon, lat] = toLonLat(event.coordinate)
-      overlay.setPosition(event.coordinate)
-      setPopupData({ type: 'map', open: true, position: event.coordinate, lat, lon })
+      if (!feature) return
+      newRequestClickInteraction.close()
+      const coord = event.coordinate
+      const [lng, lat] = toLonLat(coord)
+      overlay.setPosition(coord)
+      setPopupData({
+        type: 'spot',
+        open: true,
+        position: coord,
+        lat,
+        lng,
+        status: feature.get('status') as SpotRequestStatus,
+        fireNumber: feature.get('fireNumber'),
+        spotId: feature.get('spotId') as number,
+        spotRequest: feature.get('spotRequest') as SpotRequestOutput
+      })
     })
 
     const currentFiresClickInteraction = new CurrentFiresClickInteraction({
@@ -341,6 +334,7 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
       shouldIgnoreClick: event =>
         Boolean(mapObject.forEachFeatureAtPixel(event.pixel, (f, layer) => (layer === featureLayer ? f : undefined))),
       onFireClick: ({ attributes, coordinate }) => {
+        newRequestClickInteraction.close()
         overlay.setPosition(coordinate)
         setPopupData({
           type: 'fire',
@@ -350,8 +344,7 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
         })
       },
       onMapMiss: () => {
-        overlay.setPosition(undefined)
-        setPopupData(null)
+        // popup dismissal on empty clicks is handled by NewRequestClickInteraction.onEmptyClick
       }
     })
     currentFiresClickInteractionRef.current = currentFiresClickInteraction
@@ -369,6 +362,8 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
     return () => {
       currentFireLayerControllerRef.current = null
       currentFiresClickInteractionRef.current = null
+      newRequestClickInteractionRef.current = null
+      mapObject.removeInteraction(newRequestClickInteraction)
       mapObject.removeInteraction(currentFiresClickInteraction)
       mapObject.setTarget('')
     }
@@ -506,12 +501,16 @@ const SMURFIMap = ({ selectedCoordinates, spotRequests: propSpotRequests }: SMUR
             )}
             {popupData?.type === 'map' && (
               <NewRequestPopup
-                onConfirm={() =>
+                onConfirm={() => {
+                  newRequestClickInteractionRef.current?.close()
                   navigate(SMURFI_NEW_REQUEST_ROUTE, {
                     state: { latitude: popupData.lat, longitude: popupData.lon }
                   })
-                }
-                onCancel={() => setPopupData(null)}
+                }}
+                onCancel={() => {
+                  newRequestClickInteractionRef.current?.close()
+                  setPopupData(null)
+                }}
               />
             )}
           </Box>

--- a/web/apps/wps-web/src/features/smurfi/components/requestForm/SpotRequestForm.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/requestForm/SpotRequestForm.tsx
@@ -45,6 +45,7 @@ import { useDispatch, useSelector } from 'react-redux'
 interface SpotRequestFormProps {
   onCancel: () => void
   onSubmit?: (request: SpotRequestOutput) => void
+  initialLocation?: { latitude: number; longitude: number }
 }
 
 const forecastTypeOptions: Record<SpotRequestFormValues['forecastType'], string> = {
@@ -143,7 +144,7 @@ const defaultValues: SpotRequestFormValues = {
 type DistributionItem = string | DistributionGroup
 const isGroup = (item: DistributionItem): item is DistributionGroup => typeof item !== 'string'
 
-const SpotRequestForm: React.FC<SpotRequestFormProps> = ({ onCancel, onSubmit }) => {
+const SpotRequestForm: React.FC<SpotRequestFormProps> = ({ onCancel, onSubmit, initialLocation }) => {
   const dispatch: AppDispatch = useDispatch()
   const { fireCentres, loading: fireCentresLoading } = useSelector(selectFireCentres)
   const { spotRequestSubmitting, spotRequestSubmitError, spotRequests } = useSelector(
@@ -168,7 +169,7 @@ const SpotRequestForm: React.FC<SpotRequestFormProps> = ({ onCancel, onSubmit })
     formState: { errors }
   } = useForm<SpotRequestFormValues, unknown, SpotRequestFormData>({
     resolver: zodResolver(spotRequestSchema),
-    defaultValues,
+    defaultValues: { ...defaultValues, location: initialLocation ?? null },
     mode: 'onBlur',
     reValidateMode: 'onChange'
   })

--- a/web/apps/wps-web/src/features/smurfi/components/requestForm/SpotRequestFormPage.tsx
+++ b/web/apps/wps-web/src/features/smurfi/components/requestForm/SpotRequestFormPage.tsx
@@ -2,10 +2,21 @@ import SpotRequestForm from '@/features/smurfi/components/requestForm/SpotReques
 import { Box, Button, Typography } from '@mui/material'
 import { SpotRequestOutput } from '@wps/api/SMURFIAPI'
 import { getSmurfiRequestRoute, SMURFI_DASHBOARD_ROUTE } from '@wps/utils/constants'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
+
+interface NewRequestLocationState {
+  latitude?: number
+  longitude?: number
+}
 
 const SpotRequestFormPage = () => {
   const navigate = useNavigate()
+  const { state } = useLocation()
+  const locationState = (state as NewRequestLocationState | null) ?? {}
+  const initialLocation =
+    locationState.latitude != null && locationState.longitude != null
+      ? { latitude: locationState.latitude, longitude: locationState.longitude }
+      : undefined
 
   const handleSubmit = (spotRequest: SpotRequestOutput) => {
     navigate(getSmurfiRequestRoute(spotRequest.id))
@@ -19,7 +30,11 @@ const SpotRequestFormPage = () => {
           Back to Dashboard
         </Button>
       </Box>
-      <SpotRequestForm onCancel={() => navigate(SMURFI_DASHBOARD_ROUTE)} onSubmit={handleSubmit} />
+      <SpotRequestForm
+        onCancel={() => navigate(SMURFI_DASHBOARD_ROUTE)}
+        onSubmit={handleSubmit}
+        initialLocation={initialLocation}
+      />
     </Box>
   )
 }


### PR DESCRIPTION
- adds a NewRequestClickInteraction module for handling click interaction related to opening a popup at a clicked location which allows a user to create a new request 
- the clicked coordinates are passed through to the new request form
- adds a 'pointer' to all popups
- a click on the map when any popup is open closes the popup