### PR TITLE
Dev: Bump GDAL to 3.13.1 and overhaul local mac setup + docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ WFWX_SECRET=somesecret
 WFWX_MAX_PAGE_SIZE=1000
 KEYCLOAK_PUBLIC_KEY=thisispublickey
 KEYCLOAK_CLIENT=client
+# POSTGRES_WRITE_HOST/READ_HOST: use the compose service name `db` for docker
+# (this file is the basis for .env.docker); for native local dev (.env) set these
+# to `localhost`.
 # POSTGRES_WRITE_HOST=host.docker.internal
 POSTGRES_WRITE_HOST=db
 POSTGRES_READ_HOST=db
@@ -45,7 +48,7 @@ REDIS_NOAA_CACHE_EXPIRY=21600
 # c-haines tiff output is a feature that's useful for debugging - not intended to be set to true anywhere
 # other than on a developers machine.
 C_HAINES_OUTPUT_TIFF=False
-CLASSPATH=/somewhere/wps/api/libs/REDapp_Lib.jar:/somewhere/wps/api/libs/WTime.jar:/somewhere/wps/api/libs/hss-java.jar
+CLASSPATH=/path/to/wps/backend/packages/wps-api/libs/REDapp_Lib.jar:/path/to/wps/backend/packages/wps-api/libs/WTime.jar:/path/to/wps/backend/packages/wps-api/libs/hss-java.jar
 SFMS_SECRET=somesecret
 NATS_STREAM_PREFIX=local
 NATS_SERVER=localhost

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     # https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases
     container: &api-base-image
-      image: ghcr.io/bcgov/wps/wps-api-base:03-30-2026
+      image: ghcr.io/bcgov/wps/wps-api-base:06-16-2026
       options: --user 0
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/setup_mac_test.yml
+++ b/.github/workflows/setup_mac_test.yml
@@ -9,13 +9,6 @@ name: Setup script (macOS)
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "setup/mac.sh"
-      - "backend/packages/*/pyproject.toml"
-      - "backend/uv.lock"
-      - ".env.example"
-      - ".github/workflows/setup_mac_test.yml"
   schedule:
     # Mondays 09:00 UTC -- catch external drift (homebrew-core gdal vs the pyproject
     # pin, the wkhtmltopdf release, osgeo base images) even when the repo hasn't changed.

--- a/.github/workflows/setup_mac_test.yml
+++ b/.github/workflows/setup_mac_test.yml
@@ -1,0 +1,82 @@
+name: Setup script (macOS)
+
+# Runs setup/mac.sh on a clean, disposable arm64 macOS runner to verify the local
+# backend setup works end-to-end (Homebrew deps, GDAL, Postgres/PostGIS, Redis, uv).
+# This is the e2e test for setup/mac.sh that can't be safely run on a dev machine.
+#
+# Note: GitHub runners ship with Homebrew/Python preinstalled, so the "fresh machine"
+# Homebrew bootstrap branch in mac.sh is skipped here (brew is already present).
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "setup/mac.sh"
+      - "backend/packages/*/pyproject.toml"
+      - "backend/uv.lock"
+      - ".env.example"
+      - ".github/workflows/setup_mac_test.yml"
+  schedule:
+    # Mondays 09:00 UTC -- catch external drift (homebrew-core gdal vs the pyproject
+    # pin, the wkhtmltopdf release, osgeo base images) even when the repo hasn't changed.
+    - cron: "0 9 * * 1"
+
+concurrency:
+  group: setup-mac-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mac-setup:
+    name: Provision a clean macOS machine with setup/mac.sh
+    # Apple Silicon (arm64) -- matches dev machines and exercises the Rosetta/wkhtmltopdf path.
+    runs-on: macos-15
+    timeout-minutes: 75
+    env:
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run setup/mac.sh
+        # Runners have passwordless sudo, so the wkhtmltopdf .pkg / Rosetta steps run
+        # non-interactively.
+        run: bash setup/mac.sh
+
+      - name: Put provisioned tools on PATH for the smoke test
+        # mac.sh exports these for its own run only; re-expose them for later steps.
+        run: |
+          echo "$(brew --prefix postgresql@17)/bin" >> "$GITHUB_PATH"
+          echo "JAVA_HOME=$(brew --prefix openjdk)/libexec/openjdk.jdk/Contents/Home" >> "$GITHUB_ENV"
+
+      - name: Smoke test -- tools installed
+        run: |
+          set -euo pipefail
+          gdal-config --version
+          psql --version
+          redis-cli ping
+          uv --version
+          command -v wkhtmltopdf >/dev/null && wkhtmltopdf --version || echo "wkhtmltopdf not installed (optional)"
+
+      - name: Smoke test -- database provisioned
+        run: |
+          set -euo pipefail
+          psql -d wps -c "select postgis_version();"
+
+      - name: Create .env for the backend
+        run: |
+          set -euo pipefail
+          cp .env.example .env
+          # native dev: DB on localhost; hostname-safe object-store placeholders
+          sed -i '' -e 's/^POSTGRES_WRITE_HOST=db/POSTGRES_WRITE_HOST=localhost/' \
+                    -e 's/^POSTGRES_READ_HOST=db/POSTGRES_READ_HOST=localhost/' \
+                    -e 's/=object_store_server/=object-store-server/' \
+                    -e 's/=wx_object_store_server/=wx-object-store-server/' .env
+
+      - name: Smoke test -- uv sync with GDAL binding
+        run: |
+          set -euo pipefail
+          cd backend
+          uv sync --all-extras
+          uv run python -c "from osgeo import gdal; print('osgeo gdal', gdal.__version__)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DOCKER_IMAGE=ghcr.io/bcgov/wps/wps-api-base:03-30-2026
+ARG DOCKER_IMAGE=ghcr.io/bcgov/wps/wps-api-base:06-16-2026
 # To build locally, point to a local base image you've already built (see openshift/wps-api-base)
 # e.g. : docker build --build-arg DOCKER_IMAGE=wps-api-base:my-tag .
 

--- a/Dockerfile.jobs
+++ b/Dockerfile.jobs
@@ -1,4 +1,4 @@
-ARG DOCKER_IMAGE=image-registry.apps.silver.devops.gov.bc.ca/e1e498-tools/wps-jobs-base:30-03-2026
+ARG DOCKER_IMAGE=image-registry.apps.silver.devops.gov.bc.ca/e1e498-tools/wps-jobs-base:16-06-2026
 # To build locally, point to a local base image you've already built (see wps-jobs-base)
 # e.g. : docker build --build-arg DOCKER_IMAGE=wps-jobs-base:my-tag .
 

--- a/README.md
+++ b/README.md
@@ -13,31 +13,43 @@ Wildfire Predictive Services to support decision making in prevention, preparedn
 
 ### Dependencies
 
