### PR TITLE
Dev: exception tracebacks not appearing in weather model job logs

### DIFF
--- a/backend/packages/wps-api/src/app/jobs/rdps_sfms.py
+++ b/backend/packages/wps-api/src/app/jobs/rdps_sfms.py
@@ -116,7 +116,7 @@ class RDPSGrib:
                 # We catch and log exceptions, but keep trying to download.
                 # We intentionally catch a broad exception, as we want to try and download as much
                 # as we can.
-                logger.error("unexpected exception processing %s", url, exc_info=exception)
+                logger.exception("unexpected exception processing %s", url)
 
     async def _process_model_run(self, model_run_hour: int):
         """Process a particular RDPS model run"""
@@ -140,10 +140,9 @@ class RDPSGrib:
                 # We catch and log exceptions, but keep trying to process.
                 # We intentionally catch a broad exception, as we want to try to process as much as we can.
                 self.exception_count += 1
-                logger.error(
+                logger.exception(
                     "unexpected exception processing RDPS model run %d",
                     hour,
-                    exc_info=exception,
                 )
 
     async def apply_retention_policy(self, days_to_retain: int):
@@ -214,9 +213,7 @@ def main():
         sys.exit(os.EX_OK)
     except Exception as exception:
         # Exit non 0 - failure.
-        logger.error(
-            "An error occurred while downloading and storing RDPS data.", exc_info=exception
-        )
+        logger.exception("An error occurred while downloading and storing RDPS data.")
         rc_message = ":scream: Encountered an error while processing RDPS data."
         send_chatops_notification(rc_message, exception)
         sys.exit(os.EX_SOFTWARE)

--- a/backend/packages/wps-api/src/app/jobs/rdps_sfms.py
+++ b/backend/packages/wps-api/src/app/jobs/rdps_sfms.py
@@ -111,7 +111,7 @@ class RDPSGrib:
                             finally:
                                 # delete the file when done.
                                 os.remove(downloaded)
-            except Exception as exception:
+            except Exception:
                 self.exception_count += 1
                 # We catch and log exceptions, but keep trying to download.
                 # We intentionally catch a broad exception, as we want to try and download as much
@@ -136,7 +136,7 @@ class RDPSGrib:
                 await self._process_model_run(hour)
                 if self.files_downloaded > 0:
                     create_model_run_for_sfms(self.session, ModelEnum.RDPS, self.now, hour)
-            except Exception as exception:
+            except Exception:
                 # We catch and log exceptions, but keep trying to process.
                 # We intentionally catch a broad exception, as we want to try to process as much as we can.
                 self.exception_count += 1

--- a/backend/packages/wps-jobs/src/weather_model_jobs/ecmwf.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/ecmwf.py
@@ -175,7 +175,7 @@ class ECMWF:
                     self.model_run_repository.mark_url_as_processed(url)
                 except Exception as exception:
                     self.exception_count += 1
-                    logger.error("unexpected exception processing %s", url, exc_info=exception)
+                    logger.exception("unexpected exception processing %s", url)
                     self.model_run_repository.session.rollback()
 
             # files_processed is incremented whether the file was processed previously or on this run, so we can use it to check if all files were processed.
@@ -194,11 +194,10 @@ class ECMWF:
             except Exception as exception:
                 # We intentionally catch a broad exception, as we want to try to process as much as we can.
                 self.exception_count += 1
-                logger.error(
+                logger.exception(
                     "unexpected exception processing %s model run %d",
                     self.model_type,
                     hour,
-                    exc_info=exception,
                 )
 
     def store_processed_result(
@@ -263,7 +262,7 @@ def main():
         # due to C extension teardown order (GDAL, PROJ, eccodes, etc.)
         os._exit(os.EX_OK)
     except Exception as exception:
-        logger.error("An error occurred while processing ECMWF model.", exc_info=exception)
+        logger.exception("An error occurred while processing ECMWF model.")
         rc_message = ":poop: Encountered error retrieving model data from ECMWF"
         send_chatops_notification(rc_message, exception)
         os._exit(os.EX_SOFTWARE)

--- a/backend/packages/wps-jobs/src/weather_model_jobs/ecmwf.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/ecmwf.py
@@ -173,7 +173,7 @@ class ECMWF:
 
                     self.files_processed += 1
                     self.model_run_repository.mark_url_as_processed(url)
-                except Exception as exception:
+                except Exception:
                     self.exception_count += 1
                     logger.exception("unexpected exception processing %s", url)
                     self.model_run_repository.session.rollback()
@@ -191,7 +191,7 @@ class ECMWF:
         for hour in get_model_run_hours(self.model_type):
             try:
                 self.process_model_run(hour)
-            except Exception as exception:
+            except Exception:
                 # We intentionally catch a broad exception, as we want to try to process as much as we can.
                 self.exception_count += 1
                 logger.exception(

--- a/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
@@ -171,7 +171,7 @@ def parse_high_res_model_url(url):
         prediction_hour = url_parts[8]
         prediction_timestamp = model_run_timestamp + datetime.timedelta(hours=int(prediction_hour))
         return variable_name, projection, model_run_timestamp, prediction_timestamp
-    except Exception as exc:
+    except Exception:
         logger.exception("HRDPS URL %s is not in the expected format", url)
 
 
@@ -295,7 +295,7 @@ class EnvCanada:
                             finally:
                                 # delete the file when done.
                                 os.remove(downloaded)
-            except Exception as exception:
+            except Exception:
                 self.exception_count += 1
                 # We catch and log exceptions, but keep trying to download.
                 # We intentionally catch a broad exception, as we want to try and download as much
@@ -329,7 +329,7 @@ class EnvCanada:
         for hour in get_env_canada_model_run_hours(self.model_type):
             try:
                 self.process_model_run(hour)
-            except Exception as exception:
+            except Exception:
                 # We catch and log exceptions, but keep trying to process.
                 # We intentionally catch a broad exception, as we want to try to process as much as we can.
                 self.exception_count += 1

--- a/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
@@ -172,8 +172,7 @@ def parse_high_res_model_url(url):
         prediction_timestamp = model_run_timestamp + datetime.timedelta(hours=int(prediction_hour))
         return variable_name, projection, model_run_timestamp, prediction_timestamp
     except Exception as exc:
-        logger.error("HRDPS URL %s is not in the expected format", url)
-        logger.error(exc_info=exc)
+        logger.exception("HRDPS URL %s is not in the expected format", url)
 
 
 def parse_env_canada_filename(url):
@@ -301,7 +300,7 @@ class EnvCanada:
                 # We catch and log exceptions, but keep trying to download.
                 # We intentionally catch a broad exception, as we want to try and download as much
                 # as we can.
-                logger.error("unexpected exception processing %s", url, exc_info=exception)
+                logger.exception("unexpected exception processing %s", url)
 
     def process_model_run(self, model_run_hour):
         """Process a particular model run"""
@@ -334,11 +333,10 @@ class EnvCanada:
                 # We catch and log exceptions, but keep trying to process.
                 # We intentionally catch a broad exception, as we want to try to process as much as we can.
                 self.exception_count += 1
-                logger.error(
+                logger.exception(
                     "unexpected exception processing %s model run %d",
                     self.model_type,
                     hour,
-                    exc_info=exception,
                 )
 
 
@@ -392,7 +390,7 @@ def main():
         sys.exit(os.EX_SOFTWARE)
     except Exception as exception:
         # We catch and log any exceptions we may have missed.
-        logger.error("unexpected exception processing", exc_info=exception)
+        logger.exception("unexpected exception processing")
         rc_message = f":poop: Encountered error retrieving {sys.argv[1]} model data from Env Canada"
         send_chatops_notification(rc_message, exception)
         # Exit with a failure code.

--- a/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
@@ -340,7 +340,7 @@ class NOAA:
                     )
                 else:
                     raise http_error
-            except Exception as exception:
+            except Exception:
                 self.exception_count += 1
                 # We catch and log exceptions, but keep trying to download.
                 # We intentionally catch a broad exception, as we want to try and download as much
@@ -375,7 +375,7 @@ class NOAA:
         for hour in get_gfs_and_nam_model_run_hours():
             try:
                 self.process_model_run(hour)
-            except Exception as exception:
+            except Exception:
                 # We catch and log exceptions, but keep trying to process.
                 # We intentionally catch a broad exception, as we want to try to process as much as we can.
                 self.exception_count += 1

--- a/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
@@ -336,7 +336,7 @@ class NOAA:
                         "Grib file not available at %s for url %s",
                         time_utils.get_utc_now(),
                         url,
-                        exc_info=http_error,
+                        exc_info=True,
                     )
                 else:
                     raise http_error
@@ -345,7 +345,7 @@ class NOAA:
                 # We catch and log exceptions, but keep trying to download.
                 # We intentionally catch a broad exception, as we want to try and download as much
                 # as we can.
-                logger.error("unexpected exception processing %s", url, exc_info=exception)
+                logger.exception("unexpected exception processing %s", url)
 
     def process_model_run(self, model_run_hour):
         """Process a particular model run"""
@@ -379,11 +379,10 @@ class NOAA:
                 # We catch and log exceptions, but keep trying to process.
                 # We intentionally catch a broad exception, as we want to try to process as much as we can.
                 self.exception_count += 1
-                logger.error(
+                logger.exception(
                     "unexpected exception processing %s model run %s",
                     self.model_type,
                     hour,
-                    exc_info=exception,
                 )
 
 
@@ -436,7 +435,7 @@ def main():
         sys.exit(os.EX_SOFTWARE)
     except Exception as exception:
         # We catch and log any exceptions we may have missed.
-        logger.error("unexpected exception processing", exc_info=exception)
+        logger.exception("unexpected exception processing")
         rc_message = ":poop: Encountered error retrieving {sys.argv[1]} model data from NOAA"
         send_chatops_notification(rc_message, exception)
         # Exit with a failure code.


### PR DESCRIPTION
  Exception tracebacks were silently dropped from log output in all weather model processing jobs. The root cause was passing `exc_info=exception` (an exception instance) to `logger.error()`. In Python 3.12+, this path
  extracts `exception.__traceback__` directly — if the traceback is `None` or absent, no stack trace is emitted. The idiomatic fix is `logger.exception()`, which always captures the full traceback via `sys.exc_info()`
  from within the active `except` block.

  **Changes:**
  - Replace `logger.error(..., exc_info=exception)` with `logger.exception(...)` across `env_canada.py`, `ecmwf.py`, `noaa.py`, and `rdps_sfms.py`
  - Merge a split two-call pattern in `env_canada.py` (`logger.error(msg)` + `logger.error(exc_info=exc)`) into a single `logger.exception(msg)`
  - Fix `logger.warning(..., exc_info=http_error)` in `noaa.py` to use `exc_info=True` (warnings have no `.exception` equivalent)
# Test Links:
[Landing Page](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5496-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
