### PR TITLE
Dev: prevent NaN min_wind_speed values from breaking JSON serialization

### DIFF
--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/hfi_minimum_wind_speed.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/hfi_minimum_wind_speed.py
@@ -184,7 +184,12 @@ def get_minimum_wind_speed_for_hfi(
     # Compute minimum wind speed for each classification
     min_wind_speeds: dict[int, float | None] = {}
     for hfi_class, mask in hfi_class_ids.items():
-        min_wind_speeds[hfi_class] = np.nanmin(wind_speed_array[mask]) if np.any(mask) else None
+        if not np.any(mask):
+            min_wind_speeds[hfi_class] = None
+            continue
+        values = wind_speed_array[mask]
+        valid = values[~np.isnan(values)]
+        min_wind_speeds[hfi_class] = float(np.min(valid)) if len(valid) > 0 else None
 
     return min_wind_speeds
 

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_hfi_minimum_wind_speed.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_hfi_minimum_wind_speed.py
@@ -54,3 +54,15 @@ def test_arrays_with_no_data_values():
 
     assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.ADVISORY.value]] == 15
     assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.WARNING.value]] == 14
+
+
+def test_all_masked_wind_speeds_are_nodata():
+    """When every pixel at an HFI threshold has nodata wind speed, result must be None not NaN."""
+    wind_speed_array = np.array([5, -1, -1, 20])
+    hfi_array = np.array([1000, 5000, 8000, 500])
+
+    result = get_minimum_wind_speed_for_hfi(wind_speed_array, hfi_array, mock_advisory_id_lut, -1)
+
+    # Both advisory-threshold pixels (index 1, 2) have nodata (-1 → NaN), so result must be None
+    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.ADVISORY.value]] is None
+    assert result[mock_advisory_id_lut[HfiClassificationThresholdEnum.WARNING.value]] is None

--- a/backend/packages/wps-shared/src/wps_shared/schemas/fba.py
+++ b/backend/packages/wps-shared/src/wps_shared/schemas/fba.py
@@ -1,9 +1,10 @@
 """This module contains pydantic models related to the new formal/non-tinker fba."""
 
+import math
 from datetime import date, datetime
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from wps_shared.schemas.auto_spatial_advisory import SFMSRunType
 from wps_shared.schemas.psu import FireCentre
@@ -126,6 +127,13 @@ class AdvisoryMinWindStats(BaseModel):
 
     threshold: HfiThreshold
     min_wind_speed: Optional[float]
+
+    @field_validator("min_wind_speed", mode="before")
+    @classmethod
+    def nan_to_none(cls, v):
+        if isinstance(v, float) and math.isnan(v):
+            return None
+        return v
 
 
 class FireZoneHFIStats(BaseModel):


### PR DESCRIPTION
  - `np.nanmin()` returns `float('nan')` (not `None`) when every pixel at an HFI
    threshold has a nodata wind speed value. That NaN passed the `is not None` guard
    in `create_hfi_wind_speed_record`, got persisted to the DB, and caused FastAPI to
    crash on serialization (`Out of range float values are not JSON compliant: nan`).

  - Fixed `get_minimum_wind_speed_for_hfi` to filter out nodata (`NaN`) values before
    calling `np.min`, returning `None` when no valid wind speed values exist for a
    threshold — preventing future bad data from entering the DB.

  - Added a Pydantic `field_validator` on `AdvisoryMinWindStats.min_wind_speed` to
    coerce any NaN already stored in the DB to `None` at read time, fixing the
    immediate production error without requiring a DB migration. 
# Test Links:
[Landing Page](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5498-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
