### PR TITLE
Dev: Fix chatops notifications truncating the wrong end of tracebacks

### DIFF
--- a/backend/packages/wps-shared/src/wps_shared/chatops_notification.py
+++ b/backend/packages/wps-shared/src/wps_shared/chatops_notification.py
@@ -36,7 +36,7 @@ def send_chatops_notification(text: str, exc_info: Exception) -> str | None:
         f"{config.get('HOSTNAME')} ({threading.get_native_id()}): {exc_info}\n"
     )
     max_tb_len = webhook_max_char_len - len(header) - 8  # 8 for "```\n" + "\n```"
-    full_message = f"{header}```\n{traceback_str[:max_tb_len]}\n```"
+    full_message = f"{header}```\n{traceback_str[-max_tb_len:]}\n```"
     pod_logs_url = f"{config.get('OPENSHIFT_CONSOLE_URL')}/k8s/ns/{config.get('PROJECT_NAMESPACE')}/pods/{config.get('HOSTNAME')}/logs"
     result = None
     try:

--- a/backend/packages/wps-shared/src/wps_shared/tests/test_chatops_notification.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/test_chatops_notification.py
@@ -74,3 +74,20 @@ def test_returns_none_on_request_exception(monkeypatch):
 def test_does_not_raise_on_exception(monkeypatch):
     monkeypatch.setattr(requests, "post", MagicMock(side_effect=Exception("unexpected")))
     send_chatops_notification("test", Exception("err"))  # must not raise
+
+
+def test_long_traceback_preserves_tail(monkeypatch, mock_post):
+    """When traceback exceeds the 2000-char limit, the tail (innermost frame + exception line) is
+    kept rather than the head. The header already contains str(exc), so we assert on the
+    'ExceptionType: message' form which only appears in the traceback itself."""
+    try:
+        raise ValueError("unique_sentinel_value")
+    except ValueError as exc:
+        exception = exc
+
+    # Small limit so the traceback is truncated; head-truncation would lose the final
+    # "ValueError: unique_sentinel_value" line while tail-truncation keeps it.
+    monkeypatch.setattr("wps_shared.chatops_notification.webhook_max_char_len", 200)
+    send_chatops_notification("test", exception)
+    body = mock_post.call_args.kwargs["json"]["body"]
+    assert "ValueError: unique_sentinel_value" in body


### PR DESCRIPTION
  When a traceback exceeded the 2000-character webhook limit, the message was
  head-truncated (`[:max_tb_len]`), keeping the outermost (least useful) frames
  and discarding the exception type, message, and innermost frames at the bottom.

  Changed to tail-truncate (`[-max_tb_len:]`) so the most actionable part of the
  traceback — the exception line and innermost frames — is always preserved within
  the character limit.

  Added a regression test that verifies `ExceptionType: message` (which only
  appears in the traceback tail, not the header) survives truncation.
# Test Links:
[Landing Page](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5499-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
