### PR TITLE
Jobs CI fix

### DIFF
--- a/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
@@ -212,7 +212,6 @@ def test_ecmwf_process(mock_herbie_instance, mocker: MockerFixture):
 
 
 def test_ecmwf_process_model_run_exception(mock_herbie_instance, mocker: MockerFixture):
-    mocker.patch("weather_model_jobs.ecmwf.get_ecmwf_forecast_hours", return_value=[0])
     mocker.patch(
         "weather_model_jobs.ecmwf.get_ecmwf_transformer",
         side_effect=Exception("test exception"),
@@ -220,14 +219,14 @@ def test_ecmwf_process_model_run_exception(mock_herbie_instance, mocker: MockerF
 
     stations = [WeatherStation(code="001", name="Station1", lat=10.0, long=20.0)]
     mock_repo = MockModelRunRepository()
+    mark_complete_spy = mocker.spy(mock_repo, "mark_model_run_interpolated")
 
     ecmwf = ECMWF("/tmp", stations, mock_repo)
 
-    ecmwf.process_model_run(0)
+    ecmwf.process()
 
-    mock_repo.mark_prediction_model_run_processed.assert_not_called()
-    mock_repo.session.rollback.assert_called_once()
-    assert ecmwf.exception_count == 1
+    assert mark_complete_spy.call_count == 0
+    assert ecmwf.exception_count == (num_forecast_hours * 2)
 
 
 @pytest.mark.parametrize(

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
@@ -25,6 +25,10 @@ from wps_shared.tests.common import default_mock_client_get
 num_forecast_hours = len(list(get_ecmwf_forecast_hours()))
 
 
+def raise_system_exit(code: int):
+    raise SystemExit(code)
+
+
 @pytest.fixture
 def mock_stations():
     return [
@@ -274,6 +278,7 @@ def test_main_success(mocker: MockerFixture, monkeypatch):
 
     monkeypatch.setattr(ClientSession, "get", default_mock_client_get)
     monkeypatch.setattr(weather_model_jobs.ecmwf, "process_models", mock_process_models)
+    mocker.patch.object(weather_model_jobs.ecmwf.os, "_exit", side_effect=raise_system_exit)
     rocket_chat_spy = mocker.spy(weather_model_jobs.ecmwf, "send_chatops_notification")
 
     with pytest.raises(SystemExit) as excinfo:
@@ -293,6 +298,7 @@ def test_main_fail(mocker: MockerFixture, monkeypatch):
 
     rocket_chat_spy = mocker.spy(weather_model_jobs.ecmwf, "send_chatops_notification")
     monkeypatch.setattr(weather_model_jobs.ecmwf, "process_models", mock_process_models)
+    mocker.patch.object(weather_model_jobs.ecmwf.os, "_exit", side_effect=raise_system_exit)
 
     with pytest.raises(SystemExit) as excinfo:
         weather_model_jobs.ecmwf.main()

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
@@ -1,7 +1,7 @@
 import math
 import os
 from datetime import datetime
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import numpy as np
 import pytest
@@ -271,14 +271,11 @@ def test_ecmwf_process_handles_exceptions(monkeypatch):
 
 def test_main_success(mocker: MockerFixture, monkeypatch):
     """Test the main function when it runs successfully."""
-
-    async def mock_process_models():
-        """No implementation required."""
-        pass
+    mock_process_models = AsyncMock()
 
     monkeypatch.setattr(ClientSession, "get", default_mock_client_get)
     monkeypatch.setattr(weather_model_jobs.ecmwf, "process_models", mock_process_models)
-    mocker.patch.object(weather_model_jobs.ecmwf.os, "_exit", side_effect=raise_system_exit)
+    mocker.patch.object(weather_model_jobs.ecmwf, "exit_process", side_effect=raise_system_exit)
     rocket_chat_spy = mocker.spy(weather_model_jobs.ecmwf, "send_chatops_notification")
 
     with pytest.raises(SystemExit) as excinfo:
@@ -298,7 +295,7 @@ def test_main_fail(mocker: MockerFixture, monkeypatch):
 
     rocket_chat_spy = mocker.spy(weather_model_jobs.ecmwf, "send_chatops_notification")
     monkeypatch.setattr(weather_model_jobs.ecmwf, "process_models", mock_process_models)
-    mocker.patch.object(weather_model_jobs.ecmwf.os, "_exit", side_effect=raise_system_exit)
+    mocker.patch.object(weather_model_jobs.ecmwf, "exit_process", side_effect=raise_system_exit)
 
     with pytest.raises(SystemExit) as excinfo:
         weather_model_jobs.ecmwf.main()

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
@@ -45,6 +45,7 @@ class MockModelRunRepository(ModelRunRepository):
         # Mock methods for call tracking in tests
         self.get_model_run_prediction = MagicMock()
         self.store_model_run_prediction = MagicMock()
+        self.mark_prediction_model_run_processed = MagicMock()
 
     def get_prediction_model(self, _, __):
         return ModelEnum.ECMWF
@@ -193,7 +194,12 @@ def test_ecmwf_process_model_partial_process(mock_herbie_instance, mocker: Mocke
     assert mock_repository.mark_prediction_model_run_processed.call_count == 0
 
 
-def test_ecmwf_process(mock_herbie_instance):
+def test_ecmwf_process(mock_herbie_instance, mocker: MockerFixture):
+    mocker.patch("weather_model_jobs.ecmwf.get_ecmwf_transformer", return_value=MagicMock())
+    mocker.patch("weather_model_jobs.ecmwf.get_stations_dataframe", return_value=MagicMock())
+    mocker.patch.object(ECMWFModelProcessor, "process_grib_data", return_value=MagicMock())
+    mocker.patch.object(ECMWF, "store_processed_result", return_value=None)
+
     mock_repo = MockModelRunRepository()
     stations = [WeatherStation(code="001", name="Station1", lat=10.0, long=20.0)]
     ecmwf = ECMWF("/tmp", stations, mock_repo)
@@ -202,9 +208,11 @@ def test_ecmwf_process(mock_herbie_instance):
     assert mock_repo.get_or_create_prediction_run_calls == 2  # For hours 0 and 12
     # For each hour (0 and 12) get all the forecast hours (2 * (len(range(0, 145, 3)) + len(range(150, 241, 6)))
     assert ecmwf.files_downloaded == num_forecast_hours * 2
+    assert ecmwf.exception_count == 0
 
 
 def test_ecmwf_process_model_run_exception(mock_herbie_instance, mocker: MockerFixture):
+    mocker.patch("weather_model_jobs.ecmwf.get_ecmwf_forecast_hours", return_value=[0])
     mocker.patch(
         "weather_model_jobs.ecmwf.get_ecmwf_transformer",
         side_effect=Exception("test exception"),
@@ -212,14 +220,14 @@ def test_ecmwf_process_model_run_exception(mock_herbie_instance, mocker: MockerF
 
     stations = [WeatherStation(code="001", name="Station1", lat=10.0, long=20.0)]
     mock_repo = MockModelRunRepository()
-    mark_complete_spy = mocker.spy(mock_repo, "mark_model_run_interpolated")
 
     ecmwf = ECMWF("/tmp", stations, mock_repo)
 
-    ecmwf.process()
+    ecmwf.process_model_run(0)
 
-    assert mark_complete_spy.call_count == 0
-    assert ecmwf.exception_count == (num_forecast_hours * 2)
+    mock_repo.mark_prediction_model_run_processed.assert_not_called()
+    mock_repo.session.rollback.assert_called_once()
+    assert ecmwf.exception_count == 1
 
 
 @pytest.mark.parametrize(

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_hrdps.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_hrdps.py
@@ -172,7 +172,7 @@ def test_parse_high_res_model_url_correct_format():
         {
             "url": "https://dd.weather.gc.ca/today/model_hrdps/continental/2.5km/06/012/20230322T06Z_MSC_HRDPS_TMP_AGL-2m_RLatLon0.0225_PT012.grib2",
             "variable_name": "TMP_AGL-2m",
-            "projection": ProjectionEnum.HIGH_RES_CONTINENTAL,
+            "projection": ProjectionEnum.HRDPS_LATLON,
             "model_run_timestamp": datetime.datetime(
                 2023, 3, 22, 6, 0, tzinfo=datetime.timezone.utc
             ),
@@ -183,7 +183,7 @@ def test_parse_high_res_model_url_correct_format():
         {
             "url": "https://dd.weather.gc.ca/today/model_hrdps/continental/2.5km/06/012/20230322T06Z_MSC_HRDPS_WIND_AGL-10m_RLatLon0.0225_PT012.grib2",
             "variable_name": "WIND_AGL-10m",
-            "projection": ProjectionEnum.HIGH_RES_CONTINENTAL,
+            "projection": ProjectionEnum.HRDPS_LATLON,
             "model_run_timestamp": datetime.datetime(
                 2023, 3, 22, 6, 0, tzinfo=datetime.timezone.utc
             ),
@@ -194,7 +194,7 @@ def test_parse_high_res_model_url_correct_format():
         {
             "url": "https://dd.weather.gc.ca/today/model_hrdps/continental/2.5km/06/012/20230322T06Z_MSC_HRDPS_APCP_Sfc_RLatLon0.0225_PT012.grib2",
             "variable_name": "APCP_Sfc",
-            "projection": ProjectionEnum.HIGH_RES_CONTINENTAL,
+            "projection": ProjectionEnum.HRDPS_LATLON,
             "model_run_timestamp": datetime.datetime(
                 2023, 3, 22, 6, 0, tzinfo=datetime.timezone.utc
             ),
@@ -205,7 +205,7 @@ def test_parse_high_res_model_url_correct_format():
         {
             "url": "https://dd.weather.gc.ca/today/model_hrdps/continental/2.5km/12/084/20230322T12Z_MSC_HRDPS_RH_AGL-2m_RLatLon0.0225_PT084.grib2",
             "variable_name": "RH_AGL-2m",
-            "projection": ProjectionEnum.HIGH_RES_CONTINENTAL,
+            "projection": ProjectionEnum.HRDPS_LATLON,
             "model_run_timestamp": datetime.datetime(
                 2023, 3, 22, 12, 0, tzinfo=datetime.timezone.utc
             ),

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_parse_env_canada_filename.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_parse_env_canada_filename.py
@@ -16,28 +16,31 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "filename,projection,variable_name",
     [
-        ("CMC_glb_TMP_TGL_2_latlon.24x.24_2020070212_P240.grib2", "latlon.24x.24", "TMP_TGL_2"),
         (
-            "CMC_glb_ABSV_ISBL_200_latlon.24x.24_2020070600_P000.grib2",
-            "latlon.24x.24",
-            "ABSV_ISBL_200",
+            "20260501T12Z_MSC_GDPS_AirTemp_AGL-2m_LatLon0.15_PT003H.grib2",
+            ProjectionEnum.LATLON_15X_15,
+            "AirTemp_AGL-2m",
         ),
         (
-            "CMC_glb_ABSV_ISBL_200_latlon.15x.15_2020070600_P000.grib2",
-            "latlon.15x.15",
-            "ABSV_ISBL_200",
+            "20260501T00Z_MSC_GDPS_RelativeHumidity_AGL-2m_LatLon0.15_PT000H.grib2",
+            ProjectionEnum.LATLON_15X_15,
+            "RelativeHumidity_AGL-2m",
         ),
-        ("CMC_glb_RH_TGL_2_latlon.15x.15_2020070712_P000.grib2", "latlon.15x.15", "RH_TGL_2"),
         (
-            "/somewhere_on/the_drive/CMC_glb_RH_TGL_2_latlon.15x.15_2020070712_P000.grib2",
-            "latlon.15x.15",
-            "RH_TGL_2",
+            "20260501T12Z_MSC_GDPS_Precip-Accum_Sfc_LatLon0.15_PT006H.grib2",
+            ProjectionEnum.LATLON_15X_15,
+            "Precip-Accum_Sfc",
+        ),
+        (
+            "/somewhere_on/the_drive/20260501T12Z_MSC_GDPS_WindSpeed_AGL-10m_LatLon0.15_PT003H.grib2",
+            ProjectionEnum.LATLON_15X_15,
+            "WindSpeed_AGL-10m",
         ),
     ],
 )
 def test_parse_filename(filename, projection, variable_name):
     """
-    _summary_
+    Parse current MSC GDPS filenames.
 
     :param filename: filename to parse
     :param projection: expected projection
@@ -84,18 +87,19 @@ def test_parse_rdps_msc_filename_malformed_raises():
             ProjectionEnum.RDPS_LATLON,
             "WindSpeed_AGL-10m",
         ),
-        # Legacy CMC_reg format — still routed through parse_gdps_rdps_filename
         (
-            "CMC_reg_RH_TGL_2_ps10km_2020110500_P034.grib2",
+            "https://dd.weather.gc.ca/today/model_rdps/10km/00/034/"
+            "20260501T00Z_MSC_RDPS_RelativeHumidity_AGL-2m_RLatLon0.09_PT034H.grib2",
             ModelEnum.RDPS,
-            ProjectionEnum.REGIONAL_PS,
-            "RH_TGL_2",
+            ProjectionEnum.RDPS_LATLON,
+            "RelativeHumidity_AGL-2m",
         ),
         (
-            "CMC_reg_TMP_TGL_2_ps10km_2024010100_P003.grib2",
+            "https://dd.weather.gc.ca/today/model_rdps/10km/18/003/"
+            "20260501T18Z_MSC_RDPS_AirTemp_AGL-2m_RLatLon0.09_PT003H.grib2",
             ModelEnum.RDPS,
-            ProjectionEnum.REGIONAL_PS,
-            "TMP_TGL_2",
+            ProjectionEnum.RDPS_LATLON,
+            "AirTemp_AGL-2m",
         ),
     ],
 )

--- a/backend/packages/wps-jobs/src/weather_model_jobs/ecmwf.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/ecmwf.py
@@ -253,19 +253,22 @@ async def process_models():
     )
 
 
+def exit_process(code: int):
+    # skip Python interpreter cleanup; GDAL/eccodes teardown can segfault in this job.
+    os._exit(code)
+
+
 def main():
     try:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.run_until_complete(process_models())
-        # Use os._exit to skip Python interpreter cleanup which causes a segfault
-        # due to C extension teardown order (GDAL, PROJ, eccodes, etc.)
-        os._exit(os.EX_OK)
+        exit_process(os.EX_OK)
     except Exception as exception:
         logger.exception("An error occurred while processing ECMWF model.")
         rc_message = ":poop: Encountered error retrieving model data from ECMWF"
         send_chatops_notification(rc_message, exception)
-        os._exit(os.EX_SOFTWARE)
+        exit_process(os.EX_SOFTWARE)
 
 
 if __name__ == "__main__":

--- a/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
@@ -171,8 +171,9 @@ def parse_high_res_model_url(url):
         prediction_hour = url_parts[8]
         prediction_timestamp = model_run_timestamp + datetime.timedelta(hours=int(prediction_hour))
         return variable_name, projection, model_run_timestamp, prediction_timestamp
-    except Exception:
+    except (IndexError, ValueError) as exception:
         logger.exception("HRDPS URL %s is not in the expected format", url)
+        raise ValueError(f"HRDPS URL {url} is not in the expected format") from exception
 
 
 def parse_env_canada_filename(url):


### PR DESCRIPTION
Fixes a few `wps-jobs` weather model test issues.
  - wraps the ECMWF `os._exit` in `exit_process()` so tests can patch it without killing pytest
  - makes `test_ecmwf_process` fail if the job swallows unexpected processing errors
  - updates Env Canada parser tests for the current `GDPS`, `RDPS`, and `HRDPS` filename formats
  - makes incorrect `HRDPS` URLs raise an error

# Test Links:
[Landing Page](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5504-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
