### PR TITLE
SFMS Insights: Show SFMSng data

### DIFF
--- a/backend/packages/wps-api/src/app/main.py
+++ b/backend/packages/wps-api/src/app/main.py
@@ -32,6 +32,7 @@ from app.routers import (
     object_store_proxy,
     psu,
     sfms,
+    sfmsng,
     snow,
     stations,
     weather_models,
@@ -134,6 +135,7 @@ api.include_router(hfi_calc.router, tags=["HFI"])
 api.include_router(fba_calc.router, tags=["FBA Calc"])
 api.include_router(fba.router, tags=["Auto Spatial Advisory"])
 api.include_router(sfms.router, tags=["SFMS", "Auto Spatial Advisory"])
+api.include_router(sfmsng.router, tags=["SFMS Insights"])
 api.include_router(morecast_v2.router, tags=["Morecast v2"])
 api.include_router(snow.router, tags=["SFMS Insights"])
 api.include_router(fire_watch.router, tags=["Fire Watch"])

--- a/backend/packages/wps-api/src/app/routers/sfmsng.py
+++ b/backend/packages/wps-api/src/app/routers/sfmsng.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends
 from wps_shared.auth import audit, authentication_required
 from wps_shared.db.crud.sfms_run import get_sfms_insights_bounds
 from wps_shared.db.database import get_async_read_session_scope
-from wps_shared.db.models.auto_spatial_advisory import RunTypeEnum
 from wps_shared.schemas.fba import SFMSBoundsByYear, SFMSBoundsDateRange, SFMSBoundsResponse
 
 router = APIRouter(
@@ -19,9 +18,10 @@ async def get_sfmsng_run_bounds():
         results = await get_sfms_insights_bounds(session)
 
     sfms_bounds: SFMSBoundsByYear = {}
-    for year, run_type, min_date, max_date in results:
-        run_type_key = run_type.value if isinstance(run_type, RunTypeEnum) else run_type
-        year_bounds = sfms_bounds.setdefault(year, {})
-        year_bounds[run_type_key] = SFMSBoundsDateRange(minimum=min_date, maximum=max_date)
+    for bounds in results:
+        year_bounds = sfms_bounds.setdefault(bounds.year, {})
+        year_bounds[bounds.run_type.value] = SFMSBoundsDateRange(
+            minimum=bounds.minimum, maximum=bounds.maximum
+        )
 
     return SFMSBoundsResponse(sfms_bounds=sfms_bounds)

--- a/backend/packages/wps-api/src/app/routers/sfmsng.py
+++ b/backend/packages/wps-api/src/app/routers/sfmsng.py
@@ -1,0 +1,27 @@
+"""Routers for SFMS Next Generation data."""
+
+from fastapi import APIRouter, Depends
+from wps_shared.auth import audit, authentication_required
+from wps_shared.db.crud.sfms_run import get_sfms_insights_bounds
+from wps_shared.db.database import get_async_read_session_scope
+from wps_shared.db.models.auto_spatial_advisory import RunTypeEnum
+from wps_shared.schemas.fba import SFMSBoundsByYear, SFMSBoundsDateRange, SFMSBoundsResponse
+
+router = APIRouter(
+    prefix="/sfmsng",
+    dependencies=[Depends(authentication_required), Depends(audit)],
+)
+
+
+@router.get("/run-bounds", response_model=SFMSBoundsResponse)
+async def get_sfmsng_run_bounds():
+    async with get_async_read_session_scope() as session:
+        results = await get_sfms_insights_bounds(session)
+
+    sfms_bounds: SFMSBoundsByYear = {}
+    for year, run_type, min_date, max_date in results:
+        run_type_key = run_type.value if isinstance(run_type, RunTypeEnum) else run_type
+        year_bounds = sfms_bounds.setdefault(year, {})
+        year_bounds[run_type_key] = SFMSBoundsDateRange(minimum=min_date, maximum=max_date)
+
+    return SFMSBoundsResponse(sfms_bounds=sfms_bounds)

--- a/backend/packages/wps-api/src/app/tests/sfms/test_sfmsng_endpoint.py
+++ b/backend/packages/wps-api/src/app/tests/sfms/test_sfmsng_endpoint.py
@@ -1,0 +1,43 @@
+from datetime import date
+from unittest.mock import patch
+
+import app.main
+import pytest
+from fastapi.testclient import TestClient
+from wps_shared.db.models.auto_spatial_advisory import RunTypeEnum
+
+client = TestClient(app.main.app)
+
+get_sfmsng_run_bounds_url = "/api/sfmsng/run-bounds"
+
+
+async def mock_get_sfms_insights_bounds(*_, **__):
+    return [
+        (2025, RunTypeEnum.actual, date(2025, 4, 5), date(2025, 9, 25)),
+    ]
+
+
+async def mock_get_sfms_insights_bounds_no_data(*_, **__):
+    return []
+
+
+@pytest.mark.usefixtures("mock_jwt_decode")
+@patch("app.routers.sfmsng.get_sfms_insights_bounds", mock_get_sfms_insights_bounds)
+def test_get_sfmsng_run_bounds():
+    response = client.get(get_sfmsng_run_bounds_url)
+    assert response.status_code == 200
+    json_response = response.json()
+    assert json_response["sfms_bounds"]["2025"]["actual"]["minimum"] == "2025-04-05"
+    assert json_response["sfms_bounds"]["2025"]["actual"]["maximum"] == "2025-09-25"
+
+
+@pytest.mark.usefixtures("mock_jwt_decode")
+@patch(
+    "app.routers.sfmsng.get_sfms_insights_bounds",
+    mock_get_sfms_insights_bounds_no_data,
+)
+def test_get_sfmsng_run_bounds_no_bounds():
+    response = client.get(get_sfmsng_run_bounds_url)
+    assert response.status_code == 200
+    json_response = response.json()
+    assert json_response["sfms_bounds"] == {}

--- a/backend/packages/wps-api/src/app/tests/sfms/test_sfmsng_endpoint.py
+++ b/backend/packages/wps-api/src/app/tests/sfms/test_sfmsng_endpoint.py
@@ -5,6 +5,7 @@ import app.main
 import pytest
 from fastapi.testclient import TestClient
 from wps_shared.db.models.auto_spatial_advisory import RunTypeEnum
+from wps_shared.schemas.sfms import SFMSRunBounds
 
 client = TestClient(app.main.app)
 
@@ -13,7 +14,12 @@ get_sfmsng_run_bounds_url = "/api/sfmsng/run-bounds"
 
 async def mock_get_sfms_insights_bounds(*_, **__):
     return [
-        (2025, RunTypeEnum.actual, date(2025, 4, 5), date(2025, 9, 25)),
+        SFMSRunBounds(
+            year=2025,
+            run_type=RunTypeEnum.actual,
+            minimum=date(2025, 4, 5),
+            maximum=date(2025, 9, 25),
+        ),
     ]
 
 

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/sfms_run.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/sfms_run.py
@@ -5,7 +5,7 @@ import logging
 from datetime import date, datetime
 from typing import List
 
-from sqlalchemy import insert
+from sqlalchemy import extract, func, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from wps_shared.db.models.auto_spatial_advisory import RunTypeEnum
@@ -106,7 +106,11 @@ def track_sfms_run(
                         session, log_id, status=SFMSRunLogStatus.FAILED, completed_at=get_utc_now()
                     )
                 except Exception:
-                    logger.error("Failed to update run log for %s after job failure", job_name.value, exc_info=True)
+                    logger.error(
+                        "Failed to update run log for %s after job failure",
+                        job_name.value,
+                        exc_info=True,
+                    )
                 raise
 
         return wrapper
@@ -142,3 +146,24 @@ async def save_sfms_run(
     )
     result = await session.execute(stmt)
     return result.scalar()
+
+
+async def get_sfms_insights_bounds(session: AsyncSession):
+    """Return target-date bounds for completed SFMS runs used by SFMS Insights."""
+    stmt = (
+        select(
+            extract("YEAR", SFMSRun.target_date).label("year"),
+            SFMSRun.run_type,
+            func.min(SFMSRun.target_date).label("minDate"),
+            func.max(SFMSRun.target_date).label("maxDate"),
+        )
+        .join(SFMSRunLog, SFMSRunLog.sfms_run_id == SFMSRun.id)
+        .where(
+            SFMSRunLog.job_name == SFMSRunLogJobName.FWI_CALCULATION.value,
+            SFMSRunLog.status == SFMSRunLogStatus.SUCCESS.value,
+        )
+        .group_by(extract("YEAR", SFMSRun.target_date), SFMSRun.run_type)
+        .order_by("year")
+    )
+    result = await session.execute(stmt)
+    return result.all()

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/sfms_run.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/sfms_run.py
@@ -15,6 +15,7 @@ from wps_shared.db.models.sfms_run import (
     SFMSRunLogJobName,
     SFMSRunLogStatus,
 )
+from wps_shared.schemas.sfms import SFMSRunBounds
 from wps_shared.utils.time import get_utc_now
 
 logger = logging.getLogger(__name__)
@@ -148,14 +149,14 @@ async def save_sfms_run(
     return result.scalar()
 
 
-async def get_sfms_insights_bounds(session: AsyncSession):
+async def get_sfms_insights_bounds(session: AsyncSession) -> list[SFMSRunBounds]:
     """Return target-date bounds for completed SFMS runs used by SFMS Insights."""
     stmt = (
         select(
             extract("YEAR", SFMSRun.target_date).label("year"),
             SFMSRun.run_type,
-            func.min(SFMSRun.target_date).label("minDate"),
-            func.max(SFMSRun.target_date).label("maxDate"),
+            func.min(SFMSRun.target_date).label("minimum"),
+            func.max(SFMSRun.target_date).label("maximum"),
         )
         .join(SFMSRunLog, SFMSRunLog.sfms_run_id == SFMSRun.id)
         .where(
@@ -166,4 +167,4 @@ async def get_sfms_insights_bounds(session: AsyncSession):
         .order_by("year")
     )
     result = await session.execute(stmt)
-    return result.all()
+    return [SFMSRunBounds.model_validate(row) for row in result.mappings().all()]

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/sfms_run.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/sfms_run.py
@@ -101,16 +101,14 @@ def track_sfms_run(
                 )
                 return result
             except Exception:
-                logger.error("%s failed", job_name.value, exc_info=True)
+                logger.exception("%s failed", job_name.value)
                 try:
                     await update_sfms_run_log(
                         session, log_id, status=SFMSRunLogStatus.FAILED, completed_at=get_utc_now()
                     )
                 except Exception:
-                    logger.error(
-                        "Failed to update run log for %s after job failure",
-                        job_name.value,
-                        exc_info=True,
+                    logger.exception(
+                        "Failed to update run log for %s after job failure", job_name.value
                     )
                 raise
 

--- a/backend/packages/wps-shared/src/wps_shared/schemas/fba.py
+++ b/backend/packages/wps-shared/src/wps_shared/schemas/fba.py
@@ -184,8 +184,17 @@ class FireZoneElevationStatsListResponse(BaseModel):
     hfi_elevation_info: List[FireZoneElevationStatsByThreshold]
 
 
+class SFMSBoundsDateRange(BaseModel):
+    minimum: date
+    maximum: date
+
+
+SFMSBoundsByRunType = Dict[str, SFMSBoundsDateRange]
+SFMSBoundsByYear = Dict[int, SFMSBoundsByRunType]
+
+
 class SFMSBoundsResponse(BaseModel):
-    sfms_bounds: dict
+    sfms_bounds: SFMSBoundsByYear
 
 
 class LatestSFMSRunParameter(BaseModel):

--- a/backend/packages/wps-shared/src/wps_shared/schemas/sfms.py
+++ b/backend/packages/wps-shared/src/wps_shared/schemas/sfms.py
@@ -1,7 +1,11 @@
 """This module contains pydantic schemas related to SFMS."""
 
+from datetime import date
 from typing import List, Optional
+
 from pydantic import BaseModel
+
+from wps_shared.db.models.auto_spatial_advisory import RunTypeEnum
 
 
 class HourlyTIF(BaseModel):
@@ -32,3 +36,12 @@ class SFMSDailyActual(BaseModel):
     ffmc: Optional[float] = None
     dmc: Optional[float] = None
     dc: Optional[float] = None
+
+
+class SFMSRunBounds(BaseModel):
+    """Target-date bounds for completed SFMS runs."""
+
+    year: int
+    run_type: RunTypeEnum
+    minimum: date
+    maximum: date

--- a/backend/packages/wps-shared/src/wps_shared/tests/db/crud/test_sfms_run.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/db/crud/test_sfms_run.py
@@ -246,6 +246,6 @@ async def test_get_sfms_insights_bounds_uses_successful_fwi_runs(async_session: 
 
     rows = await get_sfms_insights_bounds(async_session)
 
-    bounds_by_run_type = {row[1].value: (row[2], row[3]) for row in rows}
+    bounds_by_run_type = {row.run_type.value: (row.minimum, row.maximum) for row in rows}
     assert bounds_by_run_type["actual"] == (date(2026, 4, 1), date(2026, 9, 30))
     assert bounds_by_run_type["forecast"] == (date(2026, 4, 2), date(2026, 4, 2))

--- a/backend/packages/wps-shared/src/wps_shared/tests/db/crud/test_sfms_run.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/db/crud/test_sfms_run.py
@@ -6,7 +6,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.future import select
 from testcontainers.postgres import PostgresContainer
 
-from wps_shared.db.crud.sfms_run import save_sfms_run_log, track_sfms_run, update_sfms_run_log
+from wps_shared.db.crud.sfms_run import (
+    get_sfms_insights_bounds,
+    save_sfms_run_log,
+    track_sfms_run,
+    update_sfms_run_log,
+)
 from wps_shared.db.models.sfms_run import (
     SFMSRun,
     SFMSRunLog,
@@ -214,3 +219,33 @@ async def test_track_sfms_run_preserves_function_name(async_session: AsyncSessio
         pass
 
     assert original_name.__name__ == "original_name"
+
+
+@pytest.mark.anyio
+async def test_get_sfms_insights_bounds_uses_successful_fwi_runs(async_session: AsyncSession):
+    await async_session.execute(
+        text(
+            """INSERT INTO sfms_run (id, run_type, target_date, run_datetime, stations)
+               VALUES
+               (2, 'actual', '2026-04-01', '2026-04-01 20:00:00+00', ARRAY[1]),
+               (3, 'actual', '2026-09-30', '2026-09-30 20:00:00+00', ARRAY[1]),
+               (4, 'actual', '2026-10-15', '2026-10-15 20:00:00+00', ARRAY[1]),
+               (5, 'forecast', '2026-04-02', '2026-04-02 20:00:00+00', ARRAY[1]);"""
+        )
+    )
+    await async_session.execute(
+        text(
+            """INSERT INTO sfms_run_log (job_name, status, sfms_run_id)
+               VALUES
+               ('fwi_calculation', 'success', 2),
+               ('fwi_calculation', 'success', 3),
+               ('fwi_calculation', 'failed', 4),
+               ('fwi_calculation', 'success', 5);"""
+        )
+    )
+
+    rows = await get_sfms_insights_bounds(async_session)
+
+    bounds_by_run_type = {row[1].value: (row[2], row[3]) for row in rows}
+    assert bounds_by_run_type["actual"] == (date(2026, 4, 1), date(2026, 9, 30))
+    assert bounds_by_run_type["forecast"] == (date(2026, 4, 2), date(2026, 4, 2))

--- a/web/apps/wps-web/src/app/rootReducer.ts
+++ b/web/apps/wps-web/src/app/rootReducer.ts
@@ -25,6 +25,7 @@ import fireWatchSlice from 'features/fireWatch/slices/fireWatchSlice'
 import fireWatchFireCentresSlice from '@/features/fireWatch/slices/fireWatchFireCentresSlice'
 import burnForecastsSlice from '@/features/fireWatch/slices/burnForecastSlice'
 import { filterHFIFuelStatsByArea } from '@/features/fba/hfiStatsUtils'
+import sfmsInsightsSlice from '@/features/sfmsInsights/slices/sfmsInsightsSlice'
 
 const rootReducer = combineReducers({
   percentileStations: stationReducer,
@@ -51,7 +52,8 @@ const rootReducer = combineReducers({
   morecastInputValid: morecastInputValidSlice,
   fireWatch: fireWatchSlice,
   fireWatchFireCentres: fireWatchFireCentresSlice,
-  burnForecasts: burnForecastsSlice
+  burnForecasts: burnForecastsSlice,
+  sfmsInsights: sfmsInsightsSlice
 })
 
 // Infer whatever gets returned from rootReducer and use it as the type of the root state

--- a/web/apps/wps-web/src/features/sfmsInsights/components/SfmsInsightsAboutDataContent.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/SfmsInsightsAboutDataContent.tsx
@@ -1,0 +1,9 @@
+export const SfmsInsightsAboutDataContent = () => (
+  <>
+    <p>
+      SFMS Insights displays data produced by a new Spatial Fire Management System under active development by the
+      Predictive Services Unit.
+    </p>
+    <p>These layers are separate from the legacy SFMS products and may not match legacy SFMS outputs.</p>
+  </>
+)

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.test.ts
@@ -1,4 +1,9 @@
-import { getSnowPMTilesLayer, getFireWeatherRasterLayer, getRasterLayer } from './layerDefinitions'
+import {
+  getSnowPMTilesLayer,
+  getFireWeatherRasterLayer,
+  getRasterLayer,
+  getSFMSNGActualRasterPath
+} from './layerDefinitions'
 import { DateTime } from 'luxon'
 
 // Mock pmtiles completely to prevent any parsing
@@ -111,6 +116,20 @@ describe('layerDefinitions', () => {
   })
 
   describe('getFireWeatherRasterLayer', () => {
+    it('should generate SFMSNG actual COG paths for FWI rasters', () => {
+      const rasterDate = DateTime.fromISO('2025-11-02')
+
+      expect(getSFMSNGActualRasterPath(rasterDate, 'fwi')).toBe('sfms_ng/actual/2025/11/02/fwi_20251102_cog.tif')
+    })
+
+    it('should generate SFMSNG actual COG paths for weather rasters', () => {
+      const rasterDate = DateTime.fromISO('2025-11-02')
+
+      expect(getSFMSNGActualRasterPath(rasterDate, 'relative_humidity')).toBe(
+        'sfms_ng/actual/2025/11/02/relative_humidity_20251102_cog.tif'
+      )
+    })
+
     it('should create fire weather layer with zIndex 52', () => {
       const rasterDate = DateTime.fromISO('2025-11-02')
       const layer = getFireWeatherRasterLayer(rasterDate, 'fwi', 'test-token')
@@ -169,6 +188,14 @@ describe('layerDefinitions', () => {
       expect(layer).toBeDefined()
       expect(layer).not.toBeNull()
       expect(layer!.getProperties().rasterType).toBe('fwi')
+    })
+
+    it('should return weather layer when date is provided', () => {
+      const date = DateTime.fromISO('2025-11-02')
+      const layer = getRasterLayer(date, 'temperature', 'test-token')
+      expect(layer).toBeDefined()
+      expect(layer).not.toBeNull()
+      expect(layer!.getProperties().rasterType).toBe('temperature')
     })
 
     it('should return null and log error when date is null for fire weather raster', () => {

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.ts
@@ -13,19 +13,11 @@ import GeoTIFF from 'ol/source/GeoTIFF'
 import { boundingExtent } from 'ol/extent'
 import { fromLonLat } from 'ol/proj'
 import { BC_EXTENT } from '@wps/utils/constants'
-import {
-  RasterType,
-  SFMSNG_RASTER_TYPES,
-  type SFMSNGRasterType
-} from '@/features/sfmsInsights/components/map/rasterConfig'
+import { RasterType, type SFMSNGRasterType } from '@/features/sfmsInsights/components/map/rasterConfig'
 
 export const BASEMAP_LAYER_NAME = 'basemapLayer'
 export const SNOW_LAYER_NAME = 'snowVector'
 export const FWI_LAYER_NAME = 'fwiRaster'
-
-const isSFMSNGRasterType = (rasterType: RasterType): rasterType is SFMSNGRasterType => {
-  return SFMSNG_RASTER_TYPES.includes(rasterType as SFMSNGRasterType)
-}
 
 export const getSFMSNGActualRasterPath = (date: DateTime, rasterType: SFMSNGRasterType) => {
   const dateString = date.toISODate() ?? ''
@@ -150,10 +142,6 @@ export const getRasterLayer = (date: DateTime | null, rasterType: RasterType, to
   }
   if (!date) {
     console.error('date is required for fire weather rasters')
-    return null
-  }
-  if (!isSFMSNGRasterType(rasterType)) {
-    console.error(`unsupported raster type: ${rasterType}`)
     return null
   }
   return getFireWeatherRasterLayer(date, rasterType, token)

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.ts
@@ -13,11 +13,26 @@ import GeoTIFF from 'ol/source/GeoTIFF'
 import { boundingExtent } from 'ol/extent'
 import { fromLonLat } from 'ol/proj'
 import { BC_EXTENT } from '@wps/utils/constants'
-import { RasterType } from '@/features/sfmsInsights/components/map/rasterConfig'
+import {
+  RasterType,
+  SFMSNG_RASTER_TYPES,
+  type SFMSNGRasterType
+} from '@/features/sfmsInsights/components/map/rasterConfig'
 
 export const BASEMAP_LAYER_NAME = 'basemapLayer'
 export const SNOW_LAYER_NAME = 'snowVector'
 export const FWI_LAYER_NAME = 'fwiRaster'
+
+const isSFMSNGRasterType = (rasterType: RasterType): rasterType is SFMSNGRasterType => {
+  return SFMSNG_RASTER_TYPES.includes(rasterType as SFMSNGRasterType)
+}
+
+export const getSFMSNGActualRasterPath = (date: DateTime, rasterType: SFMSNGRasterType) => {
+  const dateString = date.toISODate() ?? ''
+  const datePath = dateString.replaceAll('-', '/')
+  const dateStringBasic = dateString.replaceAll('-', '')
+  return `sfms_ng/actual/${datePath}/${rasterType}_${dateStringBasic}_cog.tif`
+}
 
 export const getSnowPMTilesLayer = (snowDate: DateTime, token?: string) => {
   const isoDate = snowDate.toISODate() ?? ''
@@ -50,13 +65,11 @@ export const getSnowPMTilesLayer = (snowDate: DateTime, token?: string) => {
 
 export const getFireWeatherRasterLayer = (
   date: DateTime,
-  rasterType: RasterType,
+  rasterType: SFMSNGRasterType,
   token: string | undefined,
   layerName: string = FWI_LAYER_NAME
 ) => {
-  const dateString = date.toISODate() ?? '' // Format: YYYY-MM-DD
-  // Use API proxy to bypass CORS restrictions
-  const path = `sfms/calculated/forecast/${dateString}/${rasterType}${dateString.replaceAll('-', '')}_3857_cog.tif`
+  const path = getSFMSNGActualRasterPath(date, rasterType)
   const url = `${API_BASE_URL}/object-store-proxy/${path}`
 
   // Prepare headers for authentication
@@ -137,6 +150,10 @@ export const getRasterLayer = (date: DateTime | null, rasterType: RasterType, to
   }
   if (!date) {
     console.error('date is required for fire weather rasters')
+    return null
+  }
+  if (!isSFMSNGRasterType(rasterType)) {
+    console.error(`unsupported raster type: ${rasterType}`)
     return null
   }
   return getFireWeatherRasterLayer(date, rasterType, token)

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterConfig.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterConfig.ts
@@ -93,47 +93,57 @@ export const ISI_COLOR_BREAKS: ColorBreak[] = [
 ]
 
 export const TEMPERATURE_COLOR_BREAKS: ColorBreak[] = [
-  { min: -50, max: 0, color: 'rgb(0, 64, 255)', label: '<0 C' },
-  { min: 0, max: 10, color: 'rgb(0, 191, 255)', label: '0-10 C' },
-  { min: 10, max: 20, color: 'rgb(0, 180, 0)', label: '10-20 C' },
-  { min: 20, max: 30, color: 'rgb(255, 214, 0)', label: '20-30 C' },
-  { min: 30, max: null, color: 'rgb(220, 0, 0)', label: '30+ C' }
+  { min: -50, max: 0, color: 'rgb(0, 0, 255)', label: '< 0 C' },
+  { min: 0, max: 3, color: 'rgb(102, 153, 204)', label: '0 - 3 C' },
+  { min: 3, max: 6, color: 'rgb(177, 204, 245)', label: '3 - 6 C' },
+  { min: 6, max: 11, color: 'rgb(0, 170, 0)', label: '6 - 11 C' },
+  { min: 11, max: 16, color: 'rgb(128, 255, 0)', label: '11 - 16 C' },
+  { min: 16, max: 20, color: 'rgb(255, 255, 0)', label: '16 - 20 C' },
+  { min: 20, max: 25, color: 'rgb(255, 170, 0)', label: '20 - 25 C' },
+  { min: 25, max: 31, color: 'rgb(255, 0, 0)', label: '25 - 31 C' },
+  { min: 31, max: null, color: 'rgb(180, 0, 140)', label: '31+ C' }
 ]
 
 export const RH_COLOR_BREAKS: ColorBreak[] = [
-  { min: 0, max: 20, color: 'rgb(220, 0, 0)', label: '0-20%' },
-  { min: 20, max: 40, color: 'rgb(255, 170, 0)', label: '20-40%' },
-  { min: 40, max: 60, color: 'rgb(255, 255, 0)', label: '40-60%' },
-  { min: 60, max: 80, color: 'rgb(0, 191, 255)', label: '60-80%' },
-  { min: 80, max: null, color: 'rgb(0, 0, 255)', label: '80%+' }
+  { min: 0, max: 16, color: 'rgb(255, 0, 0)', label: '0 - 16%' },
+  { min: 16, max: 26, color: 'rgb(255, 170, 0)', label: '16 - 26%' },
+  { min: 26, max: 35, color: 'rgb(255, 255, 0)', label: '26 - 35%' },
+  { min: 35, max: 50, color: 'rgb(128, 255, 0)', label: '35 - 50%' },
+  { min: 50, max: 70, color: 'rgb(102, 153, 204)', label: '50 - 70%' },
+  { min: 70, max: null, color: 'rgb(0, 0, 255)', label: '70%+' }
 ]
 
 export const WIND_SPEED_COLOR_BREAKS: ColorBreak[] = [
-  { min: 0, max: 10, color: 'rgb(210, 255, 255)', label: '0-10 km/h' },
-  { min: 10, max: 20, color: 'rgb(0, 255, 0)', label: '10-20 km/h' },
-  { min: 20, max: 40, color: 'rgb(255, 255, 0)', label: '20-40 km/h' },
-  { min: 40, max: 60, color: 'rgb(255, 170, 0)', label: '40-60 km/h' },
-  { min: 60, max: null, color: 'rgb(255, 0, 0)', label: '60+ km/h' }
+  { min: 0, max: 4, color: 'rgb(0, 0, 255)', label: '0 - 4 km/h' },
+  { min: 4, max: 9, color: 'rgb(102, 153, 204)', label: '4 - 9 km/h' },
+  { min: 9, max: 13, color: 'rgb(177, 204, 245)', label: '9 - 13 km/h' },
+  { min: 13, max: 17, color: 'rgb(0, 170, 0)', label: '13 - 17 km/h' },
+  { min: 17, max: 21, color: 'rgb(128, 255, 0)', label: '17 - 21 km/h' },
+  { min: 21, max: 25, color: 'rgb(255, 170, 0)', label: '21 - 25 km/h' },
+  { min: 25, max: 31, color: 'rgb(255, 0, 0)', label: '25 - 31 km/h' },
+  { min: 31, max: null, color: 'rgb(180, 0, 140)', label: '31+ km/h' }
 ]
 
 export const WIND_DIRECTION_COLOR_BREAKS: ColorBreak[] = [
-  { min: 0, max: 45, color: 'rgb(230, 25, 75)', label: 'N-NE' },
-  { min: 45, max: 90, color: 'rgb(245, 130, 48)', label: 'NE-E' },
-  { min: 90, max: 135, color: 'rgb(255, 225, 25)', label: 'E-SE' },
-  { min: 135, max: 180, color: 'rgb(60, 180, 75)', label: 'SE-S' },
-  { min: 180, max: 225, color: 'rgb(70, 240, 240)', label: 'S-SW' },
-  { min: 225, max: 270, color: 'rgb(0, 130, 200)', label: 'SW-W' },
-  { min: 270, max: 315, color: 'rgb(145, 30, 180)', label: 'W-NW' },
-  { min: 315, max: null, color: 'rgb(240, 50, 230)', label: 'NW-N' }
+  { min: 0, max: 45, color: 'rgb(0, 0, 255)', label: 'North' },
+  { min: 45, max: 90, color: 'rgb(102, 153, 204)', label: 'Northeast' },
+  { min: 90, max: 135, color: 'rgb(177, 204, 245)', label: 'East' },
+  { min: 135, max: 180, color: 'rgb(0, 170, 0)', label: 'Southeast' },
+  { min: 180, max: 225, color: 'rgb(128, 255, 0)', label: 'South' },
+  { min: 225, max: 270, color: 'rgb(255, 255, 0)', label: 'Southwest' },
+  { min: 270, max: 315, color: 'rgb(255, 170, 0)', label: 'West' },
+  { min: 315, max: null, color: 'rgb(255, 0, 0)', label: 'Northwest' }
 ]
 
 export const PRECIPITATION_COLOR_BREAKS: ColorBreak[] = [
-  { min: 0, max: 0.1, color: 'rgb(245, 245, 245)', label: '<0.1 mm' },
-  { min: 0.1, max: 2, color: 'rgb(180, 220, 255)', label: '0.1-2 mm' },
-  { min: 2, max: 5, color: 'rgb(80, 170, 255)', label: '2-5 mm' },
-  { min: 5, max: 10, color: 'rgb(0, 90, 220)', label: '5-10 mm' },
-  { min: 10, max: 20, color: 'rgb(80, 30, 180)', label: '10-20 mm' },
-  { min: 20, max: null, color: 'rgb(120, 0, 120)', label: '20+ mm' }
+  { min: 0.0, max: 0.1, color: 'rgb(255, 0, 0)', label: '0.0 - 0.1 mm' },
+  { min: 0.1, max: 0.6, color: 'rgb(255, 170, 0)', label: '0.1 - 0.6 mm' },
+  { min: 0.6, max: 1.5, color: 'rgb(255, 255, 0)', label: '0.6 - 1.5 mm' },
+  { min: 1.5, max: 2.5, color: 'rgb(128, 255, 0)', label: '1.5 - 2.5 mm' },
+  { min: 2.5, max: 5.0, color: 'rgb(0, 170, 0)', label: '2.5 - 5.0 mm' },
+  { min: 5.0, max: 10.0, color: 'rgb(102, 153, 204)', label: '5 - 10 mm' },
+  { min: 10.0, max: 25.0, color: 'rgb(0, 0, 255)', label: '10 - 25 mm' },
+  { min: 25.0, max: null, color: 'rgb(0, 0, 128)', label: '25+ mm' }
 ]
 
 // Fuel type color mappings based on BCWS standard colors
@@ -163,6 +173,7 @@ export const FUEL_COLOR_BREAKS: ColorBreak[] = FUEL_TYPE_COLORS.map(({ value, fu
 }))
 
 export const RASTER_CONFIG: Record<RasterType, RasterConfig> = {
+  fuel: { label: 'Fuel', colorBreaks: FUEL_COLOR_BREAKS },
   fwi: { label: 'FWI', colorBreaks: FWI_COLOR_BREAKS },
   dmc: { label: 'DMC', colorBreaks: DMC_COLOR_BREAKS },
   dc: { label: 'DC', colorBreaks: DC_COLOR_BREAKS },
@@ -173,8 +184,7 @@ export const RASTER_CONFIG: Record<RasterType, RasterConfig> = {
   relative_humidity: { label: 'Relative Humidity', colorBreaks: RH_COLOR_BREAKS },
   wind_speed: { label: 'Wind Speed', colorBreaks: WIND_SPEED_COLOR_BREAKS },
   wind_direction: { label: 'Wind Direction', colorBreaks: WIND_DIRECTION_COLOR_BREAKS },
-  precipitation: { label: 'Precipitation', colorBreaks: PRECIPITATION_COLOR_BREAKS },
-  fuel: { label: 'Fuel', colorBreaks: FUEL_COLOR_BREAKS }
+  precipitation: { label: 'Precipitation', colorBreaks: PRECIPITATION_COLOR_BREAKS }
 }
 
 // Backward compatibility - export just the color breaks

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterConfig.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterConfig.ts
@@ -1,19 +1,18 @@
-export const SFMSNG_RASTER_TYPES = [
-  'fwi',
-  'dmc',
-  'dc',
-  'ffmc',
-  'bui',
-  'isi',
-  'temperature',
-  'relative_humidity',
-  'wind_speed',
-  'wind_direction',
-  'precipitation'
-]
+export type RasterType =
+  | 'fuel'
+  | 'fwi'
+  | 'dmc'
+  | 'dc'
+  | 'ffmc'
+  | 'bui'
+  | 'isi'
+  | 'temperature'
+  | 'relative_humidity'
+  | 'wind_speed'
+  | 'wind_direction'
+  | 'precipitation'
 
-export type SFMSNGRasterType = (typeof SFMSNG_RASTER_TYPES)[number]
-export type RasterType = SFMSNGRasterType | 'fuel'
+export type SFMSNGRasterType = Exclude<RasterType, 'fuel'>
 
 export interface ColorBreak {
   min: number

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterConfig.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterConfig.ts
@@ -135,14 +135,14 @@ export const WIND_DIRECTION_COLOR_BREAKS: ColorBreak[] = [
 ]
 
 export const PRECIPITATION_COLOR_BREAKS: ColorBreak[] = [
-  { min: 0.0, max: 0.1, color: 'rgb(255, 0, 0)', label: '0.0 - 0.1 mm' },
+  { min: 0, max: 0.1, color: 'rgb(255, 0, 0)', label: '0.0 - 0.1 mm' },
   { min: 0.1, max: 0.6, color: 'rgb(255, 170, 0)', label: '0.1 - 0.6 mm' },
   { min: 0.6, max: 1.5, color: 'rgb(255, 255, 0)', label: '0.6 - 1.5 mm' },
   { min: 1.5, max: 2.5, color: 'rgb(128, 255, 0)', label: '1.5 - 2.5 mm' },
-  { min: 2.5, max: 5.0, color: 'rgb(0, 170, 0)', label: '2.5 - 5.0 mm' },
-  { min: 5.0, max: 10.0, color: 'rgb(102, 153, 204)', label: '5 - 10 mm' },
-  { min: 10.0, max: 25.0, color: 'rgb(0, 0, 255)', label: '10 - 25 mm' },
-  { min: 25.0, max: null, color: 'rgb(0, 0, 128)', label: '25+ mm' }
+  { min: 2.5, max: 5, color: 'rgb(0, 170, 0)', label: '2.5 - 5.0 mm' },
+  { min: 5, max: 10, color: 'rgb(102, 153, 204)', label: '5 - 10 mm' },
+  { min: 10, max: 25, color: 'rgb(0, 0, 255)', label: '10 - 25 mm' },
+  { min: 25, max: null, color: 'rgb(0, 0, 128)', label: '25+ mm' }
 ]
 
 // Fuel type color mappings based on BCWS standard colors

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterConfig.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterConfig.ts
@@ -1,4 +1,19 @@
-export type RasterType = 'fwi' | 'dmc' | 'dc' | 'ffmc' | 'bui' | 'isi' | 'fuel'
+export const SFMSNG_RASTER_TYPES = [
+  'fwi',
+  'dmc',
+  'dc',
+  'ffmc',
+  'bui',
+  'isi',
+  'temperature',
+  'relative_humidity',
+  'wind_speed',
+  'wind_direction',
+  'precipitation'
+]
+
+export type SFMSNGRasterType = (typeof SFMSNG_RASTER_TYPES)[number]
+export type RasterType = SFMSNGRasterType | 'fuel'
 
 export interface ColorBreak {
   min: number
@@ -77,6 +92,50 @@ export const ISI_COLOR_BREAKS: ColorBreak[] = [
   { min: 26, max: null, color: 'rgb(255, 0, 0)', label: '26+' }
 ]
 
+export const TEMPERATURE_COLOR_BREAKS: ColorBreak[] = [
+  { min: -50, max: 0, color: 'rgb(0, 64, 255)', label: '<0 C' },
+  { min: 0, max: 10, color: 'rgb(0, 191, 255)', label: '0-10 C' },
+  { min: 10, max: 20, color: 'rgb(0, 180, 0)', label: '10-20 C' },
+  { min: 20, max: 30, color: 'rgb(255, 214, 0)', label: '20-30 C' },
+  { min: 30, max: null, color: 'rgb(220, 0, 0)', label: '30+ C' }
+]
+
+export const RH_COLOR_BREAKS: ColorBreak[] = [
+  { min: 0, max: 20, color: 'rgb(220, 0, 0)', label: '0-20%' },
+  { min: 20, max: 40, color: 'rgb(255, 170, 0)', label: '20-40%' },
+  { min: 40, max: 60, color: 'rgb(255, 255, 0)', label: '40-60%' },
+  { min: 60, max: 80, color: 'rgb(0, 191, 255)', label: '60-80%' },
+  { min: 80, max: null, color: 'rgb(0, 0, 255)', label: '80%+' }
+]
+
+export const WIND_SPEED_COLOR_BREAKS: ColorBreak[] = [
+  { min: 0, max: 10, color: 'rgb(210, 255, 255)', label: '0-10 km/h' },
+  { min: 10, max: 20, color: 'rgb(0, 255, 0)', label: '10-20 km/h' },
+  { min: 20, max: 40, color: 'rgb(255, 255, 0)', label: '20-40 km/h' },
+  { min: 40, max: 60, color: 'rgb(255, 170, 0)', label: '40-60 km/h' },
+  { min: 60, max: null, color: 'rgb(255, 0, 0)', label: '60+ km/h' }
+]
+
+export const WIND_DIRECTION_COLOR_BREAKS: ColorBreak[] = [
+  { min: 0, max: 45, color: 'rgb(230, 25, 75)', label: 'N-NE' },
+  { min: 45, max: 90, color: 'rgb(245, 130, 48)', label: 'NE-E' },
+  { min: 90, max: 135, color: 'rgb(255, 225, 25)', label: 'E-SE' },
+  { min: 135, max: 180, color: 'rgb(60, 180, 75)', label: 'SE-S' },
+  { min: 180, max: 225, color: 'rgb(70, 240, 240)', label: 'S-SW' },
+  { min: 225, max: 270, color: 'rgb(0, 130, 200)', label: 'SW-W' },
+  { min: 270, max: 315, color: 'rgb(145, 30, 180)', label: 'W-NW' },
+  { min: 315, max: null, color: 'rgb(240, 50, 230)', label: 'NW-N' }
+]
+
+export const PRECIPITATION_COLOR_BREAKS: ColorBreak[] = [
+  { min: 0, max: 0.1, color: 'rgb(245, 245, 245)', label: '<0.1 mm' },
+  { min: 0.1, max: 2, color: 'rgb(180, 220, 255)', label: '0.1-2 mm' },
+  { min: 2, max: 5, color: 'rgb(80, 170, 255)', label: '2-5 mm' },
+  { min: 5, max: 10, color: 'rgb(0, 90, 220)', label: '5-10 mm' },
+  { min: 10, max: 20, color: 'rgb(80, 30, 180)', label: '10-20 mm' },
+  { min: 20, max: null, color: 'rgb(120, 0, 120)', label: '20+ mm' }
+]
+
 // Fuel type color mappings based on BCWS standard colors
 export const FUEL_TYPE_COLORS: FuelTypeColorMapping[] = [
   { value: 1, fuelCode: 'C-1', color: 'rgb(209, 255, 115)', rgb: [209, 255, 115] },
@@ -110,6 +169,11 @@ export const RASTER_CONFIG: Record<RasterType, RasterConfig> = {
   ffmc: { label: 'FFMC', colorBreaks: FFMC_COLOR_BREAKS },
   bui: { label: 'BUI', colorBreaks: BUI_COLOR_BREAKS },
   isi: { label: 'ISI', colorBreaks: ISI_COLOR_BREAKS },
+  temperature: { label: 'Temperature', colorBreaks: TEMPERATURE_COLOR_BREAKS },
+  relative_humidity: { label: 'Relative Humidity', colorBreaks: RH_COLOR_BREAKS },
+  wind_speed: { label: 'Wind Speed', colorBreaks: WIND_SPEED_COLOR_BREAKS },
+  wind_direction: { label: 'Wind Direction', colorBreaks: WIND_DIRECTION_COLOR_BREAKS },
+  precipitation: { label: 'Precipitation', colorBreaks: PRECIPITATION_COLOR_BREAKS },
   fuel: { label: 'Fuel', colorBreaks: FUEL_COLOR_BREAKS }
 }
 
@@ -121,5 +185,10 @@ export const RASTER_COLOR_BREAKS: Record<RasterType, ColorBreak[]> = {
   ffmc: FFMC_COLOR_BREAKS,
   bui: BUI_COLOR_BREAKS,
   isi: ISI_COLOR_BREAKS,
+  temperature: TEMPERATURE_COLOR_BREAKS,
+  relative_humidity: RH_COLOR_BREAKS,
+  wind_speed: WIND_SPEED_COLOR_BREAKS,
+  wind_direction: WIND_DIRECTION_COLOR_BREAKS,
+  precipitation: PRECIPITATION_COLOR_BREAKS,
   fuel: FUEL_COLOR_BREAKS
 }

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterTooltipHandler.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterTooltipHandler.test.ts
@@ -77,6 +77,27 @@ describe('getRasterTooltipData', () => {
       expect(result.label).toBe('FWI')
     })
   })
+
+  describe('should handle fuel raster values', () => {
+    it('should convert valid fuel values to fuel codes', () => {
+      const result = getRasterTooltipData(new Uint8Array([2]), 'fuel')
+
+      expect(result.value).toBe('C-2')
+      expect(result.label).toBe('Fuel')
+    })
+
+    it.each([
+      ['outside grid', new Uint8Array([255])],
+      ['non-fuel area', new Uint8Array([99])],
+      ['water or non-vegetated', new Uint8Array([102])],
+      ['primary nodata', new Float32Array([-10000])]
+    ])('should hide %s fuel values', (_description, data) => {
+      const result = getRasterTooltipData(data, 'fuel')
+
+      expect(result.value).toBeNull()
+      expect(result.label).toBe('Fuel')
+    })
+  })
 })
 
 describe('findRasterLayer', () => {
@@ -85,31 +106,20 @@ describe('findRasterLayer', () => {
   })
 
   it('should find layer with rasterType property', () => {
-    const layers = [
-      createMockLayer(false),
-      createMockLayer(true, 'fwi'),
-      createMockLayer(false)
-    ]
+    const layers = [createMockLayer(false), createMockLayer(true, 'fwi'), createMockLayer(false)]
     const result = findRasterLayer(layers)
     expect(result).toBeDefined()
     expect(result?.getProperties().rasterType).toBe('fwi')
   })
 
   it('should return undefined when no raster layer exists', () => {
-    const layers = [
-      createMockLayer(false),
-      createMockLayer(false)
-    ]
+    const layers = [createMockLayer(false), createMockLayer(false)]
     const result = findRasterLayer(layers)
     expect(result).toBeUndefined()
   })
 
   it('should return first raster layer when multiple exist', () => {
-    const layers = [
-      createMockLayer(false),
-      createMockLayer(true, 'fwi'),
-      createMockLayer(true, 'dmc')
-    ]
+    const layers = [createMockLayer(false), createMockLayer(true, 'fwi'), createMockLayer(true, 'dmc')]
     const result = findRasterLayer(layers)
     expect(result?.getProperties().rasterType).toBe('fwi')
   })
@@ -121,9 +131,10 @@ describe('findRasterLayer', () => {
 })
 
 describe('getRasterType', () => {
-  const createMockLayer = (rasterType?: string) => (({
-    getProperties: () => ({ rasterType })
-  }) as any)
+  const createMockLayer = (rasterType?: string) =>
+    ({
+      getProperties: () => ({ rasterType })
+    }) as any
 
   it.each([
     ['fwi', 'fwi'],
@@ -146,9 +157,10 @@ describe('getRasterType', () => {
 })
 
 describe('getRasterData', () => {
-  const createMockLayer = (data: Float32Array | Uint8Array | null) => (({
-    getData: vi.fn(() => data)
-  }) as any)
+  const createMockLayer = (data: Float32Array | Uint8Array | null) =>
+    ({
+      getData: vi.fn(() => data)
+    }) as any
 
   it('should get data from layer at pixel coordinate', () => {
     const data = new Float32Array([42])
@@ -182,10 +194,11 @@ describe('getRasterData', () => {
 })
 
 describe('getDataAtPixel', () => {
-  const createMockLayer = (data: Float32Array | Uint8Array | null, rasterType?: string) => (({
-    getData: vi.fn(() => data),
-    getProperties: () => ({ rasterType })
-  }) as any)
+  const createMockLayer = (data: Float32Array | Uint8Array | null, rasterType?: string) =>
+    ({
+      getData: vi.fn(() => data),
+      getProperties: () => ({ rasterType })
+    }) as any
 
   it('should get tooltip data from layer with valid data', () => {
     const data = new Float32Array([42.7])

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterTooltipHandler.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterTooltipHandler.ts
@@ -40,14 +40,9 @@ export const getRasterTooltipData = (data: RasterData, rasterType: RasterType | 
 
   // For fuel type, convert numeric value to fuel code
   if (rasterType === 'fuel') {
-    // Filter out nodata and invalid values (99, 102, -10000)
-    if (roundedValue === 99 || roundedValue === 102 || roundedValue === -10000) {
-      return { value: null, label: defaultLabel }
-    }
-
     const fuelType = FUEL_TYPE_COLORS.find(f => f.value === roundedValue)
     return {
-      value: fuelType ? fuelType.fuelCode : roundedValue.toString(),
+      value: fuelType ? fuelType.fuelCode : null,
       label: defaultLabel
     }
   }

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
@@ -3,7 +3,7 @@ import { SFMSInsightsPage } from './SFMSInsightsPage'
 import { Provider } from 'react-redux'
 import { createTestStore } from '@/test/testUtils'
 import { getMostRecentProcessedSnowByDate } from '@wps/api/snow'
-import { getSFMSBounds } from '@wps/api/fbaAPI'
+import { getSFMSInsightsBounds } from '@wps/api/sfmsAPI'
 import { getDateTimeNowPST } from '@wps/utils/date'
 import { DateTime } from 'luxon'
 import { Mock } from 'vitest'
@@ -16,8 +16,8 @@ vi.mock('@wps/utils/date', () => ({
   getDateTimeNowPST: vi.fn()
 }))
 
-vi.mock('@wps/api/fbaAPI', () => ({
-  getSFMSBounds: vi.fn()
+vi.mock('@wps/api/sfmsAPI', () => ({
+  getSFMSInsightsBounds: vi.fn()
 }))
 
 vi.mock('@/features/sfmsInsights/components/map/SFMSMap', () => {
@@ -25,17 +25,20 @@ vi.mock('@/features/sfmsInsights/components/map/SFMSMap', () => {
     default: ({
       showSnow,
       snowDate,
-      rasterDate
+      rasterDate,
+      rasterType
     }: {
       showSnow: boolean
       snowDate: DateTime | null
       rasterDate: DateTime | null
+      rasterType: string
     }) => (
       <div
         data-testid="sfms-map"
         data-show-snow={showSnow}
         data-snow-date={snowDate?.toISO() ?? 'null'}
         data-raster-date={rasterDate?.toISO() ?? 'null'}
+        data-raster-type={rasterType}
       >
         Mock SFMS Map
       </div>
@@ -134,13 +137,13 @@ describe('SFMSInsightsPage', () => {
     sfmsBoundsLoading: false,
     sfmsBounds: {
       '2024': {
-        forecast: {
+        actual: {
           minimum: '2024-01-01',
           maximum: '2024-12-31'
         }
       },
       '2025': {
-        forecast: {
+        actual: {
           minimum: '2025-01-01',
           maximum: '2025-11-02'
         }
@@ -148,13 +151,14 @@ describe('SFMSInsightsPage', () => {
     }
   }
 
-  const renderWithStore = (sfmsBounds?: any) => {
+  const renderWithStore = (sfmsBounds: any = defaultRunDates.sfmsBounds) => {
+    ;(getSFMSInsightsBounds as Mock).mockResolvedValue({
+      sfms_bounds: sfmsBounds
+    })
+
     const store = createTestStore({
       authentication: defaultAuthentication,
-      runDates: {
-        ...defaultRunDates,
-        ...(sfmsBounds !== undefined && { sfmsBounds, sfmsBoundsLoading: false })
-      }
+      runDates: defaultRunDates
     })
     return render(<Provider store={store}>{<SFMSInsightsPage />}</Provider>)
   }
@@ -181,17 +185,17 @@ describe('SFMSInsightsPage', () => {
     })
     // Mock getDateTimeNowPST to return a date in 2025
     ;(getDateTimeNowPST as Mock).mockReturnValue(dateTimeNow)
-    // Mock getSFMSBounds API call
-    ;;(getSFMSBounds as Mock).mockResolvedValue({
+    // Mock SFMS Insights bounds API call
+    ;(getSFMSInsightsBounds as Mock).mockResolvedValue({
       sfms_bounds: {
         '2024': {
-          forecast: {
+          actual: {
             minimum: '2024-01-01',
             maximum: '2024-12-31'
           }
         },
         '2025': {
-          forecast: {
+          actual: {
             minimum: '2025-01-01',
             maximum: '2025-11-02'
           }
@@ -208,6 +212,14 @@ describe('SFMSInsightsPage', () => {
     const map = screen.getByTestId('sfms-map')
     const rasterDate = map.dataset.rasterDate
     expect(rasterDate).toContain('2025-11-02')
+  })
+
+  it('should show FWI by default', async () => {
+    renderWithStore()
+    await waitForPageLoad()
+
+    const map = screen.getByTestId('sfms-map')
+    expect(map).toHaveAttribute('data-raster-type', 'fwi')
   })
 
   it('should set date picker max date based on SFMS bounds', async () => {
@@ -355,7 +367,7 @@ describe('SFMSInsightsPage', () => {
     await waitForPageLoad()
 
     const maxDate = screen.getByTestId('historical-max-date')
-    expect(maxDate.textContent).toBe(dateTimeNowPlusTen.toISODate())
+    expect(maxDate.textContent).toBe('2025-11-02')
   })
 
   it('should set minDate from earliestSFMSBounds.minimum', async () => {
@@ -374,13 +386,13 @@ describe('SFMSInsightsPage', () => {
     const maxDate = screen.getByTestId('current-year-max-date')
 
     expect(minDate.textContent).toBe('2024-01-01')
-    expect(maxDate.textContent).toBe(dateTimeNowPlusTen.toISODate())
+    expect(maxDate.textContent).toBe('2025-11-02')
   })
 
   it('should update min bounds when latestBounds changes', async () => {
     renderWithStore({
       '2025': {
-        forecast: {
+        actual: {
           minimum: '2025-05-01',
           maximum: '2025-10-15'
         }
@@ -393,9 +405,6 @@ describe('SFMSInsightsPage', () => {
   })
 
   it('should set rasterDate to today when latestBounds is null', async () => {
-    // Mock getSFMSBounds to return null
-    ;(getSFMSBounds as Mock).mockResolvedValueOnce({ sfms_bounds: null })
-
     renderWithStore(null)
 
     // Wait for fetch to complete
@@ -417,12 +426,13 @@ describe('SFMSInsightsPage', () => {
   it('should set rasterDate to today when latestBounds.maximum is empty', async () => {
     renderWithStore({
       '2025': {
-        forecast: {
+        actual: {
           minimum: '2025-05-01',
           maximum: ''
         }
       }
     })
+    await waitForPageLoad()
 
     const datePicker = screen.getByTestId('date-picker')
     expect(datePicker).toBeInTheDocument()
@@ -439,7 +449,7 @@ describe('SFMSInsightsPage', () => {
   it('should not set minDate when earliestBounds.minimum is empty', async () => {
     renderWithStore({
       '2025': {
-        forecast: {
+        actual: {
           minimum: '',
           maximum: '2025-10-15'
         }
@@ -456,18 +466,19 @@ describe('SFMSInsightsPage', () => {
   it('should set rasterDate to today when all years have empty maximum', async () => {
     renderWithStore({
       '2024': {
-        forecast: {
+        actual: {
           minimum: '2024-01-01',
           maximum: ''
         }
       },
       '2025': {
-        forecast: {
+        actual: {
           minimum: '',
           maximum: ''
         }
       }
     })
+    await waitForPageLoad()
 
     const datePicker = screen.getByTestId('date-picker')
     expect(datePicker).toBeInTheDocument()

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
@@ -269,8 +269,7 @@ describe('SFMSInsightsPage', () => {
 
     fireEvent.click(screen.getByTestId('about-data-trigger'))
 
-    expect(screen.getByTestId('about-data-content')).toHaveTextContent('SFMS Next Generation')
-    expect(screen.getByTestId('about-data-content')).toHaveTextContent('separate from the legacy SFMS products')
+    expect(screen.getByTestId('about-data-content')).toBeInTheDocument()
   })
 
   it('should fetch snow data on mount with initial rasterDate', async () => {

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
@@ -214,12 +214,12 @@ describe('SFMSInsightsPage', () => {
     expect(rasterDate).toContain('2025-11-02')
   })
 
-  it('should show FWI by default', async () => {
+  it('should show the fuel grid by default', async () => {
     renderWithStore()
     await waitForPageLoad()
 
     const map = screen.getByTestId('sfms-map')
-    expect(map).toHaveAttribute('data-raster-type', 'fwi')
+    expect(map).toHaveAttribute('data-raster-type', 'fuel')
   })
 
   it('should set date picker max date based on SFMS bounds', async () => {

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
@@ -102,7 +102,6 @@ vi.mock('@/features/sfmsInsights/components/RasterTypeDropdown', () => ({
 
 describe('SFMSInsightsPage', () => {
   const dateTimeNow = DateTime.fromISO('2025-11-02')
-  const dateTimeNowPlusTen = dateTimeNow.plus({ days: 10 })
   class ResizeObserver {
     observe() {
       // mock no-op

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
@@ -263,6 +263,16 @@ describe('SFMSInsightsPage', () => {
     expect(snowCheckbox).toBeInTheDocument()
   })
 
+  it('should show SFMS Insights about data content', async () => {
+    renderWithStore()
+    await waitForPageLoad()
+
+    fireEvent.click(screen.getByTestId('about-data-trigger'))
+
+    expect(screen.getByTestId('about-data-content')).toHaveTextContent('SFMS Next Generation')
+    expect(screen.getByTestId('about-data-content')).toHaveTextContent('separate from the legacy SFMS products')
+  })
+
   it('should fetch snow data on mount with initial rasterDate', async () => {
     renderWithStore()
     await waitForPageLoad()

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.test.tsx
@@ -3,7 +3,6 @@ import { SFMSInsightsPage } from './SFMSInsightsPage'
 import { Provider } from 'react-redux'
 import { createTestStore } from '@/test/testUtils'
 import { getMostRecentProcessedSnowByDate } from '@wps/api/snow'
-import { getSFMSInsightsBounds } from '@wps/api/sfmsAPI'
 import { getDateTimeNowPST } from '@wps/utils/date'
 import { DateTime } from 'luxon'
 import { Mock } from 'vitest'
@@ -14,10 +13,6 @@ vi.mock('@wps/api/snow', () => ({
 
 vi.mock('@wps/utils/date', () => ({
   getDateTimeNowPST: vi.fn()
-}))
-
-vi.mock('@wps/api/sfmsAPI', () => ({
-  getSFMSInsightsBounds: vi.fn()
 }))
 
 vi.mock('@/features/sfmsInsights/components/map/SFMSMap', () => {
@@ -127,11 +122,7 @@ describe('SFMSInsightsPage', () => {
     roles: []
   }
 
-  const defaultRunDates = {
-    loading: false,
-    error: null,
-    runDates: [],
-    mostRecentRunDate: null,
+  const defaultSFMSInsights = {
     sfmsBoundsError: null,
     sfmsBoundsLoading: false,
     sfmsBounds: {
@@ -150,14 +141,13 @@ describe('SFMSInsightsPage', () => {
     }
   }
 
-  const renderWithStore = (sfmsBounds: any = defaultRunDates.sfmsBounds) => {
-    ;(getSFMSInsightsBounds as Mock).mockResolvedValue({
-      sfms_bounds: sfmsBounds
-    })
-
+  const renderWithStore = (sfmsBounds: any = defaultSFMSInsights.sfmsBounds) => {
     const store = createTestStore({
       authentication: defaultAuthentication,
-      runDates: defaultRunDates
+      sfmsInsights: {
+        ...defaultSFMSInsights,
+        sfmsBounds
+      }
     })
     return render(<Provider store={store}>{<SFMSInsightsPage />}</Provider>)
   }
@@ -184,23 +174,6 @@ describe('SFMSInsightsPage', () => {
     })
     // Mock getDateTimeNowPST to return a date in 2025
     ;(getDateTimeNowPST as Mock).mockReturnValue(dateTimeNow)
-    // Mock SFMS Insights bounds API call
-    ;(getSFMSInsightsBounds as Mock).mockResolvedValue({
-      sfms_bounds: {
-        '2024': {
-          actual: {
-            minimum: '2024-01-01',
-            maximum: '2024-12-31'
-          }
-        },
-        '2025': {
-          actual: {
-            minimum: '2025-01-01',
-            maximum: '2025-11-02'
-          }
-        }
-      }
-    })
   })
 
   it('should load rasterDate from SFMS bounds in store', async () => {

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
@@ -51,7 +51,7 @@ export const SFMSInsightsPage = () => {
     DateTime.fromObject({ day: 1, month: 1, year: getDateTimeNowPST().year })
   )
 
-  const [rasterType, setRasterType] = useState<RasterType>('fwi')
+  const [rasterType, setRasterType] = useState<RasterType>('fuel')
   const [showSnow, setShowSnow] = useState<boolean>(true)
 
   useEffect(() => {

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
@@ -1,49 +1,33 @@
+import { AppDispatch } from '@/app/store'
 import ASADatePicker from '@/features/fba/components/ASADatePicker'
 import Footer from '@/features/landingPage/components/Footer'
 import { RasterType } from '@/features/sfmsInsights/components/map/rasterConfig'
 import SFMSMap from '@/features/sfmsInsights/components/map/SFMSMap'
 import RasterTypeDropdown from '@/features/sfmsInsights/components/RasterTypeDropdown'
+import {
+  fetchSFMSInsightsBounds,
+  selectEarliestSFMSInsightsBounds,
+  selectLatestSFMSInsightsBounds,
+  selectSFMSInsightsBounds,
+  selectSFMSInsightsBoundsLoading
+} from '@/features/sfmsInsights/slices/sfmsInsightsSlice'
 import { Box, Checkbox, CircularProgress, FormControlLabel, Grid } from '@mui/material'
 import { getMostRecentProcessedSnowByDate } from '@wps/api/snow'
-import { getSFMSInsightsBounds, type SFMSBounds } from '@wps/api/sfmsAPI'
 import { GeneralHeader } from '@wps/ui/GeneralHeader'
 import { StyledFormControl } from '@wps/ui/StyledFormControl'
 import { SFMS_INSIGHTS_NAME } from '@wps/utils/constants'
 import { getDateTimeNowPST } from '@wps/utils/date'
-import { logError } from '@wps/utils/error'
 import { isNull } from 'lodash'
 import { DateTime } from 'luxon'
 import { useEffect, useState } from 'react'
-
-const findActualBoundsInOrder = (
-  sfmsBounds: SFMSBounds | null | undefined,
-  sortFn: (a: string, b: string) => number,
-  hasValue: (bounds: { minimum: string; maximum: string }) => boolean
-) => {
-  if (!sfmsBounds) return null
-
-  for (const year of Object.keys(sfmsBounds).sort(sortFn)) {
-    const bounds = sfmsBounds[year]?.actual
-    if (bounds && hasValue(bounds)) {
-      return bounds
-    }
-  }
-  return null
-}
+import { useDispatch, useSelector } from 'react-redux'
 
 export const SFMSInsightsPage = () => {
-  const [sfmsBounds, setSfmsBounds] = useState<SFMSBounds | null | undefined>(undefined)
-  const [sfmsBoundsLoading, setSfmsBoundsLoading] = useState<boolean>(false)
-  const latestBounds = findActualBoundsInOrder(
-    sfmsBounds,
-    (a, b) => b.localeCompare(a),
-    bounds => !!bounds.maximum
-  )
-  const earliestBounds = findActualBoundsInOrder(
-    sfmsBounds,
-    (a, b) => a.localeCompare(b),
-    bounds => !!bounds.minimum
-  )
+  const dispatch = useDispatch<AppDispatch>()
+  const sfmsBounds = useSelector(selectSFMSInsightsBounds)
+  const sfmsBoundsLoading = useSelector(selectSFMSInsightsBoundsLoading)
+  const latestBounds = useSelector(selectLatestSFMSInsightsBounds)
+  const earliestBounds = useSelector(selectEarliestSFMSInsightsBounds)
   const [snowDate, setSnowDate] = useState<DateTime | null>(null)
   const [rasterDate, setRasterDate] = useState<DateTime | null>(getDateTimeNowPST())
   const [maxDate, setMaxDate] = useState<DateTime>(getDateTimeNowPST().plus({ days: 10 }))
@@ -59,21 +43,8 @@ export const SFMSInsightsPage = () => {
       return
     }
 
-    const fetchBounds = async () => {
-      try {
-        setSfmsBoundsLoading(true)
-        const bounds = await getSFMSInsightsBounds()
-        setSfmsBounds(bounds.sfms_bounds)
-      } catch (err) {
-        setSfmsBounds(null)
-        logError(err)
-      } finally {
-        setSfmsBoundsLoading(false)
-      }
-    }
-
-    fetchBounds()
-  }, [sfmsBounds, sfmsBoundsLoading])
+    dispatch(fetchSFMSInsightsBounds())
+  }, [dispatch, sfmsBounds, sfmsBoundsLoading])
 
   useEffect(() => {
     if (earliestBounds?.minimum) {

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
@@ -1,50 +1,93 @@
-import { AppDispatch } from '@/app/store'
 import ASADatePicker from '@/features/fba/components/ASADatePicker'
-import { fetchSFMSBounds, selectEarliestSFMSBounds, selectLatestSFMSBounds } from '@/features/fba/slices/runDatesSlice'
 import Footer from '@/features/landingPage/components/Footer'
 import { RasterType } from '@/features/sfmsInsights/components/map/rasterConfig'
 import SFMSMap from '@/features/sfmsInsights/components/map/SFMSMap'
 import RasterTypeDropdown from '@/features/sfmsInsights/components/RasterTypeDropdown'
 import { Box, Checkbox, CircularProgress, FormControlLabel, Grid } from '@mui/material'
 import { getMostRecentProcessedSnowByDate } from '@wps/api/snow'
+import { getSFMSInsightsBounds, type SFMSBounds } from '@wps/api/sfmsAPI'
 import { GeneralHeader } from '@wps/ui/GeneralHeader'
 import { StyledFormControl } from '@wps/ui/StyledFormControl'
 import { SFMS_INSIGHTS_NAME } from '@wps/utils/constants'
 import { getDateTimeNowPST } from '@wps/utils/date'
+import { logError } from '@wps/utils/error'
 import { isNull } from 'lodash'
 import { DateTime } from 'luxon'
 import { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+
+const findActualBoundsInOrder = (
+  sfmsBounds: SFMSBounds | null | undefined,
+  sortFn: (a: string, b: string) => number,
+  hasValue: (bounds: { minimum: string; maximum: string }) => boolean
+) => {
+  if (!sfmsBounds) return null
+
+  for (const year of Object.keys(sfmsBounds).sort(sortFn)) {
+    const bounds = sfmsBounds[year]?.actual
+    if (bounds && hasValue(bounds)) {
+      return bounds
+    }
+  }
+  return null
+}
 
 export const SFMSInsightsPage = () => {
-  const dispatch = useDispatch<AppDispatch>()
-  const latestBounds = useSelector(selectLatestSFMSBounds)
-  const earliestBounds = useSelector(selectEarliestSFMSBounds)
-  const sfmsBounds = useSelector((state: any) => state.runDates.sfmsBounds)
-  const sfmsBoundsLoading = useSelector((state: any) => state.runDates.sfmsBoundsLoading)
+  const [sfmsBounds, setSfmsBounds] = useState<SFMSBounds | null | undefined>(undefined)
+  const [sfmsBoundsLoading, setSfmsBoundsLoading] = useState<boolean>(false)
+  const latestBounds = findActualBoundsInOrder(
+    sfmsBounds,
+    (a, b) => b.localeCompare(a),
+    bounds => !!bounds.maximum
+  )
+  const earliestBounds = findActualBoundsInOrder(
+    sfmsBounds,
+    (a, b) => a.localeCompare(b),
+    bounds => !!bounds.minimum
+  )
   const [snowDate, setSnowDate] = useState<DateTime | null>(null)
   const [rasterDate, setRasterDate] = useState<DateTime | null>(getDateTimeNowPST())
-  const [maxDate] = useState<DateTime>(getDateTimeNowPST().plus({ days: 10 }))
+  const [maxDate, setMaxDate] = useState<DateTime>(getDateTimeNowPST().plus({ days: 10 }))
   const [minDate, setMinDate] = useState<DateTime>(
     DateTime.fromObject({ day: 1, month: 1, year: getDateTimeNowPST().year })
   )
 
-  const [rasterType, setRasterType] = useState<RasterType>('fuel')
+  const [rasterType, setRasterType] = useState<RasterType>('fwi')
   const [showSnow, setShowSnow] = useState<boolean>(true)
 
   useEffect(() => {
-    // Only fetch SFMS bounds if we haven't fetched yet (undefined) and aren't already loading
-    if (sfmsBounds === undefined && !sfmsBoundsLoading) {
-      dispatch(fetchSFMSBounds())
+    if (sfmsBounds !== undefined || sfmsBoundsLoading) {
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+
+    const fetchBounds = async () => {
+      try {
+        setSfmsBoundsLoading(true)
+        const bounds = await getSFMSInsightsBounds()
+        setSfmsBounds(bounds.sfms_bounds)
+      } catch (err) {
+        setSfmsBounds(null)
+        logError(err)
+      } finally {
+        setSfmsBoundsLoading(false)
+      }
+    }
+
+    fetchBounds()
+  }, [sfmsBounds, sfmsBoundsLoading])
 
   useEffect(() => {
     if (earliestBounds?.minimum) {
       setMinDate(DateTime.fromISO(earliestBounds.minimum))
     }
   }, [earliestBounds])
+
+  useEffect(() => {
+    if (latestBounds?.maximum) {
+      const latestDate = DateTime.fromISO(latestBounds.maximum)
+      setMaxDate(latestDate)
+      setRasterDate(currentDate => (currentDate?.toISODate() === latestDate.toISODate() ? currentDate : latestDate))
+    }
+  }, [latestBounds])
 
   useEffect(() => {
     // Only fetch snow data once rasterDate is set
@@ -77,9 +120,13 @@ export const SFMSInsightsPage = () => {
           borderBottomColor: 'secondary.main'
         }}
       >
-        <Grid container spacing={1} sx={{
-          alignItems: 'center'
-        }}>
+        <Grid
+          container
+          spacing={1}
+          sx={{
+            alignItems: 'center'
+          }}
+        >
           {sfmsBoundsLoading ? (
             <Grid>
               <StyledFormControl>
@@ -124,5 +171,5 @@ export const SFMSInsightsPage = () => {
       </Box>
       <Footer />
     </Box>
-  );
+  )
 }

--- a/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/pages/SFMSInsightsPage.tsx
@@ -4,6 +4,7 @@ import Footer from '@/features/landingPage/components/Footer'
 import { RasterType } from '@/features/sfmsInsights/components/map/rasterConfig'
 import SFMSMap from '@/features/sfmsInsights/components/map/SFMSMap'
 import RasterTypeDropdown from '@/features/sfmsInsights/components/RasterTypeDropdown'
+import { SfmsInsightsAboutDataContent } from '@/features/sfmsInsights/components/SfmsInsightsAboutDataContent'
 import {
   fetchSFMSInsightsBounds,
   selectEarliestSFMSInsightsBounds,
@@ -13,6 +14,7 @@ import {
 } from '@/features/sfmsInsights/slices/sfmsInsightsSlice'
 import { Box, Checkbox, CircularProgress, FormControlLabel, Grid } from '@mui/material'
 import { getMostRecentProcessedSnowByDate } from '@wps/api/snow'
+import AboutDataPopover from '@wps/ui/AboutDataPopover'
 import { GeneralHeader } from '@wps/ui/GeneralHeader'
 import { StyledFormControl } from '@wps/ui/StyledFormControl'
 import { SFMS_INSIGHTS_NAME } from '@wps/utils/constants'
@@ -133,6 +135,13 @@ export const SFMSInsightsPage = () => {
             <FormControlLabel
               control={<Checkbox checked={showSnow} onChange={e => setShowSnow(e.target.checked)} />}
               label={snowDate ? `Show Latest Snow: ${snowDate.toLocaleString(DateTime.DATE_MED)}` : 'Show Latest Snow'}
+            />
+          </Grid>
+          <Grid sx={{ marginLeft: 'auto', paddingRight: 2 }}>
+            <AboutDataPopover
+              content={SfmsInsightsAboutDataContent}
+              maxWidth={450}
+              testId="sfms-insights-about-data-popover"
             />
           </Grid>
         </Grid>

--- a/web/apps/wps-web/src/features/sfmsInsights/slices/sfmsInsightsSlice.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/slices/sfmsInsightsSlice.test.ts
@@ -91,7 +91,7 @@ describe('fetchSFMSInsightsBounds thunk', () => {
     mockedGetSFMSInsightsBounds.mockResolvedValue(sfmsBounds)
 
     const store = createTestStore({ sfmsInsights: initialState }, sfmsInsightsReducer)
-    const dispatch = store.dispatch as AppDispatch
+    const dispatch: AppDispatch = store.dispatch
     await dispatch(fetchSFMSInsightsBounds())
 
     const state = store.getState().sfmsInsights
@@ -106,7 +106,7 @@ describe('fetchSFMSInsightsBounds thunk', () => {
     mockedGetSFMSInsightsBounds.mockRejectedValue(error)
 
     const store = createTestStore({ sfmsInsights: initialState }, sfmsInsightsReducer)
-    const dispatch = store.dispatch as AppDispatch
+    const dispatch: AppDispatch = store.dispatch
     await dispatch(fetchSFMSInsightsBounds())
 
     const state = store.getState().sfmsInsights

--- a/web/apps/wps-web/src/features/sfmsInsights/slices/sfmsInsightsSlice.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/slices/sfmsInsightsSlice.test.ts
@@ -118,24 +118,25 @@ describe('fetchSFMSInsightsBounds thunk', () => {
 })
 
 describe('SFMS Insights bounds selectors', () => {
+  const fullSfmsBounds = {
+    '2024': {
+      actual: {
+        minimum: '2024-01-01',
+        maximum: '2024-12-31'
+      }
+    },
+    '2025': {
+      actual: {
+        minimum: '2025-01-01',
+        maximum: '2025-11-02'
+      }
+    }
+  }
   it('selectLatestSFMSInsightsBounds returns actual bounds from most recent year', () => {
     const state = {
       sfmsInsights: {
         ...initialState,
-        sfmsBounds: {
-          '2024': {
-            actual: {
-              minimum: '2024-01-01',
-              maximum: '2024-12-31'
-            }
-          },
-          '2025': {
-            actual: {
-              minimum: '2025-01-01',
-              maximum: '2025-11-02'
-            }
-          }
-        }
+        sfmsBounds: fullSfmsBounds
       }
     }
 
@@ -149,20 +150,7 @@ describe('SFMS Insights bounds selectors', () => {
     const state = {
       sfmsInsights: {
         ...initialState,
-        sfmsBounds: {
-          '2024': {
-            actual: {
-              minimum: '2024-01-01',
-              maximum: '2024-12-31'
-            }
-          },
-          '2025': {
-            actual: {
-              minimum: '2025-01-01',
-              maximum: '2025-11-02'
-            }
-          }
-        }
+        sfmsBounds: fullSfmsBounds
       }
     }
 

--- a/web/apps/wps-web/src/features/sfmsInsights/slices/sfmsInsightsSlice.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/slices/sfmsInsightsSlice.test.ts
@@ -1,0 +1,246 @@
+import { combineReducers } from '@reduxjs/toolkit'
+import { AppDispatch } from '@/app/store'
+import { createTestStore } from '@/test/testUtils'
+import { getSFMSInsightsBounds, SFMSBoundsResponse, type SFMSBounds } from '@wps/api/sfmsAPI'
+import { logError } from '@wps/utils/error'
+import reducer, {
+  fetchSFMSInsightsBounds,
+  getSFMSInsightsBoundsFailed,
+  getSFMSInsightsBoundsStart,
+  getSFMSInsightsBoundsSuccess,
+  initialState,
+  selectEarliestSFMSInsightsBounds,
+  selectLatestSFMSInsightsBounds
+} from './sfmsInsightsSlice'
+
+const sfmsInsightsReducer = combineReducers({ sfmsInsights: reducer })
+
+vi.mock('@wps/api/sfmsAPI', async () => {
+  const actual = await vi.importActual<typeof import('@wps/api/sfmsAPI')>('@wps/api/sfmsAPI')
+  return {
+    ...actual,
+    getSFMSInsightsBounds: vi.fn()
+  }
+})
+
+vi.mock('@wps/utils/error', () => ({
+  logError: vi.fn()
+}))
+
+const mockedGetSFMSInsightsBounds = vi.mocked(getSFMSInsightsBounds)
+const mockedLogError = vi.mocked(logError)
+
+describe('sfmsInsightsSlice reducer', () => {
+  it('should return initial state for unknown action', () => {
+    const next = reducer(undefined, { type: 'UNKNOWN' })
+    expect(next).toEqual(initialState)
+  })
+
+  it('getSFMSInsightsBoundsStart clears bounds and sets loading', () => {
+    const prev = { ...initialState, sfmsBounds: {} as SFMSBounds, sfmsBoundsError: 'old error' }
+    const next = reducer(prev, getSFMSInsightsBoundsStart())
+
+    expect(next.sfmsBounds).toBeNull()
+    expect(next.sfmsBoundsLoading).toBe(true)
+    expect(next.sfmsBoundsError).toBeNull()
+  })
+
+  it('getSFMSInsightsBoundsFailed sets error, clears bounds and stops loading', () => {
+    const prev = { ...initialState, sfmsBounds: {} as SFMSBounds, sfmsBoundsLoading: true }
+    const next = reducer(prev, getSFMSInsightsBoundsFailed('bad bounds'))
+
+    expect(next.sfmsBounds).toBeNull()
+    expect(next.sfmsBoundsLoading).toBe(false)
+    expect(next.sfmsBoundsError).toBe('bad bounds')
+  })
+
+  it('getSFMSInsightsBoundsSuccess sets bounds, clears error and stops loading', () => {
+    const bounds: SFMSBounds = {
+      '2025': {
+        actual: {
+          minimum: '2025-05-01',
+          maximum: '2025-10-31'
+        }
+      }
+    }
+    const prev = { ...initialState, sfmsBoundsError: 'old error', sfmsBoundsLoading: true }
+    const next = reducer(prev, getSFMSInsightsBoundsSuccess({ sfms_bounds: bounds }))
+
+    expect(next.sfmsBounds).toBe(bounds)
+    expect(next.sfmsBoundsLoading).toBe(false)
+    expect(next.sfmsBoundsError).toBeNull()
+  })
+})
+
+describe('fetchSFMSInsightsBounds thunk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should update state with sfmsBounds and stop loading', async () => {
+    const sfmsBounds: SFMSBoundsResponse = {
+      sfms_bounds: {
+        '2025': {
+          actual: {
+            minimum: '2025-05-01',
+            maximum: '2025-10-31'
+          }
+        }
+      }
+    }
+    mockedGetSFMSInsightsBounds.mockResolvedValue(sfmsBounds)
+
+    const store = createTestStore({ sfmsInsights: initialState }, sfmsInsightsReducer)
+    const dispatch = store.dispatch as AppDispatch
+    await dispatch(fetchSFMSInsightsBounds())
+
+    const state = store.getState().sfmsInsights
+    expect(state.sfmsBounds).toBe(sfmsBounds.sfms_bounds)
+    expect(state.sfmsBoundsLoading).toBe(false)
+    expect(state.sfmsBoundsError).toBeNull()
+    expect(mockedLogError).not.toHaveBeenCalled()
+  })
+
+  it('should log an error and stop loading', async () => {
+    const error = 'Error'
+    mockedGetSFMSInsightsBounds.mockRejectedValue(error)
+
+    const store = createTestStore({ sfmsInsights: initialState }, sfmsInsightsReducer)
+    const dispatch = store.dispatch as AppDispatch
+    await dispatch(fetchSFMSInsightsBounds())
+
+    const state = store.getState().sfmsInsights
+    expect(state.sfmsBounds).toBeNull()
+    expect(state.sfmsBoundsLoading).toBe(false)
+    expect(state.sfmsBoundsError).toBe(error)
+    expect(mockedLogError).toHaveBeenCalledWith(error)
+  })
+})
+
+describe('SFMS Insights bounds selectors', () => {
+  it('selectLatestSFMSInsightsBounds returns actual bounds from most recent year', () => {
+    const state = {
+      sfmsInsights: {
+        ...initialState,
+        sfmsBounds: {
+          '2024': {
+            actual: {
+              minimum: '2024-01-01',
+              maximum: '2024-12-31'
+            }
+          },
+          '2025': {
+            actual: {
+              minimum: '2025-01-01',
+              maximum: '2025-11-02'
+            }
+          }
+        }
+      }
+    }
+
+    expect(selectLatestSFMSInsightsBounds(state)).toEqual({
+      minimum: '2025-01-01',
+      maximum: '2025-11-02'
+    })
+  })
+
+  it('selectEarliestSFMSInsightsBounds returns actual bounds from earliest year', () => {
+    const state = {
+      sfmsInsights: {
+        ...initialState,
+        sfmsBounds: {
+          '2024': {
+            actual: {
+              minimum: '2024-01-01',
+              maximum: '2024-12-31'
+            }
+          },
+          '2025': {
+            actual: {
+              minimum: '2025-01-01',
+              maximum: '2025-11-02'
+            }
+          }
+        }
+      }
+    }
+
+    expect(selectEarliestSFMSInsightsBounds(state)).toEqual({
+      minimum: '2024-01-01',
+      maximum: '2024-12-31'
+    })
+  })
+
+  it('selectLatestSFMSInsightsBounds skips years with empty maximum', () => {
+    const state = {
+      sfmsInsights: {
+        ...initialState,
+        sfmsBounds: {
+          '2024': {
+            actual: {
+              minimum: '2024-01-01',
+              maximum: ''
+            }
+          },
+          '2025': {
+            actual: {
+              minimum: '',
+              maximum: ''
+            }
+          },
+          '2023': {
+            actual: {
+              minimum: '2023-01-01',
+              maximum: '2023-12-31'
+            }
+          }
+        }
+      }
+    }
+
+    expect(selectLatestSFMSInsightsBounds(state)).toEqual({
+      minimum: '2023-01-01',
+      maximum: '2023-12-31'
+    })
+  })
+
+  it('selectEarliestSFMSInsightsBounds skips years with empty minimum', () => {
+    const state = {
+      sfmsInsights: {
+        ...initialState,
+        sfmsBounds: {
+          '2023': {
+            actual: {
+              minimum: '',
+              maximum: '2023-12-31'
+            }
+          },
+          '2024': {
+            actual: {
+              minimum: '2024-01-01',
+              maximum: ''
+            }
+          }
+        }
+      }
+    }
+
+    expect(selectEarliestSFMSInsightsBounds(state)).toEqual({
+      minimum: '2024-01-01',
+      maximum: ''
+    })
+  })
+
+  it('selectors return null when bounds are null', () => {
+    const state = {
+      sfmsInsights: {
+        ...initialState,
+        sfmsBounds: null
+      }
+    }
+
+    expect(selectLatestSFMSInsightsBounds(state)).toBeNull()
+    expect(selectEarliestSFMSInsightsBounds(state)).toBeNull()
+  })
+})

--- a/web/apps/wps-web/src/features/sfmsInsights/slices/sfmsInsightsSlice.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/slices/sfmsInsightsSlice.ts
@@ -1,0 +1,95 @@
+import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { AppThunk } from 'app/store'
+import { getSFMSInsightsBounds, SFMSBounds, SFMSBoundsResponse } from '@wps/api/sfmsAPI'
+import { logError } from '@wps/utils/error'
+
+export interface SFMSInsightsState {
+  sfmsBounds: SFMSBounds | null | undefined
+  sfmsBoundsLoading: boolean
+  sfmsBoundsError: string | null
+}
+
+export const initialState: SFMSInsightsState = {
+  sfmsBounds: undefined,
+  sfmsBoundsLoading: false,
+  sfmsBoundsError: null
+}
+
+const sfmsInsightsSlice = createSlice({
+  name: 'sfmsInsights',
+  initialState,
+  reducers: {
+    getSFMSInsightsBoundsStart(state: SFMSInsightsState) {
+      state.sfmsBounds = null
+      state.sfmsBoundsLoading = true
+      state.sfmsBoundsError = null
+    },
+    getSFMSInsightsBoundsFailed(state: SFMSInsightsState, action: PayloadAction<string>) {
+      state.sfmsBounds = null
+      state.sfmsBoundsLoading = false
+      state.sfmsBoundsError = action.payload
+    },
+    getSFMSInsightsBoundsSuccess(state: SFMSInsightsState, action: PayloadAction<SFMSBoundsResponse>) {
+      state.sfmsBounds = action.payload.sfms_bounds
+      state.sfmsBoundsLoading = false
+      state.sfmsBoundsError = null
+    }
+  }
+})
+
+export const { getSFMSInsightsBoundsStart, getSFMSInsightsBoundsFailed, getSFMSInsightsBoundsSuccess } =
+  sfmsInsightsSlice.actions
+
+export default sfmsInsightsSlice.reducer
+
+export const fetchSFMSInsightsBounds = (): AppThunk => async dispatch => {
+  try {
+    dispatch(getSFMSInsightsBoundsStart())
+    const bounds = await getSFMSInsightsBounds()
+    dispatch(getSFMSInsightsBoundsSuccess(bounds))
+  } catch (err) {
+    dispatch(getSFMSInsightsBoundsFailed((err as Error).toString()))
+    logError(err)
+  }
+}
+
+const selectSFMSInsights = (state: { sfmsInsights: SFMSInsightsState }) => state.sfmsInsights
+
+export const selectSFMSInsightsBounds = createSelector([selectSFMSInsights], sfmsInsights => sfmsInsights.sfmsBounds)
+
+export const selectSFMSInsightsBoundsLoading = createSelector(
+  [selectSFMSInsights],
+  sfmsInsights => sfmsInsights.sfmsBoundsLoading
+)
+
+const findActualBoundsInOrder = (
+  sfmsBounds: SFMSBounds | null | undefined,
+  sortFn: (a: string, b: string) => number,
+  hasValue: (bounds: { minimum: string; maximum: string }) => boolean
+) => {
+  if (!sfmsBounds) return null
+
+  for (const year of Object.keys(sfmsBounds).sort(sortFn)) {
+    const bounds = sfmsBounds[year]?.actual
+    if (bounds && hasValue(bounds)) {
+      return bounds
+    }
+  }
+  return null
+}
+
+export const selectLatestSFMSInsightsBounds = createSelector([selectSFMSInsightsBounds], sfmsBounds =>
+  findActualBoundsInOrder(
+    sfmsBounds,
+    (a, b) => b.localeCompare(a),
+    bounds => !!bounds.maximum
+  )
+)
+
+export const selectEarliestSFMSInsightsBounds = createSelector([selectSFMSInsightsBounds], sfmsBounds =>
+  findActualBoundsInOrder(
+    sfmsBounds,
+    (a, b) => a.localeCompare(b),
+    bounds => !!bounds.minimum
+  )
+)

--- a/web/packages/api/src/sfmsAPI.ts
+++ b/web/packages/api/src/sfmsAPI.ts
@@ -1,0 +1,26 @@
+import axios from './axios'
+
+export interface SFMSBoundsMinMax {
+  minimum: string
+  maximum: string
+}
+
+// Keys are 'actual' or 'forecast'
+export interface SFMSBoundsByRunType {
+  [key: string]: SFMSBoundsMinMax
+}
+
+// Keys are years (eg. 2024, 2025)
+export interface SFMSBounds {
+  [key: string]: SFMSBoundsByRunType
+}
+
+export interface SFMSBoundsResponse {
+  sfms_bounds: SFMSBounds
+}
+
+export async function getSFMSInsightsBounds(): Promise<SFMSBoundsResponse> {
+  const url = 'sfmsng/run-bounds'
+  const { data } = await axios.get(url)
+  return data
+}


### PR DESCRIPTION
- changes SFMS Insights to show data generated by SFMSng
  -  also includes weather rasters
  - uses same colours and breakpoints as WF1 SFMS viewer
- Adds `About this data` to SFMS Insights, to explain what data is being displayed 
- adds `sfmsng` endpoints for getting the start/end dates for sfmsng data
- fixes `Fuel: 255` bug 

closes #5017 #5305 
# Test Links:
[Landing Page](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5506-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
