### PR TITLE
Dev: Fix false-positive alerts from NATS consumer critical_hours logs

### DIFF
--- a/openshift/logging-alerts/nats_alerts.yaml
+++ b/openshift/logging-alerts/nats_alerts.yaml
@@ -17,8 +17,11 @@ spec:
             description: Alerts fire when any error/critical logs occur.
             summary: Nats is generating too many errors
           # Get the rate of error logs per second over the last minute, alert if any errors occurred.
+          # Uses regexp to parse the actual Python levelname from the log format rather than relying
+          # on the OpenShift collector's pre-extracted level label, which incorrectly tags logs from
+          # the critical_hours module as critical due to the module name containing "critical".
           expr: |
-            sum(rate({ kubernetes_namespace_name="e1e498-prod", kubernetes_pod_name=~"wps-prod-nats.*" } | json | level=~"critical|emerg|fatal|alert|crit|error|err|eror" [1m])) > 0
+            sum(rate({ kubernetes_namespace_name="e1e498-prod", kubernetes_pod_name=~"wps-prod-nats.*" } | regexp `- (?P<level>[A-Z]+) -` | level=~"ERROR|CRITICAL" [1m])) > 0
           for: 0s
           labels:
             namespace: e1e498-prod


### PR DESCRIPTION
 The NATS error alert was firing during normal critical hours processing runs. The root cause was a combination of two issues:

  1. The app logs in plain text format `(%(asctime)s - %(name)s - %(levelname)s - %(message)s)`, so `| json` was silently failing and not extracting a level label from log content.
  2. OpenShift's log collector pre-extracts a level label via naive keyword scanning of the full log line. Because the logger name `app.auto_spatial_advisory.critical_hours` contains the word `"critical"`, INFO-level logs from that module were tagged level=critical at ingest time.

  The fix replaces `| json | level=~"critical|emerg|..."` with `| regexp '- (?P<level>[A-Z]+) -' | level=~"ERROR|CRITICAL"`, which parses the
  actual Python levelname out of its known position in the log format string. This bypasses the collector's mislabelling and matches only logs
  genuinely emitted at ERROR or CRITICAL level.
# Test Links:
[Landing Page](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5493-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