+> **Note:** Docker Compose and the VS Code dev container are **currently
+> unsupported**. Native setup is the recommended (and supported) way to run the
+> project locally.
+
+Run the backend and front end natively — see the per-component setup docs:
+
+- Backend: [backend/README.md](backend/README.md) (uv, GDAL, Postgres/PostGIS, Redis). On macOS, `setup/mac.sh` installs the system dependencies.
+- Frontend: [web/README.md](web/README.md) (Node/yarn).
+
 ### Installing
 
-#### Running the application locally in docker:
+Native setup is the recommended and supported path. The Docker Compose and dev
+container flows further down are **currently unsupported** and may be out of date.
 
-1. Create `.env` file in `web` using `web/.env.example` as a sample.
-2. Create `.env.docker` file in `api/app` using `api/app/.env.example` as a sample.
+#### Running the api (native — recommended)
+
+Refer to [backend/packages/wps-api/README.md](backend/packages/wps-api/README.md) (setup in [backend/README.md](backend/README.md); on macOS, `setup/mac.sh` installs the dependencies).
+
+#### Running the front end (native — recommended)
+
+Refer to [web/README.md](web/README.md)
+
+#### Running the application locally in docker (currently unsupported)
+
+1. Create `web/.env` using `web/apps/wps-web/.env.example` as a sample.
+2. Create `backend/packages/wps-api/src/app/.env.docker` using the repo-root `.env.example` as a sample.
 3. Run `docker compose build` and then `docker compose up`
 4. Open [http://localhost:8080](http://localhost:8080) to view the front end served up from a static folder by the python api.
 5. Open [http://localhost:3000](http://localhost:3000) to view the front end served up in developer mode by node.
 
-#### Developing the application in a dev container, using vscode:
+#### Developing the application in a dev container, using vscode (currently unsupported)
 
-- Open up the project: `Remote-Containers: Open Folder in Container`, select docker-compose.vscode.yml
-- Sometimes VSCode doesn't pick up you've changed the docker container: `Remote-Containers: Rebuild Container`
+- Open the project and run `Dev Containers: Reopen in Container` — VS Code picks up `.devcontainer/devcontainer.json`.
+- Sometimes VSCode doesn't pick up you've changed the docker container: `Dev Containers: Rebuild Container`
 - Install extensions into the container, as needed.
 - You can point the API database to: `host.docker.internal`
 - You can start up other services outside of vscode, e.g.: `docker compose up db` and `docker compose up redis`
-
-#### Running the api alone
-
-Refer to [backend/packages/wps-api/README.md](backend/packages/wps-api/README.md).
-
-#### Running the front end alone
-
-Refer to [web/README.md](web/README.md)
 
 ### Documentation
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,7 +9,11 @@ backend/
 ├── packages/
 │   ├── wps-api/      # Main API application
 │   ├── wps-jobs/     # Background jobs
-│   └── wps-shared/   # Shared utilities
+│   ├── wps-sfms/     # SFMS processing
+│   ├── wps-shared/   # Shared utilities
+│   ├── wps-tools/    # Tooling / scripts
+│   ├── wps-weather/  # Weather model processing
+│   └── wps-wf1/      # WF1 (WFWX) integration
 ├── .venv/            # Single virtual environment
 ├── pyproject.toml    # Workspace configuration
 └── uv.lock           # Dependency lock file
@@ -17,7 +21,7 @@ backend/
 
 ## Getting Started
 
-You will need an environment file. See: `.env.example`. Contact current maintainers for current variable settings.
+You will need an environment file at the **repo root**: copy `.env.example` (in the repo root) to `.env`. python-decouple discovers it by walking up from the package directory, so it must live at the repo root, not in `backend/`. Contact current maintainers for current variable settings.
 
 ### Installing
 
@@ -31,8 +35,7 @@ You will need an environment file. See: `.env.example`. Contact current maintain
 ### Setup
 
 - Installation section above is completed
-- `.env` is correctly configured in the project root
-- this dynamic library is set in the env: `DYLD_LIBRARY_PATH=/Library/Frameworks/R.framework/Resources/lib`
+- `.env` is correctly configured in the repo root
 
 ### Install Dependencies
 
@@ -47,10 +50,14 @@ uv sync --all-extras
 # Run all tests
 uv run pytest
 
-# Run tests for a specific package
+# Run tests for a specific package (see pytest.ini for the full list of test paths)
 uv run pytest packages/wps-api/src
 uv run pytest packages/wps-jobs/src
+uv run pytest packages/wps-sfms/src
 uv run pytest packages/wps-shared/src
+uv run pytest packages/wps-weather/src
+uv run pytest packages/wps-wf1/src
+uv run pytest packages/wps-tools/tests
 
 # Run a specific test file
 uv run pytest packages/wps-shared/src/wps_shared/tests/test_fuel_raster.py
@@ -84,7 +91,8 @@ uv sync
 
 ## Docker Images
 
-Each package can be built independently:
+Each package can be built independently. Run these from the **repo root** (the
+Dockerfiles and their build context live there, not in `backend/`):
 
 ```bash
 # API image

--- a/backend/packages/wps-api/README.md
+++ b/backend/packages/wps-api/README.md
@@ -16,15 +16,23 @@ uv run pytest
 
 ### Troubleshooting
 
-**Poetry can't install rpy2**
-Error: `ld: library not found for -lpcre2-8`
+**`uv sync` fails building psycopg2: `pg_config executable not found`**
 
-pcre2 should be installed after running [mac.sh](../../../setup/mac.sh). This can be verified by running
-
-```bash
-brew list pcre2
-```
+`pg_config` must be on `PATH`. `postgresql@17` is keg-only, so add it:
 
 ```bash
-export LIBRARY_PATH="/opt/homebrew/Cellar/pcre2/10.42/lib/:$LIBRARY_PATH"
+export PATH="$(brew --prefix postgresql@17)/bin:$PATH"
 ```
+
+**Tests using jnius/REDapp segfault or can't find Java**
+
+Point `JAVA_HOME` at the brew openjdk (mac.sh installs it):
+
+```bash
+export JAVA_HOME="$(brew --prefix openjdk)/libexec/openjdk.jdk/Contents/Home"
+```
+
+**`GET /api/health` returns 500 locally**
+
+Expected — `/api/health` checks the CrunchyDB/patroni cluster via the OpenShift
+API, which isn't available locally. Use `GET /api/ready` to confirm the API is up.

--- a/backend/packages/wps-api/pyproject.toml
+++ b/backend/packages/wps-api/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "cffdrs",
     "geopandas>=1.0.1,<2",
     "shapely>=2.0.5,<3",
-    "gdal==3.12.3",
+    "gdal==3.13.1",
     "wps-wf1",
     "earthaccess>=0.15.1",
     "firebase-admin>=7.3.0",

--- a/backend/packages/wps-jobs/pyproject.toml
+++ b/backend/packages/wps-jobs/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "numpy==2.3.*",
     "xarray>=2025.3.1,<2026",
     "herbie-data>=2025.11.1,<2026",
-    "gdal==3.12.3",
+    "gdal==3.13.1",
     "wps-wf1",
     "aiofiles>=25.0.0,<26",
     "geoalchemy2>=0,<1",

--- a/backend/packages/wps-shared/pyproject.toml
+++ b/backend/packages/wps-shared/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "psycopg2-binary>=2.9.10,<3",
     "asyncpg>=0.30.0,<1",
     "redis>=8,<9",
-    "gdal==3.12.3",
+    "gdal==3.13.1",
     "wps-wf1",
     "cffdrs>=0,<1",
     "numba>=0,<1",

--- a/backend/packages/wps-weather/Dockerfile
+++ b/backend/packages/wps-weather/Dockerfile
@@ -1,4 +1,4 @@
-ARG DOCKER_IMAGE=ghcr.io/osgeo/gdal:ubuntu-small-3.12.3
+ARG DOCKER_IMAGE=ghcr.io/osgeo/gdal:ubuntu-small-3.13.1
 
 # Builder stage
 # ────────────────────────────────────────────────────────────────

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1263,9 +1263,9 @@ wheels = [
 
 [[package]]
 name = "gdal"
-version = "3.12.3"
+version = "3.13.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/cb/64ab7a1dd03e53870fd4c993d72baf6881a663953d2d2e8dd92098c12e94/gdal-3.12.3.tar.gz", hash = "sha256:a5aebb8f50b8f4d5b0c238cc9a6c988be3041bc276535daeddc399fa6ec13972", size = 899374, upload-time = "2026-03-20T13:48:41.273Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/55/0ae08a59293443bbbb8b692d1f4b6d9ca54562c359a48d0426684ac9ea06/gdal-3.13.1.tar.gz", hash = "sha256:94bb64d729ce73ceb75a314a15cba92696cdd854d99b6bf6b88a7b551227db74", size = 940649, upload-time = "2026-06-05T10:50:14.929Z" }
 
 [[package]]
 name = "geoalchemy2"
@@ -4755,7 +4755,7 @@ requires-dist = [
     { name = "earthaccess", specifier = ">=0.15.1" },
     { name = "fastapi", specifier = ">=0,<1" },
     { name = "firebase-admin", specifier = ">=7.3.0" },
-    { name = "gdal", specifier = "==3.12.3" },
+    { name = "gdal", specifier = "==3.13.1" },
     { name = "geoalchemy2", specifier = ">=0,<1" },
     { name = "geopandas", specifier = ">=1.0.1,<2" },
     { name = "greenlet", specifier = ">=3.0.0,<4" },
@@ -4831,7 +4831,7 @@ requires-dist = [
     { name = "affine", specifier = ">=2.4.0,<3" },
     { name = "aiofiles", specifier = ">=25.0.0,<26" },
     { name = "asyncpg", specifier = ">=0.30.0,<1" },
-    { name = "gdal", specifier = "==3.12.3" },
+    { name = "gdal", specifier = "==3.13.1" },
     { name = "geoalchemy2", specifier = ">=0,<1" },
     { name = "herbie-data", specifier = ">=2025.11.1,<2026" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5,<7" },
@@ -4912,7 +4912,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0,<1" },
     { name = "cffdrs", specifier = ">=0,<1" },
     { name = "fastapi", specifier = ">=0.115.11,<1" },
-    { name = "gdal", specifier = "==3.12.3" },
+    { name = "gdal", specifier = "==3.13.1" },
     { name = "geoalchemy2", specifier = ">=0,<1" },
     { name = "geopandas", specifier = ">=1.0.1,<2" },
     { name = "numba", specifier = ">=0,<1" },

--- a/docs/MANUAL_SETUP.md
+++ b/docs/MANUAL_SETUP.md
@@ -69,18 +69,21 @@ RedAPP unit tests will fail.
 
 The python `gdal` binding is pinned in `backend/packages/*/pyproject.toml` and is built
 from source by `uv sync` against the system libgdal, which must be **at least** the
-pinned version. Install GDAL from Homebrew and pin it so `brew upgrade` doesn't move the
-libgdal soname out from under the venv:
+pinned version. Install GDAL from Homebrew:
 
 ```bash
 brew install gdal
-brew pin gdal
 ```
 
-Keep the Homebrew gdal, the `ghcr.io/osgeo/gdal` base-image tag
-(`openshift/wps-api-base/docker/Dockerfile`), and the three `gdal==` pyproject pins in
-step when bumping. To bump: `brew unpin gdal && brew upgrade gdal`, update the base-image
-tag + the three pins, `uv lock`, then `uv sync`.
+We deliberately don't `brew pin gdal`: pinning the formula doesn't pin its dependencies
+(poppler, proj, geos, …), so a later `brew upgrade` can still move a dependency soname and
+break gdal. Letting homebrew keep gdal consistent with its deps avoids that; if gdal drifts
+ahead of the pinned version, `uv sync` fails loudly — that's the signal to bump.
+
+Keep the `ghcr.io/osgeo/gdal` base-image tag (`openshift/wps-api-base/docker/Dockerfile`)
+and the three `gdal==` pyproject pins in step. To bump: update the base-image tag + the
+three pins, `uv lock`, then `uv sync` (run `brew upgrade gdal` first if your local gdal is
+behind).
 
 ##### wkhtmltopdf
 

--- a/docs/MANUAL_SETUP.md
+++ b/docs/MANUAL_SETUP.md
@@ -1,8 +1,20 @@
 # Manual Setup
 
+The backend is a `uv`-managed Python workspace (see [backend/README.md](../backend/README.md)).
+On macOS most of this is automated by [`setup/mac.sh`](../setup/mac.sh); this document
+covers the manual steps and platform-specific notes.
+
 #### Local machine, in docker
 
-For local development, you can copy .env.example to .env.docker.
+> **Note:** Docker Compose and the VS Code dev container are **currently
+> unsupported** and may be out of date — native setup (below) is the recommended
+> and supported path. The docker steps are kept here for reference.
+
+For local development with docker compose, copy the repo-root `.env.example` to the
+two files compose reads (see `docker-compose.yml`'s `env_file` entries):
+
+- API: `backend/packages/wps-api/src/app/.env.docker`
+- Web: `web/.env` (sample at `web/apps/wps-web/.env.example`)
 
 ```bash
 docker compose build
@@ -10,13 +22,19 @@ docker compose build
 
 #### Local machine, running MacOS
 
-For local development, you can copy .env.example to .env.
+For native (non-docker) local development, copy the repo-root `.env.example` to `.env`
+(at the repo root — python-decouple discovers it by walking up from the package
+directory). Then change the database hosts from the docker-compose service name to
+`localhost`:
 
-NOTE: matching the version of postgresql, postgis and gdal with production is problematic, and best
-avoided. (postgresql + postgis binaries on mac use a newer version of gdal that we don't have on debian yet.)
+```
+POSTGRES_WRITE_HOST=localhost
+POSTGRES_READ_HOST=localhost
+```
 
-NOTE: installing postgresql, postgis and gdal as binaries is the preffered method of installation. Installing
-from source is a world of trouble you don't want to get into. Stick to brew.
+NOTE: matching the exact version of postgresql/postgis with production on your local
+machine is not necessary — production runs in containers (CrunchyDB) and CI matches it
+there. Locally we use Homebrew's `postgresql@17` + `postgis`.
 
 ##### Artifactory npm repo config
 
@@ -35,150 +53,132 @@ The artifactory token is currently stored in Vault as gha_artifactory_token.
 
 ##### Java
 
-Some of the unit tests use jnius to compare output against RedAPP. The default version of Java that
-comes with mac is likely to cause Segmentation Errors when you run unit tests.
-
-Install the latest JDK! Download [https://jdk.java.net/](https://jdk.java.net/)
+Some of the unit tests use jnius to compare output against RedAPP. `setup/mac.sh`
+installs `openjdk` via brew; point `JAVA_HOME` at it (the default macOS Java is likely
+to cause segmentation errors when running the unit tests):
 
 ```bash
-tar -xf openjdk-16.0.2_osx-x64_bin.tar.gz
-sudo mv jdk-16.0.2.jdk /Library/Java/JavaVirtualMachines
+export JAVA_HOME="$(brew --prefix openjdk)/libexec/openjdk.jdk/Contents/Home"
 ```
 
-Ensure that the CLASSPATH environment variable points to the jar files in api/libs, or unit tests will fail.
+Ensure the `CLASSPATH` environment variable in your `.env` points to the jar files in
+`backend/packages/wps-api/libs/` (`REDapp_Lib.jar`, `WTime.jar`, `hss-java.jar`), or the
+RedAPP unit tests will fail.
 
 ##### Gdal
 
-If you already have gdal installed above 3.12.3 you'll need to remove it and install a local version of the 3.12.3 version:
+The python `gdal` binding is pinned in `backend/packages/*/pyproject.toml` and is built
+from source by `uv sync` against the system libgdal, which must be **at least** the
+pinned version. Install GDAL from Homebrew and pin it so `brew upgrade` doesn't move the
+libgdal soname out from under the venv:
 
 ```bash
-brew uninstall postgis #depends on gdal
-brew uninstall gdal
-brew untap gdal/versions
+brew install gdal
+brew pin gdal
 ```
 
-Then:
-
-From: https://github.com/Homebrew/homebrew-core/commits/master/Formula/g/gdal.rb
-
-```bash
-brew tap-new $(whoami)/local-gdal
-curl -s https://raw.githubusercontent.com/Homebrew/homebrew-core/2761c8e5f5547753c8bebc39e95968006f5deb69/Formula/g/gdal.rb > $(brew --repository)/Library/Taps/$(whoami)/homebrew-local-gdal/Formula/gdal.rb
-brew install $(whoami)/local-gdal/gdal
-```
-
-Note that there are other subsequent steps for gdal installation. See "Install project python requirements".
+Keep the Homebrew gdal, the `ghcr.io/osgeo/gdal` base-image tag
+(`openshift/wps-api-base/docker/Dockerfile`), and the three `gdal==` pyproject pins in
+step when bumping. To bump: `brew unpin gdal && brew upgrade gdal`, update the base-image
+tag + the three pins, `uv lock`, then `uv sync`.
 
 ##### wkhtmltopdf
 
+wkhtmltopdf (used by `pdfkit` to generate HFI calculator PDFs) is discontinued and the
+Homebrew cask has been removed. `setup/mac.sh` installs it from the wkhtmltopdf packaging
+releases. Note that the production image uses the Linux `0.12.6.1-2` `.deb`, but that
+release has **no macOS build** — the newest macOS package is the older `0.12.6-2`
+x86_64 ("cocoa") `.pkg`, so on Apple Silicon it needs Rosetta 2:
+
 ```bash
-brew install --cask wkhtmltopdf
+softwareupdate --install-rosetta --agree-to-license
+curl -L -o /tmp/wkhtmltox.pkg \
+  https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-2/wkhtmltox-0.12.6-2.macos-cocoa.pkg
+sudo installer -pkg /tmp/wkhtmltox.pkg -target /
 ```
 
-##### Poetry
+PDF generation is not required for most backend work; the package is unsigned and the
+project is archived, so this is best-effort.
 
-Try to match the latest version of python in our production environment (as of writing, API is on 3.12.3)
+##### eccodes
+
+The weather-model tests need the ecCodes library:
 
 ```bash
-brew update
+brew install eccodes
+```
+
+##### Python (pyenv) and uv
+
+Match the latest version of python in our production environment (as of writing, 3.12.3):
+
+```bash
 brew install pyenv
 pyenv install 3.12.3
-pyenv local 3.12.3
-curl -sSL https://install.python-poetry.org | python -
+pyenv global 3.12.3
+brew install uv
 ```
 
 ##### Install project python requirements
 
-`poetry env use 3.12.3` doesn't actually honor the minor version, if you have more than one version
-of 3.10, and you want 3.12.3 exactly, you have to find the location of the 3.12.3 binary and point
-to that.
+Dependencies are installed for the whole workspace with `uv sync` — there is no
+per-package install step, and gdal/wps_shared are handled by the lockfile (no manual
+`pip install` needed).
+
+`psycopg2` builds from source, so `pg_config` must be on `PATH`. `postgresql@17` is
+keg-only, so expose its bin dir first:
 
 ```bash
-pyenv which python
+export PATH="$(brew --prefix postgresql@17)/bin:$PATH"
+cd backend
+uv sync --all-extras
 ```
-
-```bash
-poetry env use [path to python 3.12.3, get this by running 'pyenv which python']
-poetry run python -m pip install --upgrade pip
-```
-
-Add the artifactory repo source to your poetry config:
-
-```bash
-poetry source add --priority=supplemental psu https://artifacts.developer.gov.bc.ca/artifactory/api/pypi/{repo_name}/simple
-```
-
-Add artifactory repo credentials to poetry config:
-
-```bash
-poetry config http-basic.psu <service-account-username> <service-account-password>
-```
-
-Install dependencies:
-
-In each individual workspace you must do the following
-
-```bash
-poetry install
-# we can't include gdal in poetry as we have little control over the version of gdal available on different platforms - we must match whatever version of gdal is available on the system in question.
-poetry run python -m pip install gdal==$(gdal-config --version)
-
-# Install the wps_shared package in editable mode using pip to allow changes in the wps_shared package to be reflected immediately in the api package. This is not needed in the wps_shared workspace.
-poetry run python -m pip install -e ../wps_shared
-
-# on ubuntu, you may have to install pygdal, with the correct version specified.
-poetry run python -m pip install pygdal==3.0.4.10
-```
-
-**N.B.: If `poetry env use [version]` returns an `EnvCommandError` saying something like "pyenv: python3.10: command not found", but `pyenv versions` shows that 3.12.3 is installed, you must first run `pyenv shell 3.12.3` and then re-run `poetry env use [path to python 3.12.3]`.**
 
 ##### Troubleshooting
 
 ###### psycopg2
 
-If you experience errors when installing `psycopg2` and you are using MacOS, try running
-`env LDFLAGS="-I/usr/local/opt/openssl@1.1/include -L/usr/local/opt/openssl@1.1/lib" poetry install`
-from the command line.
-
-If you're getting errors relating to `pg_config` executable not found when installing `psycopg2` it means
-you either don't have PostgreSQL installed or psycopg2 doesn't know where to find it. You can install PostgreSQL by following instructions on <https://www.postgresql.org/download/>, be sure to update your PATH if you're installing it manually.
+If you get errors about `pg_config` not being found when building `psycopg2`, it means
+`pg_config` isn't on `PATH` — see the export above (`$(brew --prefix postgresql@17)/bin`).
 
 ###### GDAL
 
-If python gdal complains about header files (likely if you've installed gdal manually), you may have to help it find them, export location before doing pip install:
+If the python gdal build complains about header files (likely if you've installed gdal
+manually rather than via brew), help it find them before running `uv sync`:
 
 ```bash
 export CPLUS_INCLUDE_PATH=/usr/include/gdal
 export C_INCLUDE_PATH=/usr/include/gdal
 ```
 
-If gdal isn't installing, and you're on a mac, getting errors like "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/cmath:321:9: error: no member named 'signbit' in the global namespace using ::signbit;" then try the following:
+If gdal isn't building on a mac with errors like "no member named 'signbit' in the global
+namespace", then:
 
-- ensure you've applied most recent OS updates.
-- ensure XCode is updated.
-- wipe your existing virtual environment
+- ensure you've applied the most recent OS updates
+- ensure XCode is updated
+- wipe your existing virtual environment (`backend/.venv`) and re-run `uv sync`
 
 #### Local machine, running Linux
 
 ##### Ubuntu
 
-Install system dependancies:
+The production base image (`openshift/wps-api-base/docker/Dockerfile`) is the
+authoritative list of system dependencies. On a comparable Ubuntu host:
 
 ```bash
-sudo apt install python3 python3-pip
-sudo apt install python-is-python3
-# install osgeo/gdal
-sudo apt install libgdal-dev
-# isntall libudunits2-dev as required dependency of cffdrs
+sudo apt install python3 python3-pip python3-dev python-is-python3
+# geospatial / build dependencies
+sudo apt install libgdal-dev libproj-dev libgeos-dev libsqlite3-dev libxml2-dev cmake build-essential
+# required by cffdrs
 sudo apt install libudunits2-dev
-# install R and pre-req for cffdrs
-sudo apt install r-base
-R
-install.packages('rgdal')
-install.packages('cffdrs')
-# install the jdk (for running tests agains redapp)
+# postgres client headers (for psycopg2)
+sudo apt install libpq-dev
+# the jdk (for running tests against RedAPP)
 sudo apt install default-jdk
 ```
+
+Install `uv` (<https://docs.astral.sh/uv/>) and run `uv sync --all-extras` from
+`backend/`. The python `gdal` package must match the system libgdal version.
 
 ##### Fedora
 
@@ -188,78 +188,54 @@ Install system dependencies:
 sudo dnf install unixODBC-devel
 ```
 
-#### R modules for cffdrs (MacOS Big Sur)
-
-Make sure [GDAL is installed](#gdal-from-brew) on your system
-
-```bash
-- brew install r
-- brew install udunits
-- brew install proj
-```
-
-Within an R interpreter instance:
-
-```R
-- install.packages(c("rgdal","sf", "units"),,"https://mac.R-project.org")
-- install.packages('cffdrs')
-```
-
 ### Executing program
 
-See [Makefile](Makefile) for examples of running the API in docker.
+See the [Makefile](../Makefile) for docker examples and [backend/README.md](../backend/README.md)
+for running the API natively.
 
-e.g.:
-
-```bash
-make init
-```
-
-will execute `poetry install`, which is required before executing the program locally for the first time.
+Install dependencies (required before running the program for the first time):
 
 ```bash
-make docker-run
+cd backend && uv sync --all-extras
 ```
 
-will execute:
+Run the full stack in docker:
 
 ```bash
-docker compose up
+make docker-run        # docker compose up
 ```
 
-#### Local machine, running mac os
-
-See [Makefile](Makefile) for examples or running the API on your local machine.
-
-e.g.:
+Run the API natively (from `backend/packages/wps-api`):
 
 ```bash
-make run
+uv run --package wps-api python -m app.main
 ```
 
-will execute:
-
-```bash
-poetry run ruff .
-cd app; \
-poetry run uvicorn main:app --reload --port 8080;
-```
-
-To shell into the Docker container for the database, execute `make docker-shell-db`.
+To shell into the running docker containers: `make docker-shell-api` / `make docker-shell-web`.
 
 ### Running the database locally
 
 #### In Docker
 
-Executing `make docker-build-dev` followed by `make docker-run-dev` will build and run the Docker container needed to run the application locally. Running the dev container will also spin up a local Postgres service and will create a local copy of the wps database with the necessary schemas.
+```bash
+make docker-db         # docker compose up db
+```
+
+Runs a local Postgres/PostGIS container and creates the `wps` database.
 
 #### Natively
 
-As of Nov 2024 the version of postgis installed with brew doesn't work with postgresql@16. postgis is specifically
-linked to the original postgres cask (aka postgres@14). If you choose to use postgresql@16 installed via brew, you
-will need to compile postgis yourself. The alternative is to use [Postgres.app](https://postgresapp.com/).
+We use Homebrew `postgresql@17` + `postgis` locally. (This became viable once the
+project's GDAL pin moved to current homebrew-core — brew `postgis` links the same
+libgdal the venv uses, so there is no longer a conflict. The older Postgres.app
+workaround is no longer required.)
 
-After installing Postgres.app, run the following commands in a terminal (taken from the mac.sh setup script):
+```bash
+brew install postgresql@17 postgis
+brew services start postgresql@17
+```
+
+Then create the database, extension and users (these match the `.env` defaults):
 
 ```bash
 psql -d postgres -c "create database wps;"
@@ -270,67 +246,31 @@ CREATE USER wpsread;
 ALTER USER wps WITH LOGIN;
 ALTER USER wpsread WITH LOGIN;
 ALTER USER wps WITH SUPERUSER;
+ALTER USER wps WITH PASSWORD 'wps';
 grant connect on database wps to wpsread; grant usage on schema public to wpsread; grant select on all tables in schema public to wpsread;
 "
 ```
 
-If you have chosen to `brew install postgresql@16` and compile `postgis` locally, follow the instructions below:
-
-If you're running Postgresql natively for the first time:
+`\dx` in `psql -d wps` should list `postgis`. Then run the migrations:
 
 ```bash
-brew services start postgresql
-brew services list
+cd backend/packages/wps-api && uv run --package wps-api alembic upgrade head
 ```
 
-should show that the "postgresql" service is running.
+The CI pipeline enforces migrations and tests with `uv run pytest` (see
+`.github/workflows/integration.yml`); run `cd backend && uv run pytest` locally to match.
 
-```bash
-psql -d postgres
-```
+##### Postgres.app (alternative)
 
-will shell you into your local postgres server.
-
-```psql
-create user wps with password "wps";
-```
-
-(or your desired username/password combo. Make sure to update these in your .env file).
-If successful, this command will output `CREATE ROLE`.
-
-```psql
-create database wps with owner wps;
-```
-
-If successful, this command will output `CREATE DATABASE`.
-
-`\l` should show "wps" in the list of databases.
-
-```psql
-\c wps
-\dx
-```
-
-will show the list of extensions, and "postgis" should be one of them. If it isn't, run
-
-```psql
-create extension postgis;
-```
-
-If successful, this command will output `CREATE EXTENSION`. Re-run `\dx` to confirm the postgis extension has now been added.
-
-From a poetry shell, run
-
-```bash
-PYTHONPATH=. alembic upgrade head
-```
-
-Or enforce by running [scripts/test.sh](scripts/test.sh) as part of your ci/cd pipeline.
+If you'd rather not use Homebrew postgres, [Postgres.app](https://postgresapp.com/)
+bundles Postgres + PostGIS. Create the database/users with the same SQL as above. Note
+that Postgres.app bundles its own older `gdal-config`; if you add its `bin` to `PATH`,
+**append** it rather than prepend, so it doesn't shadow Homebrew's gdal during `uv sync`.
 
 #### ModuleNotFoundError: No module named 'pkg_resources'
 
 ```bash
-poetry run python -m pip install --upgrade setuptools
+cd backend && uv pip install --upgrade setuptools
 ```
 
 ## New Workstation Setup
@@ -340,7 +280,7 @@ poetry run python -m pip install --upgrade setuptools
 The following is a list of required software applications and packages. Some of these can be installed automatically using the `setup/mac.sh` script.
 
 - VS Code (technically there are other options, but this is arguably the best)
-  - using the "Python: select interpreter" command within VS Code, select the `pyenv` Python installation
+  - using the "Python: Select Interpreter" command within VS Code, select `backend/.venv/bin/python`
 - Git CLI
 - GitHub CLI
 - Openshift CLI
@@ -349,7 +289,6 @@ The following is a list of required software applications and packages. Some of 
 
 ### Optional but Recommended Software
 
-- [Fig (for Mac)](https://fig.io/)
 - [Oh My Zsh](https://ohmyz.sh/)
 - [Zenhub extension for GitHub](https://www.zenhub.com/extension)
 
@@ -361,9 +300,7 @@ The extensions listed here are shown exactly as they appear in the VS Code Exten
 - Dev Containers
 - Docker
 - ESLint
-- Fig (not available through the Extensions Marketplace within VS Code, but when Fig is installed via CLI, the Fig extension will automatically be available in VS Code)
 - GitLens - Git supercharged
-- Isort
 - Jupyter
 - Jupyter Cell Tags
 - Jupyter Keymap
@@ -378,8 +315,8 @@ The extensions listed here are shown exactly as they appear in the VS Code Exten
 - Prettier - Code formatter
 - Pylance
 - Python
-- R
 - Rainbow Brackets
 - Remote - SSH
+- Ruff
 - SonarLint
 - VS Code Counter

--- a/openshift/hourlies-prune/README.md
+++ b/openshift/hourlies-prune/README.md
@@ -13,7 +13,7 @@ oc -n e1e498-tools process -f build.yaml | oc -n e1e498-tools apply -f -
 ### Apply template using a specified branch and version
 
 ```bash
-oc -n e1e498-tools process -p VERSION=some-date -p GIT_BRANCH=my-branch process -f build.yaml | oc -n e1e498-tools apply -f -
+oc -n e1e498-tools process -p VERSION=some-date -p GIT_BRANCH=my-branch -f build.yaml | oc -n e1e498-tools apply -f -
 ```
 
 ### Kick off the build

--- a/openshift/s3-backup/README.md
+++ b/openshift/s3-backup/README.md
@@ -15,7 +15,7 @@ oc -n e1e498-tools process -f build.yaml | oc -n e1e498-tools apply -f -
 ### Apply template using a specified branch and version
 
 ```bash
-oc -n e1e498-tools process -p VERSION=some-date -p GIT_BRANCH=my-branch process -f build.yaml | oc -n e1e498-tools apply -f -
+oc -n e1e498-tools process -p VERSION=some-date -p GIT_BRANCH=my-branch -f build.yaml | oc -n e1e498-tools apply -f -
 ```
 
 ### Kick off the build

--- a/openshift/wps-api-base/docker/Dockerfile
+++ b/openshift/wps-api-base/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-full-3.12.3
+FROM ghcr.io/osgeo/gdal:ubuntu-full-3.13.1
 # in order to make the image public on GHCR, we need to add this label
 LABEL org.opencontainers.image.source="https://github.com/bcgov/wps"
 

--- a/openshift/wps-jobs-base/README.md
+++ b/openshift/wps-jobs-base/README.md
@@ -9,7 +9,7 @@ The Docker image and template in this directory are used to create the base imag
 Update the build config with your GIT_BRANCH and VERSION.
 
 ```bash
-oc -n e1e498-tools process -p GIT_BRANCH=my-branch process -p VERSION=dd-mm-yyyy -f ./openshift/build.yaml | oc -n e1e498-tools apply -f -
+oc -n e1e498-tools process -p GIT_BRANCH=my-branch -p VERSION=dd-mm-yyyy -f ./openshift/build.yaml | oc -n e1e498-tools apply -f -
 ```
 
 Kick off a build

--- a/openshift/wps-jobs-base/docker/Dockerfile
+++ b/openshift/wps-jobs-base/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.12.3
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.13.1
 # in order to make the image public on GHCR, we need to add this label
 LABEL org.opencontainers.image.source="https://github.com/bcgov/wps"
 

--- a/setup/mac.sh
+++ b/setup/mac.sh
@@ -35,11 +35,14 @@ brew install gh
 # The python gdal binding (pinned in backend/packages/*/pyproject.toml) builds from source
 # against the installed libgdal, which must be >= the pinned version. The pin tracks the
 # ghcr.io/osgeo/gdal base image tag (see openshift/wps-api-base/docker/Dockerfile); keep
-# homebrew gdal, the base image tag, and the pyproject pins in step when bumping.
+# the base image tag and the pyproject pins in step when bumping.
+#
+# We intentionally do NOT `brew pin gdal`. Pinning the formula doesn't pin its
+# dependencies, so a later `brew upgrade` of poppler/proj/etc. can move a dylib soname and
+# break gdal anyway. Instead we let homebrew keep gdal consistent with its deps; if gdal
+# drifts ahead of the pinned version the `uv sync` / gdal build fails loudly, which is the
+# signal to bump the pyproject pins + base image (and re-run `uv sync`).
 brew install gdal
-# Prevent `brew upgrade` from moving the libgdal soname out from under backend/.venv.
-# When the project bumps its gdal pin: brew unpin gdal && brew upgrade gdal && uv sync.
-brew list --pinned | grep -qx gdal || brew pin gdal
 
 ### ecCodes (for weather model unit tests)
 brew install eccodes

--- a/setup/mac.sh
+++ b/setup/mac.sh
@@ -11,9 +11,9 @@ if ! command -v brew >/dev/null 2>&1; then
 fi
 # Ensure brew is on PATH for the rest of this script (it isn't, in the shell that
 # just bootstrapped it on a fresh machine).
-if [ -x /opt/homebrew/bin/brew ]; then
+if [[ -x /opt/homebrew/bin/brew ]]; then
   eval "$(/opt/homebrew/bin/brew shellenv)"
-elif [ -x /usr/local/bin/brew ]; then
+elif [[ -x /usr/local/bin/brew ]]; then
   eval "$(/usr/local/bin/brew shellenv)"
 fi
 # Full path to brew (works on Apple Silicon /opt/homebrew and Intel /usr/local); used
@@ -56,7 +56,7 @@ else
   (
     set -e
     # The macOS build is x86_64 -- install Rosetta 2 so it runs on Apple Silicon.
-    if [ "$(uname -m)" = "arm64" ]; then
+    if [[ "$(uname -m)" == "arm64" ]]; then
       sudo softwareupdate --install-rosetta --agree-to-license
     fi
     curl -L -o /tmp/wkhtmltox.pkg "$WKHTMLTOPDF_PKG_URL"

--- a/setup/mac.sh
+++ b/setup/mac.sh
@@ -1,55 +1,144 @@
 #!/usr/bin/env bash
 
-## Run this to install all project dependencies on a mac via brew
+## Run this to install all project dependencies on a mac via brew.
+## Safe to re-run: every step is idempotent.
+
+set -euo pipefail
 
 ### homebrew
-curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
+if ! command -v brew >/dev/null 2>&1; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+# Ensure brew is on PATH for the rest of this script (it isn't, in the shell that
+# just bootstrapped it on a fresh machine).
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+# Full path to brew (works on Apple Silicon /opt/homebrew and Intel /usr/local); used
+# in the shell-config instructions printed at the end.
+BREW_EXE="$(command -v brew)"
 
-### openjdk
+### openjdk (for jnius/RedAPP unit tests)
 brew install openjdk
-
-### Symlink it for mac
-sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+# Point JAVA_HOME at the brew openjdk (no sudo symlink needed). pyjnius/RedAPP tests
+# read this. Exported for this script run only; the instructions printed at the end
+# tell the user how to persist it in their preferred shell.
+JAVA_HOME_VAL="$(brew --prefix openjdk)/libexec/openjdk.jdk/Contents/Home"
+export JAVA_HOME="$JAVA_HOME_VAL"
 
 ### gh api
 brew install gh
 
 ### gdal
-brew tap-new $(whoami)/local-gdal
-# Grabs 3.12.3 formula -- https://github.com/Homebrew/homebrew-core/commits/master/Formula/g/gdal.rb
-curl -s https://raw.githubusercontent.com/Homebrew/homebrew-core/2761c8e5f5547753c8bebc39e95968006f5deb69/Formula/g/gdal.rb > $(brew --repository)/Library/Taps/$(whoami)/homebrew-local-gdal/Formula/gdal.rb
-brew install $(whoami)/local-gdal/gdal # if you have gdal/postgis already installed you'll have to uninstall them both, see MANUAL.md for more details
+# The python gdal binding (pinned in backend/packages/*/pyproject.toml) builds from source
+# against the installed libgdal, which must be >= the pinned version. The pin tracks the
+# ghcr.io/osgeo/gdal base image tag (see openshift/wps-api-base/docker/Dockerfile); keep
+# homebrew gdal, the base image tag, and the pyproject pins in step when bumping.
+brew install gdal
+# Prevent `brew upgrade` from moving the libgdal soname out from under backend/.venv.
+# When the project bumps its gdal pin: brew unpin gdal && brew upgrade gdal && uv sync.
+brew list --pinned | grep -qx gdal || brew pin gdal
 
-### For generated HFI Calculator PDFs
-brew install --cask wkhtmltopdf
+### ecCodes (for weather model unit tests)
+brew install eccodes
 
-### pyenv
+### wkhtmltopdf (for generating HFI Calculator PDFs)
+# wkhtmltopdf is discontinued and the Homebrew cask is gone. The only macOS package is
+# the older 0.12.6-2 x86_64 ("cocoa") build, so on Apple Silicon it needs Rosetta 2.
+# Installing the .pkg requires sudo. This is optional -- only HFI PDF generation needs
+# it -- so failures here are non-fatal and won't abort the rest of setup.
+WKHTMLTOPDF_PKG_URL="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-2/wkhtmltox-0.12.6-2.macos-cocoa.pkg"
+if command -v wkhtmltopdf >/dev/null 2>&1; then
+  echo "wkhtmltopdf already installed; skipping."
+else
+  (
+    set -e
+    # The macOS build is x86_64 -- install Rosetta 2 so it runs on Apple Silicon.
+    if [ "$(uname -m)" = "arm64" ]; then
+      sudo softwareupdate --install-rosetta --agree-to-license
+    fi
+    curl -L -o /tmp/wkhtmltox.pkg "$WKHTMLTOPDF_PKG_URL"
+    sudo installer -pkg /tmp/wkhtmltox.pkg -target /
+    rm -f /tmp/wkhtmltox.pkg
+  ) || echo "WARNING: wkhtmltopdf install failed (optional; only needed for HFI PDF generation). Continuing."
+fi
+
+### pyenv + python
 brew install pyenv
-pyenv install 3.12.3
+pyenv install -s 3.12.3
 pyenv global 3.12.3
 
 ### uv
 brew install uv
 
-### postgres - Nov 2024 - Commenting out the postgres setup. See MANUAL.md for reasons and manual postgres setup.
-# echo "installing and configuring postgres"
-# brew install postgresql
-# brew services start postgresql
-# brew install postgis
-# psql -d postgres -c "create database wps;"
-# psql -d wps -c "create extension postgis;"
-# psql -d wps -c "
-# CREATE USER wps;
-# CREATE USER wpsread;
-# ALTER USER wps WITH LOGIN;
-# ALTER USER wpsread WITH LOGIN;
-# ALTER USER wps WITH SUPERUSER;
-# grant connect on database wps to wpsread; grant usage on schema public to wpsread; grant select on all tables in schema public to wpsread;
-# "
-# echo "finished installing and configuration postgres, run migrations in poetry shell"
+### postgres + postgis
+# Homebrew's postgis depends on the current homebrew-core gdal, which now matches the
+# project's pinned gdal (see the gdal note above), so brew postgis no longer collides
+# with it -- the Nov 2024 reason for avoiding brew postgres is resolved.
+# postgis ships bottles for postgresql@17 and @18; we use @17.
+echo "installing and configuring postgres"
+brew install postgresql@17 postgis
+brew services start postgresql@17
+# postgresql@17 is keg-only; expose its client tools (psql, pg_config) on PATH.
+# pg_config is required for the psycopg2 source build during `uv sync`. Exported for
+# this script run only; the instructions printed at the end tell the user how to
+# persist it in their preferred shell.
+PG_BIN="$(brew --prefix postgresql@17)/bin"
+export PATH="$PG_BIN:$PATH"
+# wait for the server to accept connections before creating the database
+for _ in $(seq 1 15); do
+  if pg_isready -q; then break; fi
+  sleep 1
+done
+# create the wps database, extension and users (each step idempotent)
+psql -d postgres -tc "SELECT 1 FROM pg_database WHERE datname='wps'" | grep -q 1 \
+  || psql -d postgres -c "create database wps;"
+psql -d wps -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+psql -d wps -tc "SELECT 1 FROM pg_roles WHERE rolname='wps'" | grep -q 1 \
+  || psql -d wps -c "CREATE USER wps;"
+psql -d wps -tc "SELECT 1 FROM pg_roles WHERE rolname='wpsread'" | grep -q 1 \
+  || psql -d wps -c "CREATE USER wpsread;"
+psql -d wps -c "
+ALTER USER wps WITH LOGIN;
+ALTER USER wpsread WITH LOGIN;
+ALTER USER wps WITH SUPERUSER;
+ALTER USER wps WITH PASSWORD 'wps';
+grant connect on database wps to wpsread; grant usage on schema public to wpsread; grant select on all tables in schema public to wpsread;
+"
+echo "finished installing and configuring postgres; run migrations with: (cd backend/packages/wps-api && uv run --package wps-api alembic upgrade head)"
 
 ### redis
 brew install redis
 brew services start redis
 
 echo "finished installing all local machine dependencies"
+
+### Shell configuration
+# The variables above were exported for this script run only. Print instructions so
+# the user can persist them in whatever shell they use (we don't edit profiles for them).
+cat <<EOF
+
+============================================================
+ADD THESE TO YOUR SHELL PROFILE
+============================================================
+These were set for this script run only. Add the lines for
+your shell so new terminals have:
+  - brew on PATH
+  - JAVA_HOME (for pyjnius/RedAPP tests)
+  - postgresql@17 client tools (psql, pg_config -- 'uv sync')
+
+bash / zsh  (e.g. ~/.zprofile, ~/.bash_profile, ~/.zshrc):
+
+  eval "\$($BREW_EXE shellenv)"
+  export JAVA_HOME="$JAVA_HOME_VAL"
+  export PATH="$PG_BIN:\$PATH"
+
+fish  (~/.config/fish/config.fish):
+
+  $BREW_EXE shellenv fish | source
+  set -gx JAVA_HOME "$JAVA_HOME_VAL"
+  fish_add_path "$PG_BIN"
+============================================================
+EOF

--- a/setup/vsc-extensions-install.sh
+++ b/setup/vsc-extensions-install.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+if ! command -v code >/dev/null 2>&1; then
+  echo "error: the 'code' CLI is not on your PATH." >&2
+  echo "In VS Code: Cmd+Shift+P -> \"Shell Command: Install 'code' command in PATH\", then re-run this script." >&2
+  echo "Or for a one-off run:" >&2
+  echo "  export PATH=\"/Applications/Visual Studio Code.app/Contents/Resources/app/bin:\$PATH\"" >&2
+  exit 1
+fi
+
 code --install-extension alexkrechik.cucumberautocomplete
 code --install-extension charliermarsh.ruff
 code --install-extension dbaeumer.vscode-eslint


### PR DESCRIPTION
  Bumps GDAL from `3.12.3` → `3.13.1` so the project tracks current `homebrew-core` (which removes
  the need for the custom pinned-tap workaround on macOS and unblocks using Homebrew
  Postgres/PostGIS locally), then overhauls `setup/mac.sh` and the setup docs to match, and adds an
  automated e2e check for the setup script.

  ### What changed

  **GDAL bump (the headline)**
  - `gdal==3.12.3` → `gdal==3.13.1` in `wps-api`, `wps-shared`, `wps-jobs` `pyproject.toml`s;
  `uv.lock` regenerated (`gdal` is the only resolution change).
  - Base image tags bumped to `ghcr.io/osgeo/gdal:ubuntu-{full,small}-3.13.1` in
  `openshift/wps-api-base`, `openshift/wps-jobs-base`, and
  `backend/packages/wps-weather/Dockerfile`.

  **`setup/mac.sh` overhaul**
  - Fixes the Homebrew bootstrap (it previously printed the installer instead of executing it) and
  puts `brew` on `PATH` for the rest of the run.
  - Adds `set -euo pipefail` and makes every step idempotent (safe to re-run).
  - GDAL: plain `brew install gdal` + `brew pin gdal`
  - Postgres: installs `postgresql@17` + `postgis` and provisions the `wps` DB/users (viable now
  that GDAL matches core).
  - Adds `eccodes` (required by weather-model tests); installs `wkhtmltopdf` from the packaging
  releases with Rosetta 2 on Apple Silicon (optional, non-fatal).
  - Java via `JAVA_HOME` instead of an interactive `sudo` symlink.

  **Documentation**
  - Root `README.md`: native setup is the recommended/supported path; Docker Compose and the dev
  container are marked **currently unsupported**; fixes broken env-file/dev-container paths; fills
  the empty Dependencies section.
  - `backend/README.md` / `backend/packages/wps-api/README.md`: correct the package list, env-file
  location, Docker-build cwd; replace obsolete poetry/`rpy2` troubleshooting with current notes.
  - `docs/MANUAL_SETUP.md`: rewritten from poetry-era to `uv` (removes the R/`cffdrs` section,
  fixes broken links/paths, invalid SQL, and nonexistent `Makefile` targets).
  - `.env.example`: corrected `CLASSPATH` path and docker-vs-native DB host guidance.

  **CI**
  - `.github/workflows/setup_mac_test.yml`: runs `setup/mac.sh` end-to-end on a clean arm64
  `macos-15` runner, then smoke-tests the result (`uv sync`, `from osgeo import gdal`). Triggers: manual and a weekly cron
  to catch external drift.

  ## Testing

  - `setup/mac.sh`: `shellcheck` clean; full stubbed dry-run passes under `set -euo pipefail` (exit
  `0`); idempotent DB guards verified against a live cluster.
  - GDAL `3.13.1` verified locally: `uv sync --all-extras` clean, `from osgeo import gdal` →
  `3.13.1`, full test run identical to the `3.12.3` baseline (no version-sensitive regressions).
# Test Links:
[Landing Page](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5513-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
