### PR TITLE
ASA NaN Wind Speeds

### DIFF
--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/hfi_minimum_wind_speed.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/hfi_minimum_wind_speed.py
@@ -181,10 +181,13 @@ def get_minimum_wind_speed_for_hfi(
     if wind_nodata_value is not None:  # convert nodata values to np.nan
         wind_speed_array = np.where(wind_speed_array == wind_nodata_value, np.nan, wind_speed_array)
 
-    # Compute minimum wind speed for each classification
     min_wind_speeds: dict[int, float | None] = {}
     for hfi_class, mask in hfi_class_ids.items():
-        min_wind_speeds[hfi_class] = np.nanmin(wind_speed_array[mask]) if np.any(mask) else None
+        # nodata can overlap valid HFI pixels. Don't persist NaN when no real wind value exists.
+        finite_wind_speeds = wind_speed_array[mask & np.isfinite(wind_speed_array)]
+        min_wind_speeds[hfi_class] = (
+            float(np.min(finite_wind_speeds)) if finite_wind_speeds.size > 0 else None
+        )
 
     return min_wind_speeds
 

--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/zone_stats.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/zone_stats.py
@@ -3,7 +3,6 @@ Functions for computing fuel type stats
 """
 
 import logging
-import math
 from datetime import date
 from typing import List, Optional
 
@@ -20,13 +19,6 @@ from wps_shared.schemas.fba import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def finite_wind_speed_or_none(value: float | None) -> float | None:
-    if value is None:
-        return None
-    # existing rows may contain NaN from older runs, which JSON responses cannot encode.
-    return value if math.isfinite(value) else None
 
 
 """
@@ -119,7 +111,7 @@ def get_zone_wind_stats_for_source_id(
         all_zone_wind_stats.append(
             AdvisoryMinWindStats(
                 threshold=hfi_threshold,
-                min_wind_speed=finite_wind_speed_or_none(zone_wind_stats.min_wind_speed),
+                min_wind_speed=zone_wind_stats.min_wind_speed,
             )
         )
 

--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/zone_stats.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/zone_stats.py
@@ -1,22 +1,32 @@
 """
 Functions for computing fuel type stats
 """
+
 import logging
+import math
 from datetime import date
 from typing import List, Optional
+
 from wps_shared.db.models.auto_spatial_advisory import (
     SFMSFuelType as DBSFMSFuelType,
-    AdvisoryHFIWindSpeed
+    AdvisoryHFIWindSpeed,
 )
 from wps_shared.schemas.fba import (
     AdvisoryCriticalHours,
+    AdvisoryMinWindStats,
     ClassifiedHfiThresholdFuelTypeArea,
     HfiThreshold,
     SFMSFuelType,
-    AdvisoryMinWindStats
 )
 
 logger = logging.getLogger(__name__)
+
+
+def finite_wind_speed_or_none(value: float | None) -> float | None:
+    if value is None:
+        return None
+    # existing rows may contain NaN from older runs, which JSON responses cannot encode.
+    return value if math.isfinite(value) else None
 
 
 """
@@ -26,22 +36,34 @@ logger = logging.getLogger(__name__)
     <!-- July 31 to August 15 - 80% -->
     <!-- August 16 - October 31 (end of season) - 90% -->
 """
+
+
 def get_optional_percent_curing(grass_curing_date: date, sfms_fuel_type: DBSFMSFuelType):
     # 12 is the sfms fuel id for grass types
     if sfms_fuel_type is None or sfms_fuel_type.fuel_type_id != 12:
         return None
-    
-    if grass_curing_date >= date(grass_curing_date.year, 11, 1) and grass_curing_date <= date(grass_curing_date.year, 12, 31):
+
+    if grass_curing_date >= date(grass_curing_date.year, 11, 1) and grass_curing_date <= date(
+        grass_curing_date.year, 12, 31
+    ):
         return 60
-    if grass_curing_date >= date(grass_curing_date.year, 1, 1) and grass_curing_date <= date(grass_curing_date.year, 7, 15):
+    if grass_curing_date >= date(grass_curing_date.year, 1, 1) and grass_curing_date <= date(
+        grass_curing_date.year, 7, 15
+    ):
         return 60
-    if grass_curing_date >= date(grass_curing_date.year, 7, 16) and grass_curing_date <= date(grass_curing_date.year, 7, 30):
+    if grass_curing_date >= date(grass_curing_date.year, 7, 16) and grass_curing_date <= date(
+        grass_curing_date.year, 7, 30
+    ):
         return 70
-    if grass_curing_date >= date(grass_curing_date.year, 7, 31) and grass_curing_date <= date(grass_curing_date.year, 8, 15):
+    if grass_curing_date >= date(grass_curing_date.year, 7, 31) and grass_curing_date <= date(
+        grass_curing_date.year, 8, 15
+    ):
         return 80
-    if grass_curing_date >= date(grass_curing_date.year, 8, 16) and grass_curing_date <= date(grass_curing_date.year, 10, 31):
+    if grass_curing_date >= date(grass_curing_date.year, 8, 16) and grass_curing_date <= date(
+        grass_curing_date.year, 10, 31
+    ):
         return 90
-    
+
     return None
 
 
@@ -60,18 +82,29 @@ def get_fuel_type_area_stats(
         (ft for ft in sfms_fuel_types if ft.id == fuel_type_id), None
     )
     percent_curing = get_optional_percent_curing(grass_curing_date, fuel_type_obj)
-    fuel_type_code_details = fuel_type_obj.fuel_type_code + (f" (≥{percent_conifer} PC)" if percent_conifer is not None else "")
+    fuel_type_code_details = fuel_type_obj.fuel_type_code + (
+        f" (≥{percent_conifer} PC)" if percent_conifer is not None else ""
+    )
     return ClassifiedHfiThresholdFuelTypeArea(
-        fuel_type=SFMSFuelType(fuel_type_id=fuel_type_obj.fuel_type_id, fuel_type_code=fuel_type_code_details, description=fuel_type_obj.description),
+        fuel_type=SFMSFuelType(
+            fuel_type_id=fuel_type_obj.fuel_type_id,
+            fuel_type_code=fuel_type_code_details,
+            description=fuel_type_obj.description,
+        ),
         threshold=hfi_threshold,
-        critical_hours=AdvisoryCriticalHours(start_time=critical_hour_start, end_time=critical_hour_end),
+        critical_hours=AdvisoryCriticalHours(
+            start_time=critical_hour_start, end_time=critical_hour_end
+        ),
         area=area,
         fuel_area=fuel_area,
-        percent_curing=percent_curing)
+        percent_curing=percent_curing,
+    )
 
 
-def get_zone_wind_stats_for_source_id(zone_wind_stats: List[AdvisoryHFIWindSpeed], hfi_thresholds_by_id: dict[int, HfiThreshold]) -> List[AdvisoryMinWindStats]:
-    """ Marshall AdvisoryHFIWindSpeed data model objects into AdvisoryMinWindStats API model objects.
+def get_zone_wind_stats_for_source_id(
+    zone_wind_stats: List[AdvisoryHFIWindSpeed], hfi_thresholds_by_id: dict[int, HfiThreshold]
+) -> List[AdvisoryMinWindStats]:
+    """Marshall AdvisoryHFIWindSpeed data model objects into AdvisoryMinWindStats API model objects.
 
     :param zone_wind_stats: advisory hfi wind speeds for a zone
     :param hfi_thresholds_by_id: hfi thresholds keyed by their ids
@@ -79,10 +112,15 @@ def get_zone_wind_stats_for_source_id(zone_wind_stats: List[AdvisoryHFIWindSpeed
     """
     all_zone_wind_stats = []
     for zone_wind_stats in zone_wind_stats:
-            hfi_threshold = hfi_thresholds_by_id.get(zone_wind_stats.threshold)
-            if hfi_threshold is None:
-                logger.error(f"No hfi threshold for id: ${zone_wind_stats.threshold}")
-                continue
-            all_zone_wind_stats.append(AdvisoryMinWindStats(threshold=hfi_threshold, min_wind_speed=zone_wind_stats.min_wind_speed if zone_wind_stats else None))
+        hfi_threshold = hfi_thresholds_by_id.get(zone_wind_stats.threshold)
+        if hfi_threshold is None:
+            logger.error(f"No hfi threshold for id: ${zone_wind_stats.threshold}")
+            continue
+        all_zone_wind_stats.append(
+            AdvisoryMinWindStats(
+                threshold=hfi_threshold,
+                min_wind_speed=finite_wind_speed_or_none(zone_wind_stats.min_wind_speed),
+            )
+        )
 
     return all_zone_wind_stats

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_hfi_minimum_wind_speed.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_hfi_minimum_wind_speed.py
@@ -3,7 +3,10 @@ from wps_shared.db.crud.auto_spatial_advisory import HfiClassificationThresholdE
 
 from app.auto_spatial_advisory.hfi_minimum_wind_speed import get_minimum_wind_speed_for_hfi
 
-mock_advisory_id_lut = {HfiClassificationThresholdEnum.ADVISORY.value: 1, HfiClassificationThresholdEnum.WARNING.value: 2}
+mock_advisory_id_lut = {
+    HfiClassificationThresholdEnum.ADVISORY.value: 1,
+    HfiClassificationThresholdEnum.WARNING.value: 2,
+}
 
 
 def test_minimum_wind_speed_for_hfi_normal_case():
@@ -12,8 +15,12 @@ def test_minimum_wind_speed_for_hfi_normal_case():
 
     result = get_minimum_wind_speed_for_hfi(wind_speed_array, hfi_array, mock_advisory_id_lut, -1)
 
-    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.ADVISORY.value]] == 10  # Smallest wind speed where HFI is 4000-9999
-    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.WARNING.value]] == 15  # Smallest wind speed where HFI is >= 10000
+    assert (
+        result[mock_advisory_id_lut[HfiClassificationThresholdEnum.ADVISORY.value]] == 10
+    )  # Smallest wind speed where HFI is 4000-9999
+    assert (
+        result[mock_advisory_id_lut[HfiClassificationThresholdEnum.WARNING.value]] == 15
+    )  # Smallest wind speed where HFI is >= 10000
 
 
 def test_no_matching_hfi_values():
@@ -32,8 +39,32 @@ def test_hfi_values_with_nan():
 
     result = get_minimum_wind_speed_for_hfi(wind_speed_array, hfi_array, mock_advisory_id_lut, -1)
 
-    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.ADVISORY.value]] == 10  # min wind speed should be 10
-    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.WARNING.value]] == 25  # Ignore NaN, min wind speed should be 20
+    assert (
+        result[mock_advisory_id_lut[HfiClassificationThresholdEnum.ADVISORY.value]] == 10
+    )  # min wind speed should be 10
+    assert (
+        result[mock_advisory_id_lut[HfiClassificationThresholdEnum.WARNING.value]] == 25
+    )  # Ignore NaN, min wind speed should be 20
+
+
+def test_hfi_values_with_nan_wind_speeds_use_finite_minimums():
+    wind_speed_array = np.array([5, np.nan, np.nan, 20, 25])
+    hfi_array = np.array([1000, 5000, 12000, 8000, 15000])
+
+    result = get_minimum_wind_speed_for_hfi(wind_speed_array, hfi_array, mock_advisory_id_lut, -1)
+
+    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.ADVISORY.value]] == 20
+    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.WARNING.value]] == 25
+
+
+def test_hfi_values_with_only_nodata_wind_speeds_returns_none():
+    wind_speed_array = np.array([5, -1, -1, 20])
+    hfi_array = np.array([1000, 5000, 12000, 8000])
+
+    result = get_minimum_wind_speed_for_hfi(wind_speed_array, hfi_array, mock_advisory_id_lut, -1)
+
+    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.ADVISORY.value]] == 20
+    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.WARNING.value]] is None
 
 
 def test_empty_arrays():

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_zone_stats.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_zone_stats.py
@@ -1,3 +1,4 @@
+import math
 from datetime import date
 
 import pytest
@@ -167,3 +168,15 @@ def test_get_zone_wind_stats(zone_wind_stats, hfi_thresholds_by_id, expected_adv
         )
         == expected_advisory_wind_stats
     )
+
+
+def test_get_zone_wind_stats_normalizes_nan_min_wind_speed():
+    zone_wind_stats = [
+        AdvisoryHFIWindSpeed(
+            id=1, advisory_shape_id=1, threshold=1, run_parameters=1, min_wind_speed=math.nan
+        )
+    ]
+
+    result = get_zone_wind_stats_for_source_id(zone_wind_stats, hfi_threshold_by_id)
+
+    assert result == [AdvisoryMinWindStats(threshold=advisory_threshold, min_wind_speed=None)]

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_zone_stats.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_zone_stats.py
@@ -209,5 +209,12 @@ def test_get_zone_wind_stats_skips_unknown_threshold():
     assert result == [AdvisoryMinWindStats(threshold=advisory_threshold, min_wind_speed=10)]
 
 
-def test_percent_curing_none_fuel_type():
-    assert get_optional_percent_curing(date(2024, 8, 1), None) is None
+def test_percent_curing_non_fuel_type():
+    non_fuel_type = SFMSFuelType(
+        id=99,
+        fuel_type_id=99,
+        fuel_type_code="Non-fuel",
+        description="Non-fuel",
+    )
+
+    assert get_optional_percent_curing(date(2024, 8, 1), non_fuel_type) is None

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_zone_stats.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_zone_stats.py
@@ -180,3 +180,34 @@ def test_get_zone_wind_stats_normalizes_nan_min_wind_speed():
     result = get_zone_wind_stats_for_source_id(zone_wind_stats, hfi_threshold_by_id)
 
     assert result == [AdvisoryMinWindStats(threshold=advisory_threshold, min_wind_speed=None)]
+
+
+def test_get_zone_wind_stats_normalizes_inf_min_wind_speed():
+    zone_wind_stats = [
+        AdvisoryHFIWindSpeed(
+            id=1, advisory_shape_id=1, threshold=1, run_parameters=1, min_wind_speed=math.inf
+        )
+    ]
+
+    result = get_zone_wind_stats_for_source_id(zone_wind_stats, hfi_threshold_by_id)
+
+    assert result == [AdvisoryMinWindStats(threshold=advisory_threshold, min_wind_speed=None)]
+
+
+def test_get_zone_wind_stats_skips_unknown_threshold():
+    zone_wind_stats = [
+        AdvisoryHFIWindSpeed(
+            id=1, advisory_shape_id=1, threshold=99, run_parameters=1, min_wind_speed=5
+        ),
+        AdvisoryHFIWindSpeed(
+            id=2, advisory_shape_id=1, threshold=1, run_parameters=1, min_wind_speed=10
+        ),
+    ]
+
+    result = get_zone_wind_stats_for_source_id(zone_wind_stats, hfi_threshold_by_id)
+
+    assert result == [AdvisoryMinWindStats(threshold=advisory_threshold, min_wind_speed=10)]
+
+
+def test_percent_curing_none_fuel_type():
+    assert get_optional_percent_curing(date(2024, 8, 1), None) is None

--- a/backend/packages/wps-shared/src/wps_shared/db/models/auto_spatial_advisory.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/models/auto_spatial_advisory.py
@@ -329,6 +329,15 @@ class AdvisoryHFIWindSpeed(Base):
     run_parameters = Column(Integer, ForeignKey(RunParameters.id), nullable=False, index=True)
     _min_wind_speed = Column("min_wind_speed", Float, nullable=True)
 
+    # hybrid_property exposes _min_wind_speed through three roles:
+    #   - getter (instance): normalizes NaN/Inf stored by raster calculations to None
+    #   - expression (class): returns the raw Column so the property can be used in SQLAlchemy
+    #     query filters/ordering (e.g. .filter(AdvisoryHFIWindSpeed.min_wind_speed > 5));
+    #     without this, class-level access would invoke the getter and fail on a Column object
+    #   - setter: delegates to the underlying column attribute
+    # Pyright reports false-positive redeclaration and type errors here because it does not
+    # model SQLAlchemy's hybrid_property descriptor; the three same-named methods are
+    # intentional and correct at runtime.
     @hybrid_property
     def min_wind_speed(self) -> float | None:
         v = self._min_wind_speed

--- a/backend/packages/wps-shared/src/wps_shared/db/models/auto_spatial_advisory.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/models/auto_spatial_advisory.py
@@ -1,4 +1,5 @@
 import enum
+import math
 
 from geoalchemy2 import Geometry
 from sqlalchemy import (
@@ -14,6 +15,7 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from wps_shared.db.models import Base
 from wps_shared.db.models.common import TZTimeStamp
@@ -325,7 +327,21 @@ class AdvisoryHFIWindSpeed(Base):
         Integer, ForeignKey(HfiClassificationThreshold.id), nullable=False, index=True
     )
     run_parameters = Column(Integer, ForeignKey(RunParameters.id), nullable=False, index=True)
-    min_wind_speed = Column(Float, nullable=True)
+    _min_wind_speed = Column("min_wind_speed", Float, nullable=True)
+
+    @hybrid_property
+    def min_wind_speed(self) -> float | None:
+        v = self._min_wind_speed
+        return v if v is None or math.isfinite(v) else None
+
+    @min_wind_speed.expression
+    @classmethod
+    def min_wind_speed(cls):
+        return cls._min_wind_speed
+
+    @min_wind_speed.setter
+    def min_wind_speed(self, value: float | None):
+        self._min_wind_speed = value
 
 
 class AdvisoryHFIPercentConifer(Base):

--- a/backend/packages/wps-shared/src/wps_shared/tests/db/models/test_advisory_hfi_wind_speed.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/db/models/test_advisory_hfi_wind_speed.py
@@ -159,7 +159,7 @@ async def test_finite_wind_speed_passes_through(async_session, prerequisites):
     )
     fetched = result.scalar_one()
 
-    assert fetched.min_wind_speed == 12.5
+    assert fetched.min_wind_speed == pytest.approx(12.5)
 
 
 @pytest.mark.anyio

--- a/backend/packages/wps-shared/src/wps_shared/tests/db/models/test_advisory_hfi_wind_speed.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/db/models/test_advisory_hfi_wind_speed.py
@@ -1,0 +1,184 @@
+"""Integration tests for AdvisoryHFIWindSpeed.min_wind_speed hybrid property.
+
+These tests verify that legacy NaN values stored in the database are normalized
+to None when read back through the ORM, without affecting normal values.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from geoalchemy2 import WKTElement
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.future import select
+from testcontainers.postgres import PostgresContainer
+
+from wps_shared.db.models import Base
+from wps_shared.db.models.auto_spatial_advisory import (
+    AdvisoryHFIWindSpeed,
+    HfiClassificationThreshold,
+    RunParameters,
+    Shape,
+    ShapeType,
+    ShapeTypeEnum,
+)
+from wps_shared.db.models.psu import FireCentre
+from wps_shared.run_type import RunType
+from wps_shared.tests.common import TESTCONTAINERS_POSTGRES_IMAGE
+
+test_run_datetime = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+test_for_date = test_run_datetime.date()
+
+
+@pytest.fixture(scope="function")
+def postgres_container():
+    with PostgresContainer(TESTCONTAINERS_POSTGRES_IMAGE) as postgres:
+        yield postgres
+
+
+@pytest.fixture(scope="function")
+async def engine(postgres_container):
+    sync_url = postgres_container.get_connection_url()
+    db_url = sync_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
+
+    engine = create_async_engine(db_url, echo=False)
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            text("""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'hficlassificationthresholdenum') THEN
+                    CREATE TYPE hficlassificationthresholdenum AS ENUM ('advisory', 'warning');
+                END IF;
+                IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'runtypeenum') THEN
+                    CREATE TYPE runtypeenum AS ENUM ('actual', 'forecast');
+                END IF;
+            END
+            $$;
+        """)
+        )
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+async def session_factory(engine):
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+async def async_session(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture(scope="function")
+async def prerequisites(session_factory):
+    """Shared prerequisite rows needed for AdvisoryHFIWindSpeed FK constraints."""
+    async with session_factory() as session:
+        shape_type = ShapeType(name=ShapeTypeEnum.fire_zone_unit)
+        fire_centre = FireCentre(name="Test Centre")
+        session.add_all([shape_type, fire_centre])
+        await session.commit()
+
+        shape = Shape(
+            source_identifier="1",
+            placename_label="Zone 1",
+            fire_centre=fire_centre.id,
+            shape_type=shape_type.id,
+            geom=WKTElement("MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)))", srid=3005),
+        )
+        threshold = HfiClassificationThreshold(description="advisory", name="advisory")
+        run_param = RunParameters(
+            run_type=RunType.FORECAST.value,
+            run_datetime=test_run_datetime,
+            for_date=test_for_date,
+            complete=True,
+        )
+        session.add_all([shape, threshold, run_param])
+        await session.commit()
+
+        return shape, threshold, run_param
+
+
+@pytest.mark.anyio
+async def test_nan_wind_speed_stored_in_db_reads_as_none(async_session, prerequisites):
+    """Legacy rows with NaN stored in the DB should surface as None via the hybrid property."""
+    shape, threshold, run_param = prerequisites
+
+    await async_session.execute(
+        text(
+            "INSERT INTO advisory_hfi_wind_speed "
+            "(advisory_shape_id, threshold, run_parameters, min_wind_speed) "
+            "VALUES (:shape_id, :threshold_id, :run_param_id, 'NaN'::float)"
+        ),
+        {"shape_id": shape.id, "threshold_id": threshold.id, "run_param_id": run_param.id},
+    )
+    await async_session.commit()
+
+    # PostgreSQL treats NaN = NaN as true (unlike IEEE 754), so this finds the row.
+    result = await async_session.execute(
+        text(
+            "SELECT id FROM advisory_hfi_wind_speed "
+            "WHERE advisory_shape_id = :shape_id AND min_wind_speed = 'NaN'::float "
+            "ORDER BY id DESC LIMIT 1"
+        ),
+        {"shape_id": shape.id},
+    )
+    row_id = result.scalar_one()
+
+    result = await async_session.execute(
+        select(AdvisoryHFIWindSpeed).where(AdvisoryHFIWindSpeed.id == row_id)
+    )
+    row = result.scalar_one()
+
+    assert row is not None
+    assert row.min_wind_speed is None
+
+
+@pytest.mark.anyio
+async def test_finite_wind_speed_passes_through(async_session, prerequisites):
+    """Finite values should be returned unchanged."""
+    shape, threshold, run_param = prerequisites
+
+    record = AdvisoryHFIWindSpeed(
+        advisory_shape_id=shape.id,
+        threshold=threshold.id,
+        run_parameters=run_param.id,
+        min_wind_speed=12.5,
+    )
+    async_session.add(record)
+    await async_session.commit()
+
+    result = await async_session.execute(
+        select(AdvisoryHFIWindSpeed).where(AdvisoryHFIWindSpeed.id == record.id)
+    )
+    fetched = result.scalar_one()
+
+    assert fetched.min_wind_speed == 12.5
+
+
+@pytest.mark.anyio
+async def test_null_wind_speed_passes_through(async_session, prerequisites):
+    """NULL values (no data for that zone/threshold) should remain None."""
+    shape, threshold, run_param = prerequisites
+
+    record = AdvisoryHFIWindSpeed(
+        advisory_shape_id=shape.id,
+        threshold=threshold.id,
+        run_parameters=run_param.id,
+        min_wind_speed=None,
+    )
+    async_session.add(record)
+    await async_session.commit()
+
+    result = await async_session.execute(
+        select(AdvisoryHFIWindSpeed).where(AdvisoryHFIWindSpeed.id == record.id)
+    )
+    fetched = result.scalar_one()
+
+    assert fetched.min_wind_speed is None


### PR DESCRIPTION
- Minimum wind speeds had been stored as NaN in our data base. This could very rarely happen if SFMS data was missing and/or there were no high HFI pixels in a zone. This would result in a JSON serialization error and no fuel/hfi data would get sent to the frontend
- This fixes the wind processing, to store NULL instead of NaN and adds model verification so existing NaN values are converted to NULL
# Test Links:
[Landing Page](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5497-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
