### PR TITLE
Dev: Adjust NATS message processing to handle unack'd messages and add pod anti-affinity

### DIFF
--- a/backend/packages/wps-api/pyproject.toml
+++ b/backend/packages/wps-api/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "matplotlib>=3,<4",
     "rope>=1,<2",
     "pytest-watch>=4.2.0,<5",
+    "testcontainers[nats]>=4.10.0,<5",
 ]
 
 [tool.uv.sources]

--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/nats_consumer.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/nats_consumer.py
@@ -48,13 +48,24 @@ def parse_nats_message(msg: Msg):
 
 async def process_message(msg: Msg):
     """Process a single JetStream message and only ack after successful processing."""
+
+    async def keepalive():
+        while True:
+            await asyncio.sleep(450)  # 7.5 minutes, half of ack_wait
+            await msg.in_progress()
+            logger.debug("Sent in_progress for message: %s", msg.subject)
+
     try:
         logger.info("Msg received - %s\n", msg)
         run_type, run_datetime, for_date = parse_nats_message(msg)
         logger.info(
             "Awaiting process_sfms_hfi_stats({}, {}, {})\n".format(run_type, run_datetime, for_date)
         )
-        await process_sfms_hfi_stats(run_type, run_datetime, for_date)
+        keepalive_task = asyncio.create_task(keepalive())
+        try:
+            await process_sfms_hfi_stats(run_type, run_datetime, for_date)
+        finally:
+            keepalive_task.cancel()
         await msg.ack()
     except Exception as exc:
         logger.error(
@@ -102,7 +113,7 @@ async def run():
     consumer_config = ConsumerConfig(
         durable_name=hfi_classify_durable_group,
         ack_policy=AckPolicy.EXPLICIT,
-        ack_wait=86400,  # 24 hours
+        ack_wait=900,  # 15 minutes; keepalive pings extend this for long-running jobs
         max_deliver=6,  # initial try + 5 retries
     )
 

--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/nats_consumer.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/nats_consumer.py
@@ -27,6 +27,9 @@ from app.auto_spatial_advisory.process_stats import process_sfms_hfi_stats
 
 logger = logging.getLogger(__name__)
 
+_ACK_WAIT = 900           # 15 minutes; keepalive pings extend this for long-running jobs
+_KEEPALIVE_INTERVAL = 450  # 7.5 minutes, half of _ACK_WAIT
+
 
 def parse_nats_message(msg: Msg):
     """
@@ -51,7 +54,7 @@ async def process_message(msg: Msg):
 
     async def keepalive():
         while True:
-            await asyncio.sleep(450)  # 7.5 minutes, half of ack_wait
+            await asyncio.sleep(_KEEPALIVE_INTERVAL)
             await msg.in_progress()
             logger.debug("Sent in_progress for message: %s", msg.subject)
 
@@ -79,6 +82,25 @@ async def process_message(msg: Msg):
             logger.exception("Failed to negatively acknowledge message: %s", msg.data)
 
 
+async def _setup_subscriber(jetstream):
+    await jetstream.add_stream(
+        name=stream_name,
+        config=StreamConfig(retention=RetentionPolicy.WORK_QUEUE),
+        subjects=subjects,
+    )
+    return await jetstream.pull_subscribe(
+        stream=stream_name,
+        subject=sfms_file_subject,
+        durable=hfi_classify_durable_group,
+        config=ConsumerConfig(
+            durable_name=hfi_classify_durable_group,
+            ack_policy=AckPolicy.EXPLICIT,
+            ack_wait=_ACK_WAIT,
+            max_deliver=6,
+        ),
+    )
+
+
 async def run():
     async def disconnected_cb():
         logger.info("Got disconnected!")
@@ -102,27 +124,7 @@ async def run():
         closed_cb=closed_cb,
     )
     jetstream = nats_connection.jetstream()
-    # we create a stream, this is important, we need to messages to stick around for a while!
-    # idempotent operation, IFF stream with same configuration is added each time
-    await jetstream.add_stream(
-        name=stream_name,
-        config=StreamConfig(retention=RetentionPolicy.WORK_QUEUE),
-        subjects=subjects,
-    )
-
-    consumer_config = ConsumerConfig(
-        durable_name=hfi_classify_durable_group,
-        ack_policy=AckPolicy.EXPLICIT,
-        ack_wait=900,  # 15 minutes; keepalive pings extend this for long-running jobs
-        max_deliver=6,  # initial try + 5 retries
-    )
-
-    sfms_sub = await jetstream.pull_subscribe(
-        stream=stream_name,
-        subject=sfms_file_subject,
-        durable=hfi_classify_durable_group,
-        config=consumer_config,
-    )
+    sfms_sub = await _setup_subscriber(jetstream)
     while True:
         msgs: List[Msg] = await sfms_sub.fetch(batch=1, timeout=None)
         for msg in msgs:

--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/nats_consumer.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/nats_consumer.py
@@ -102,7 +102,7 @@ async def run():
     consumer_config = ConsumerConfig(
         durable_name=hfi_classify_durable_group,
         ack_policy=AckPolicy.EXPLICIT,
-        ack_wait=600,  # 10 minutes
+        ack_wait=86400,  # 24 hours
         max_deliver=6,  # initial try + 5 retries
     )
 

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_nats_consumer.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_nats_consumer.py
@@ -7,49 +7,56 @@ import pytest
 from app.auto_spatial_advisory.nats_consumer import process_message
 from app.auto_spatial_advisory.process_hfi import RunType
 
+_MODULE = "app.auto_spatial_advisory.nats_consumer"
+_PARSED_MSG = (RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))
+
+
+@pytest.fixture
+def msg():
+    m = Mock()
+    m.data = b'{"ignored": true}'
+    m.ack = AsyncMock()
+    m.nak = AsyncMock()
+    return m
+
+
+@pytest.fixture
+def patch_parse(monkeypatch):
+    mock = Mock(return_value=_PARSED_MSG)
+    monkeypatch.setattr(f"{_MODULE}.parse_nats_message", mock)
+    return mock
+
+
+@pytest.fixture
+def captured_tasks(monkeypatch):
+    tasks = []
+    real = asyncio.create_task
+
+    def capture(coro, **kwargs):
+        task = real(coro, **kwargs)
+        tasks.append(task)
+        return task
+
+    monkeypatch.setattr("asyncio.create_task", capture)
+    return tasks
+
 
 @pytest.mark.anyio
-async def test_process_message_acks_after_success(monkeypatch):
-    msg = Mock()
-    msg.data = b'{"ignored": true}'
-    msg.ack = AsyncMock()
-    msg.nak = AsyncMock()
-
-    parse_message = Mock(
-        return_value=(RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))
-    )
+async def test_process_message_acks_after_success(msg, patch_parse, monkeypatch):
     process_stats = AsyncMock()
-
-    monkeypatch.setattr("app.auto_spatial_advisory.nats_consumer.parse_nats_message", parse_message)
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.process_sfms_hfi_stats", process_stats
-    )
+    monkeypatch.setattr(f"{_MODULE}.process_sfms_hfi_stats", process_stats)
 
     await process_message(msg)
 
-    parse_message.assert_called_once_with(msg)
-    process_stats.assert_awaited_once_with(
-        RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1)
-    )
+    patch_parse.assert_called_once_with(msg)
+    process_stats.assert_awaited_once_with(*_PARSED_MSG)
     msg.ack.assert_awaited_once()
     msg.nak.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_process_message_naks_after_failure(monkeypatch):
-    msg = Mock()
-    msg.data = b'{"ignored": true}'
-    msg.ack = AsyncMock()
-    msg.nak = AsyncMock()
-
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.parse_nats_message",
-        Mock(return_value=(RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))),
-    )
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.process_sfms_hfi_stats",
-        AsyncMock(side_effect=RuntimeError("boom")),
-    )
+async def test_process_message_naks_after_failure(msg, patch_parse, monkeypatch):
+    monkeypatch.setattr(f"{_MODULE}.process_sfms_hfi_stats", AsyncMock(side_effect=RuntimeError("boom")))
 
     await process_message(msg)
 
@@ -58,79 +65,31 @@ async def test_process_message_naks_after_failure(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_keepalive_task_cancelled_on_success(monkeypatch):
-    msg = Mock()
-    msg.data = b'{"ignored": true}'
-    msg.ack = AsyncMock()
-    msg.nak = AsyncMock()
-
-    created_tasks = []
-    real_create_task = asyncio.create_task
-
-    def capturing_create_task(coro, **kwargs):
-        task = real_create_task(coro, **kwargs)
-        created_tasks.append(task)
-        return task
-
-    monkeypatch.setattr("asyncio.create_task", capturing_create_task)
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.parse_nats_message",
-        Mock(return_value=(RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))),
-    )
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.process_sfms_hfi_stats",
-        AsyncMock(),
-    )
+async def test_keepalive_task_cancelled_on_success(msg, patch_parse, captured_tasks, monkeypatch):
+    monkeypatch.setattr(f"{_MODULE}.process_sfms_hfi_stats", AsyncMock())
 
     await process_message(msg)
-    await asyncio.sleep(0)  # Let event loop process the cancellation
+    await asyncio.sleep(0)
 
-    assert len(created_tasks) == 1
-    assert created_tasks[0].done()
+    assert len(captured_tasks) == 1
+    assert captured_tasks[0].done()
     msg.ack.assert_awaited_once()
 
 
 @pytest.mark.anyio
-async def test_keepalive_task_cancelled_on_processing_failure(monkeypatch):
-    msg = Mock()
-    msg.data = b'{"ignored": true}'
-    msg.ack = AsyncMock()
-    msg.nak = AsyncMock()
-
-    created_tasks = []
-    real_create_task = asyncio.create_task
-
-    def capturing_create_task(coro, **kwargs):
-        task = real_create_task(coro, **kwargs)
-        created_tasks.append(task)
-        return task
-
-    monkeypatch.setattr("asyncio.create_task", capturing_create_task)
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.parse_nats_message",
-        Mock(return_value=(RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))),
-    )
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.process_sfms_hfi_stats",
-        AsyncMock(side_effect=RuntimeError("processing failed")),
-    )
+async def test_keepalive_task_cancelled_on_processing_failure(msg, patch_parse, captured_tasks, monkeypatch):
+    monkeypatch.setattr(f"{_MODULE}.process_sfms_hfi_stats", AsyncMock(side_effect=RuntimeError("boom")))
 
     await process_message(msg)
-    await asyncio.sleep(0)  # Let event loop process the cancellation
+    await asyncio.sleep(0)
 
-    assert len(created_tasks) == 1
-    assert created_tasks[0].done()
+    assert len(captured_tasks) == 1
+    assert captured_tasks[0].done()
     msg.nak.assert_awaited_once()
 
 
 @pytest.mark.anyio
-async def test_in_progress_sent_while_processing(monkeypatch):
-    msg = Mock()
-    msg.data = b'{"ignored": true}'
-    msg.ack = AsyncMock()
-    msg.nak = AsyncMock()
-
-    # Signal from in_progress back to slow_process so the test is deterministic
+async def test_in_progress_sent_while_processing(msg, patch_parse, monkeypatch):
     in_progress_called = asyncio.Event()
 
     async def signal_in_progress():
@@ -138,22 +97,13 @@ async def test_in_progress_sent_while_processing(monkeypatch):
 
     msg.in_progress = AsyncMock(side_effect=signal_in_progress)
 
-    # Patch sleep to yield without blocking so the keepalive fires immediately
     _real_sleep = asyncio.sleep
     monkeypatch.setattr("asyncio.sleep", lambda s: _real_sleep(0))
 
     async def slow_process(*args, **kwargs):
-        # Block until keepalive has fired at least once, then allow processing to complete
         await in_progress_called.wait()
 
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.parse_nats_message",
-        Mock(return_value=(RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))),
-    )
-    monkeypatch.setattr(
-        "app.auto_spatial_advisory.nats_consumer.process_sfms_hfi_stats",
-        slow_process,
-    )
+    monkeypatch.setattr(f"{_MODULE}.process_sfms_hfi_stats", slow_process)
 
     await process_message(msg)
 

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_nats_consumer.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_nats_consumer.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import date, datetime
 from unittest.mock import AsyncMock, Mock
 
@@ -54,3 +55,106 @@ async def test_process_message_naks_after_failure(monkeypatch):
 
     msg.ack.assert_not_called()
     msg.nak.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_keepalive_task_cancelled_on_success(monkeypatch):
+    msg = Mock()
+    msg.data = b'{"ignored": true}'
+    msg.ack = AsyncMock()
+    msg.nak = AsyncMock()
+
+    created_tasks = []
+    real_create_task = asyncio.create_task
+
+    def capturing_create_task(coro, **kwargs):
+        task = real_create_task(coro, **kwargs)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr("asyncio.create_task", capturing_create_task)
+    monkeypatch.setattr(
+        "app.auto_spatial_advisory.nats_consumer.parse_nats_message",
+        Mock(return_value=(RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))),
+    )
+    monkeypatch.setattr(
+        "app.auto_spatial_advisory.nats_consumer.process_sfms_hfi_stats",
+        AsyncMock(),
+    )
+
+    await process_message(msg)
+    await asyncio.sleep(0)  # Let event loop process the cancellation
+
+    assert len(created_tasks) == 1
+    assert created_tasks[0].done()
+    msg.ack.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_keepalive_task_cancelled_on_processing_failure(monkeypatch):
+    msg = Mock()
+    msg.data = b'{"ignored": true}'
+    msg.ack = AsyncMock()
+    msg.nak = AsyncMock()
+
+    created_tasks = []
+    real_create_task = asyncio.create_task
+
+    def capturing_create_task(coro, **kwargs):
+        task = real_create_task(coro, **kwargs)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr("asyncio.create_task", capturing_create_task)
+    monkeypatch.setattr(
+        "app.auto_spatial_advisory.nats_consumer.parse_nats_message",
+        Mock(return_value=(RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))),
+    )
+    monkeypatch.setattr(
+        "app.auto_spatial_advisory.nats_consumer.process_sfms_hfi_stats",
+        AsyncMock(side_effect=RuntimeError("processing failed")),
+    )
+
+    await process_message(msg)
+    await asyncio.sleep(0)  # Let event loop process the cancellation
+
+    assert len(created_tasks) == 1
+    assert created_tasks[0].done()
+    msg.nak.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_in_progress_sent_while_processing(monkeypatch):
+    msg = Mock()
+    msg.data = b'{"ignored": true}'
+    msg.ack = AsyncMock()
+    msg.nak = AsyncMock()
+
+    # Signal from in_progress back to slow_process so the test is deterministic
+    in_progress_called = asyncio.Event()
+
+    async def signal_in_progress():
+        in_progress_called.set()
+
+    msg.in_progress = AsyncMock(side_effect=signal_in_progress)
+
+    # Patch sleep to yield without blocking so the keepalive fires immediately
+    _real_sleep = asyncio.sleep
+    monkeypatch.setattr("asyncio.sleep", lambda s: _real_sleep(0))
+
+    async def slow_process(*args, **kwargs):
+        # Block until keepalive has fired at least once, then allow processing to complete
+        await in_progress_called.wait()
+
+    monkeypatch.setattr(
+        "app.auto_spatial_advisory.nats_consumer.parse_nats_message",
+        Mock(return_value=(RunType.ACTUAL, datetime(2025, 1, 1, 12, 0), date(2025, 1, 1))),
+    )
+    monkeypatch.setattr(
+        "app.auto_spatial_advisory.nats_consumer.process_sfms_hfi_stats",
+        slow_process,
+    )
+
+    await process_message(msg)
+
+    msg.in_progress.assert_awaited()

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_nats_consumer_integration.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_nats_consumer_integration.py
@@ -1,0 +1,137 @@
+"""Integration tests for nats_consumer using a real NATS JetStream server.
+
+These tests require Docker/Podman. Run with:
+    cd backend && uv run pytest -m integration packages/wps-api/src/app/tests/auto_spatial_advisory/test_nats_consumer_integration.py
+"""
+
+import asyncio
+import json
+import uuid
+from unittest.mock import AsyncMock
+
+import nats as nats_lib
+import pytest
+from testcontainers.nats import NatsContainer
+
+from app.auto_spatial_advisory.nats_config import sfms_file_subject
+from app.auto_spatial_advisory.nats_consumer import _setup_subscriber, process_message
+
+_MODULE = "app.auto_spatial_advisory.nats_consumer"
+_ACK_WAIT_TEST = 5  # seconds; production is 900
+_KEEPALIVE_INTERVAL_TEST = 2  # seconds; production is 450
+
+
+def _payload() -> bytes:
+    inner = json.dumps(
+        {
+            "run_type": "actual",
+            "for_date": "2025-01-01",
+            "create_time": "2025-01-01T12:00:00",
+        }
+    )
+    return json.dumps(inner).encode()
+
+
+@pytest.fixture(scope="module")
+def nats_uri():
+    with NatsContainer(jetstream=True) as container:
+        yield container.nats_uri()
+
+
+@pytest.fixture
+async def nats_setup(nats_uri, monkeypatch):
+    test_id = uuid.uuid4().hex[:8]
+    test_stream = f"test_sfms_{test_id}"
+    test_durable = f"test_hfi_{test_id}"
+
+    monkeypatch.setattr(f"{_MODULE}._ACK_WAIT", _ACK_WAIT_TEST)
+    monkeypatch.setattr(f"{_MODULE}._KEEPALIVE_INTERVAL", _KEEPALIVE_INTERVAL_TEST)
+    monkeypatch.setattr(f"{_MODULE}.stream_name", test_stream)
+    monkeypatch.setattr(f"{_MODULE}.hfi_classify_durable_group", test_durable)
+
+    nc = await nats_lib.connect(nats_uri)
+    js = nc.jetstream()
+    sub = await _setup_subscriber(js)
+
+    yield js, sub, test_stream
+
+    try:
+        await js.delete_stream(test_stream)
+    except Exception:
+        pass
+    await nc.close()
+
+
+@pytest.mark.anyio
+async def test_nats_redelivers_unacked_message(nats_setup):
+    """Baseline: NATS redelivers a message when ack_wait expires without an ack."""
+    js, sub, _ = nats_setup
+    await js.publish(sfms_file_subject, _payload())
+
+    [msg] = await sub.fetch(batch=1, timeout=5)
+    assert msg.metadata.num_delivered == 1
+    # Intentionally do not ack — let ack_wait expire.
+
+    await asyncio.sleep(_ACK_WAIT_TEST + 1)
+
+    [msg2] = await sub.fetch(batch=1, timeout=5)
+    assert msg2.metadata.num_delivered == 2
+    await msg2.ack()
+
+
+@pytest.mark.anyio
+async def test_message_acked_after_success(nats_setup, monkeypatch):
+    """Successful processing calls ack (not nak), and the message is removed from the work queue."""
+    js, sub, _ = nats_setup
+    monkeypatch.setattr(f"{_MODULE}.process_sfms_hfi_stats", AsyncMock())
+    await js.publish(sfms_file_subject, _payload())
+
+    [msg] = await sub.fetch(batch=1, timeout=5)
+    msg.ack = AsyncMock(wraps=msg.ack)
+    msg.nak = AsyncMock(wraps=msg.nak)
+
+    await process_message(msg)
+
+    msg.ack.assert_awaited_once()
+    msg.nak.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_keepalive_prevents_redelivery(nats_setup, monkeypatch):
+    """Processing that exceeds ack_wait still acks successfully because keepalive extends the deadline."""
+    js, sub, _ = nats_setup
+    original_sleep = asyncio.sleep
+
+    async def slow_process(*_):
+        await original_sleep(_ACK_WAIT_TEST + 2)
+
+    monkeypatch.setattr(f"{_MODULE}.process_sfms_hfi_stats", slow_process)
+    await js.publish(sfms_file_subject, _payload())
+
+    [msg] = await sub.fetch(batch=1, timeout=5)
+    msg.ack = AsyncMock(wraps=msg.ack)
+    msg.nak = AsyncMock(wraps=msg.nak)
+
+    await process_message(msg)
+
+    msg.ack.assert_awaited_once()
+    msg.nak.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_message_nacked_after_failure(nats_setup, monkeypatch):
+    """Processing failure naks the message; it remains in the stream for redelivery."""
+    js, sub, _ = nats_setup
+    monkeypatch.setattr(
+        f"{_MODULE}.process_sfms_hfi_stats", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    await js.publish(sfms_file_subject, _payload())
+
+    [msg] = await sub.fetch(batch=1, timeout=5)
+    msg.ack = AsyncMock(wraps=msg.ack)
+    msg.nak = AsyncMock(wraps=msg.nak)
+
+    await process_message(msg)
+
+    msg.nak.assert_awaited_once()
+    msg.ack.assert_not_awaited()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -4427,6 +4427,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/31/5e7b23f9e43ff7fd46d243808d70c5e8daf3bc08ecf5a7fb84d5e38f7603/testcontainers-4.14.1-py3-none-any.whl", hash = "sha256:03dfef4797b31c82e7b762a454b6afec61a2a512ad54af47ab41e4fa5415f891", size = 125640, upload-time = "2026-01-31T23:13:45.464Z" },
 ]
 
+[package.optional-dependencies]
+nats = [
+    { name = "nats-py" },
+]
+
 [[package]]
 name = "threadpoolctl"
 version = "3.6.0"
@@ -4732,6 +4737,7 @@ dev = [
     { name = "pycodestyle" },
     { name = "pytest-watch" },
     { name = "rope" },
+    { name = "testcontainers", extra = ["nats"] },
 ]
 
 [package.metadata]
@@ -4784,6 +4790,7 @@ requires-dist = [
     { name = "setuptools", specifier = ">=80.0.0,<81" },
     { name = "shapely", specifier = ">=2.0.5,<3" },
     { name = "sqlalchemy", specifier = ">=2,<3" },
+    { name = "testcontainers", extras = ["nats"], marker = "extra == 'dev'", specifier = ">=4.10.0,<5" },
     { name = "uvicorn", specifier = ">=0,<1" },
     { name = "wps-sfms", editable = "packages/wps-sfms" },
     { name = "wps-shared", editable = "packages/wps-shared" },

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -296,6 +296,7 @@ objects:
               requiredDuringSchedulingIgnoredDuringExecution:
                 - labelSelector:
                     matchLabels:
+                      app: ${APP_NAME}-${SUFFIX}
                       component: nats-consumer
                   topologyKey: "kubernetes.io/hostname"
           containers:

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -152,7 +152,15 @@ objects:
         metadata:
           labels:
             app: ${APP_NAME}-${SUFFIX}
+            component: nats-server
         spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      component: nats-server
+                  topologyKey: "kubernetes.io/hostname"
           # Common volumes for the containers
           volumes:
             - name: config-volume
@@ -281,7 +289,15 @@ objects:
         metadata:
           labels:
             app: ${APP_NAME}-${SUFFIX}
+            component: nats-consumer
         spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      component: nats-consumer
+                  topologyKey: "kubernetes.io/hostname"
           containers:
             - name: ${APP_NAME}-${SUFFIX}-nats-consumer
               image: ${IMAGE_REGISTRY}/${PROJ_TOOLS}/${IMAGE_NAME}:${IMAGE_TAG}

--- a/openshift/templates/nats.yaml
+++ b/openshift/templates/nats.yaml
@@ -159,6 +159,7 @@ objects:
               requiredDuringSchedulingIgnoredDuringExecution:
                 - labelSelector:
                     matchLabels:
+                      app: ${APP_NAME}-${SUFFIX}
                       component: nats-server
                   topologyKey: "kubernetes.io/hostname"
           # Common volumes for the containers


### PR DESCRIPTION

  #### Ack wait timeout 

  Increased the JetStream consumer ack_wait from 600 seconds (10 minutes) to 86400 seconds (24 hours). It's possible a longer timeout could happen but more likely cluster issues preventing job completion in the existing time window. When the previous timeout expired mid-run, NATS would redeliver the message and a duplicate job would start. With a 24-hour window, a consumer has the full processing time it needs before NATS considers the message unacknowledged.

  #### Pod anti-affinity 

  Added requiredDuringSchedulingIgnoredDuringExecution pod anti-affinity to both the NATS server StatefulSet and the nats-consumer Deployment. Each workload gets its own component label (nats-server / nats-consumer) used as the anti-affinity selector with `topologyKey: kubernetes.io/hostname`. This enforces at schedule time that no two pods of the same role share a node, so a single node failure can't take down all replicas of either the NATS cluster or its consumers.

Closes #5466
# Test Links:
[Landing Page](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5486-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
