### PR TITLE
Dev: Handle Redis cache.set() errors to prevent false KubeJobFailed alerts

### DIFF
--- a/backend/packages/wps-shared/src/wps_shared/tests/weather_models/test_download.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/weather_models/test_download.py
@@ -1,0 +1,92 @@
+"""Tests for wps_shared.weather_models.download"""
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+import redis.exceptions
+import requests
+
+from wps_shared.tests.common import MockResponse
+from wps_shared.weather_models import download
+
+
+URL = "https://dd.weather.gc.ca/model_rdps/some_file.grib2"
+CACHE_VAR = "REDIS_CACHE_ENV_CANADA"
+EXPIRY_VAR = "REDIS_ENV_CANADA_CACHE_EXPIRY"
+
+
+@pytest.fixture
+def mock_200_response():
+    return MockResponse(content=b"grib data", status_code=200)
+
+
+@pytest.fixture
+def redis_down():
+    """Redis client that raises ConnectionError on every call."""
+    mock = MagicMock()
+    mock.get.side_effect = redis.exceptions.ConnectionError("Connection refused")
+    mock.set.side_effect = redis.exceptions.ConnectionError("Connection refused")
+    return mock
+
+
+@pytest.fixture
+def redis_up_empty():
+    """Redis client with no cached entry."""
+    mock = MagicMock()
+    mock.get.return_value = None
+    return mock
+
+
+class TestDownloadCacheDisabled:
+    def test_downloads_file_when_cache_disabled(self, monkeypatch, mock_200_response):
+        monkeypatch.setattr(requests, "get", lambda *_, **__: mock_200_response)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = download(URL, tmp, CACHE_VAR, "RDPS")
+        assert result is not None
+
+    def test_returns_none_on_404_when_cache_disabled(self, monkeypatch):
+        monkeypatch.setattr(requests, "get", lambda *_, **__: MockResponse(status_code=404))
+        with tempfile.TemporaryDirectory() as tmp:
+            result = download(URL, tmp, CACHE_VAR, "RDPS")
+        assert result is None
+
+
+class TestDownloadCacheEnabled:
+    def test_returns_cached_file_on_cache_hit(self, monkeypatch, mock_200_response):
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = b"cached grib data"
+        monkeypatch.setenv(CACHE_VAR, "True")
+        monkeypatch.setattr("wps_shared.utils.redis._create_redis", lambda: mock_redis)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = download(URL, tmp, CACHE_VAR, "RDPS")
+        assert result is not None
+        mock_redis.get.assert_called_once_with(URL)
+
+    def test_downloads_and_caches_on_cache_miss(self, monkeypatch, mock_200_response, redis_up_empty):
+        monkeypatch.setenv(CACHE_VAR, "True")
+        monkeypatch.setattr("wps_shared.utils.redis._create_redis", lambda: redis_up_empty)
+        monkeypatch.setattr(requests, "get", lambda *_, **__: mock_200_response)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = download(URL, tmp, CACHE_VAR, "RDPS", EXPIRY_VAR)
+        assert result is not None
+        redis_up_empty.set.assert_called_once()
+
+    def test_redis_get_failure_falls_through_to_download(self, monkeypatch, mock_200_response, redis_down, caplog):  # noqa: F811
+        monkeypatch.setenv(CACHE_VAR, "True")
+        monkeypatch.setattr("wps_shared.utils.redis._create_redis", lambda: redis_down)
+        monkeypatch.setattr(requests, "get", lambda *_, **__: mock_200_response)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = download(URL, tmp, CACHE_VAR, "RDPS")
+        assert result is not None
+        assert any("Connection refused" in r.message for r in caplog.records if r.levelname == "ERROR")
+
+    def test_redis_set_failure_does_not_raise(self, monkeypatch, mock_200_response, redis_up_empty, caplog):
+        """Redis being down during cache.set() must not propagate — this was the prod bug."""
+        redis_up_empty.set.side_effect = redis.exceptions.ConnectionError("Connection refused")
+        monkeypatch.setenv(CACHE_VAR, "True")
+        monkeypatch.setattr("wps_shared.utils.redis._create_redis", lambda: redis_up_empty)
+        monkeypatch.setattr(requests, "get", lambda *_, **__: mock_200_response)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = download(URL, tmp, CACHE_VAR, "RDPS", EXPIRY_VAR)
+        assert result is not None
+        assert any("Connection refused" in r.message for r in caplog.records if r.levelname == "ERROR")

--- a/backend/packages/wps-shared/src/wps_shared/weather_models/__init__.py
+++ b/backend/packages/wps-shared/src/wps_shared/weather_models/__init__.py
@@ -137,9 +137,12 @@ def download(url: str, path: str, config_cache_var: str, model_name: str, config
                 file_object.write(response.content)
             # Cache the response
             if cache:
-                with open(target, "rb") as file_object:
-                    # Cache for 6 hours (21600 seconds)
-                    cache.set(url, file_object.read(), ex=config.get(config_cache_expiry_var, 21600))
+                try:
+                    with open(target, "rb") as file_object:
+                        # Cache for 6 hours (21600 seconds)
+                        cache.set(url, file_object.read(), ex=config.get(config_cache_expiry_var, 21600))
+                except Exception as error:
+                    logger.error(error)
         elif response.status_code == 404:
             # We expect this to happen frequently - just log for info.
             logger.info("404 error for %s", url)


### PR DESCRIPTION
  - `cache.set()` in `wps_shared.weather_models.download` was not wrapped in a try/except, unlike `cache.get()`. When Redis was unavailable, a `ConnectionError` during cache write would propagate up through the per-URL
  exception handler, increment exception_count, and cause the job to exit non-zero — triggering `KubeJobFailed` alerts for every successfully downloaded file that couldn't be cached.
  - Wrap `cache.set()` in the same try/except pattern as `cache.get()`, logging the error and continuing.
# Test Links:
[Landing Page](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5494-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
