### PR TITLE
Adjust KFC prep level

### DIFF
--- a/backend/packages/wps-api/alembic/versions/d3513840fd37_adjust_prep_level_for_kfc.py
+++ b/backend/packages/wps-api/alembic/versions/d3513840fd37_adjust_prep_level_for_kfc.py
@@ -1,0 +1,34 @@
+"""Adjust prep level for KFC
+
+Revision ID: d3513840fd37
+Revises: 0f0c47b0c47a
+Create Date: 2026-05-28 09:58:15.454075
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'd3513840fd37'
+down_revision = '0f0c47b0c47a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # https://github.com/bcgov/wps/issues/5432
+    op.execute("""
+        UPDATE hfi_fire_start_lookup
+        SET prep_level = 2
+        WHERE fire_start_range_id = (SELECT id FROM hfi_fire_start_range WHERE label = '1-2')
+        AND mean_intensity_group = 2
+    """)
+
+
+def downgrade():
+    op.execute("""
+        UPDATE hfi_fire_start_lookup
+        SET prep_level = 1
+        WHERE fire_start_range_id = (SELECT id FROM hfi_fire_start_range WHERE label = '1-2')
+        AND mean_intensity_group = 2
+    """)


### PR DESCRIPTION
Adjust KFC prep level to 2 when fire starts = 1-2 AND M/FIG (ie intensity group) = 2.

Current behaviour in prod:
<img width="298" height="351" alt="image" src="https://github.com/user-attachments/assets/fa83c77a-a720-484d-9bfb-da0890ccb6d3" />

See the original issue for testing/repo steps.

Fix in my local:

<img width="298" height="373" alt="image" src="https://github.com/user-attachments/assets/d5e4a0c4-e1a8-4602-89bf-6697d4125e9a" />


Closes: #5432 

# Test Links:
[Landing Page](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5467-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
