### PR TITLE
Bug: SFMS Station/Dailies

### DIFF
--- a/backend/packages/wps-wf1/src/wps_wf1/parsers.py
+++ b/backend/packages/wps-wf1/src/wps_wf1/parsers.py
@@ -41,6 +41,17 @@ class WF1RecordTypeEnum(enum.Enum):
     MANUAL = "MANUAL"
 
 
+SFMS_SITE_TYPE_IDS = (
+    "HUB_STN",
+    "WXSTN_GOES",
+    "WXSTN_MB",
+    "WXSTN_TEL",
+    "WXSTN_CELL",
+    "WXSTN_UHF",
+    "EXTERNAL",
+)
+
+
 def construct_zone_code(station: any):
     """Constructs the 2-character zone code for a weather station, using the station's
     zone.alias integer value, prefixed by the fire centre-to-letter mapping.
@@ -339,11 +350,8 @@ async def dailies_list_mapper(
     return wf1_dailies
 
 
-def sfms_daily_actuals_mapper(
-    raw_dailies: List[dict], stations: List[WFWXWeatherStation]
-) -> List[SFMSDailyActual]:
+def sfms_daily_actuals_mapper(raw_dailies: List[dict]) -> List[SFMSDailyActual]:
     """Maps raw dailies to list of SFMSDailyActual objects"""
-    station_lookup = {station.code: station for station in stations}
     sfms_daily_actuals: List[SFMSDailyActual] = []
     for raw_daily in raw_dailies:
         station_data = raw_daily.get("stationData")
@@ -353,28 +361,18 @@ def sfms_daily_actuals_mapper(
         if (
             is_station_valid(station_data)
             and station_status_id == "ACTIVE"
-            # Site types match those used to define APP_WF1_WEATHER.STATION_BC_ACTIVE_REPORTING_VW,
-            # the station source for legacy SFMS.
-            and site_type_id
-            in (
-                "HUB_STN",
-                "WXSTN_GOES",
-                "WXSTN_MB",
-                "WXSTN_TEL",
-                "WXSTN_CELL",
-                "WXSTN_UHF",
-                "EXTERNAL",
-            )
+            # site types match APP_WF1_WEATHER.STATION_BC_ACTIVE_REPORTING_VW,
+            # the legacy SFMS station source.
+            and site_type_id in SFMS_SITE_TYPE_IDS
             and raw_daily.get("recordType").get("id") == WF1RecordTypeEnum.ACTUAL.value
         ):
             station_code = station_data.get("stationCode")
-            station = station_lookup[station_code]
             sfms_daily_actuals.append(
                 SFMSDailyActual(
                     code=station_code,
-                    lat=station.lat,
-                    lon=station.long,
-                    elevation=station.elevation,
+                    lat=station_data.get("latitude"),
+                    lon=station_data.get("longitude"),
+                    elevation=station_data.get("elevation"),
                     temperature=raw_daily.get("temperature"),
                     dewpoint=raw_daily.get("dewPoint"),
                     relative_humidity=raw_daily.get("relativeHumidity"),

--- a/backend/packages/wps-wf1/src/wps_wf1/tests/test_parsers.py
+++ b/backend/packages/wps-wf1/src/wps_wf1/tests/test_parsers.py
@@ -4,20 +4,7 @@ from datetime import datetime, timezone
 import pytest
 from wps_shared.db.models.observations import HourlyActual
 from wps_shared.schemas.sfms import SFMSDailyActual
-from wps_shared.schemas.stations import WFWXWeatherStation
 from wps_wf1.parsers import parse_hourly_actual, sfms_daily_actuals_mapper
-
-
-def _make_station(code, lat=49.0, lon=-123.0, elevation=100):
-    return WFWXWeatherStation(
-        wfwx_id=f"wfwx-{code}",
-        code=code,
-        name=f"S{code}",
-        latitude=lat,
-        longitude=lon,
-        elevation=elevation,
-        zone_code=None,
-    )
 
 
 def _make_raw_daily(
@@ -26,6 +13,7 @@ def _make_raw_daily(
     status="ACTIVE",
     lat=49.0,
     lon=-123.0,
+    elevation=100,
     site_type="WXSTN_TEL",
     **weather_fields,
 ):
@@ -44,6 +32,7 @@ def _make_raw_daily(
             "siteType": {"id": site_type},
             "latitude": lat,
             "longitude": lon,
+            "elevation": elevation,
         },
         "recordType": {"id": record_type},
         **defaults,
@@ -124,9 +113,9 @@ class TestParseHourlyActual:
 
 class TestSfmsDailyActualsMapper:
     def test_maps_actual_with_all_weather_fields(self):
-        station = _make_station(100, lat=49.0, lon=-123.0, elevation=150)
         raw = _make_raw_daily(
             100,
+            elevation=150,
             temperature=15.0,
             relativeHumidity=50.0,
             precipitation=2.5,
@@ -137,7 +126,7 @@ class TestSfmsDailyActualsMapper:
             droughtCode=200.0,
         )
 
-        result = sfms_daily_actuals_mapper([raw], [station])
+        result = sfms_daily_actuals_mapper([raw])
 
         assert len(result) == 1
         assert result[0] == SFMSDailyActual(
@@ -156,10 +145,9 @@ class TestSfmsDailyActualsMapper:
         )
 
     def test_maps_none_weather_fields(self):
-        station = _make_station(100)
         raw = _make_raw_daily(100)
 
-        result = sfms_daily_actuals_mapper([raw], [station])
+        result = sfms_daily_actuals_mapper([raw])
 
         assert len(result) == 1
         actual = result[0]
@@ -173,61 +161,49 @@ class TestSfmsDailyActualsMapper:
         assert actual.dc is None
 
     def test_filters_forecast_record_type(self):
-        station = _make_station(100)
         raw = _make_raw_daily(100, record_type="FORECAST", temperature=20.0)
 
-        assert sfms_daily_actuals_mapper([raw], [station]) == []
+        assert sfms_daily_actuals_mapper([raw]) == []
 
     def test_filters_inactive_station(self):
-        station = _make_station(100)
         raw = _make_raw_daily(100, status="INACTIVE", temperature=20.0)
 
-        assert sfms_daily_actuals_mapper([raw], [station]) == []
+        assert sfms_daily_actuals_mapper([raw]) == []
 
     @pytest.mark.parametrize("status", ["TEST", "PROJECT"])
     def test_filters_non_active_station(self, status):
-        station = _make_station(100)
         raw = _make_raw_daily(100, status=status, temperature=20.0)
 
-        assert sfms_daily_actuals_mapper([raw], [station]) == []
+        assert sfms_daily_actuals_mapper([raw]) == []
 
     def test_filters_invalid_site_type(self):
-        station = _make_station(100)
         raw = _make_raw_daily(100, site_type="UNKNOWN_TYPE", temperature=20.0)
 
-        assert sfms_daily_actuals_mapper([raw], [station]) == []
+        assert sfms_daily_actuals_mapper([raw]) == []
 
     def test_filters_missing_site_type(self):
-        station = _make_station(100)
         raw = _make_raw_daily(100, temperature=20.0)
         del raw["stationData"]["siteType"]
 
-        assert sfms_daily_actuals_mapper([raw], [station]) == []
+        assert sfms_daily_actuals_mapper([raw]) == []
 
     def test_filters_station_with_null_coordinates(self):
-        station = _make_station(100)
         raw = _make_raw_daily(100, lat=None, lon=None, temperature=20.0)
 
-        assert sfms_daily_actuals_mapper([raw], [station]) == []
+        assert sfms_daily_actuals_mapper([raw]) == []
 
     def test_empty_raw_dailies(self):
-        station = _make_station(100)
-
-        assert sfms_daily_actuals_mapper([], [station]) == []
+        assert sfms_daily_actuals_mapper([]) == []
 
     def test_multiple_stations_mixed_records(self):
-        stations = [
-            _make_station(100, lat=49.0, lon=-123.0, elevation=100),
-            _make_station(200, lat=50.0, lon=-124.0, elevation=300),
-        ]
         raw_dailies = [
             _make_raw_daily(100, temperature=10.0),
             _make_raw_daily(200, record_type="FORECAST", temperature=20.0),
-            _make_raw_daily(200, temperature=25.0),
+            _make_raw_daily(200, lat=50.0, lon=-124.0, elevation=300, temperature=25.0),
             _make_raw_daily(100, status="INACTIVE", temperature=30.0),
         ]
 
-        result = sfms_daily_actuals_mapper(raw_dailies, stations)
+        result = sfms_daily_actuals_mapper(raw_dailies)
 
         assert len(result) == 2
         assert result[0].code == 100
@@ -235,13 +211,11 @@ class TestSfmsDailyActualsMapper:
         assert result[1].code == 200
         assert result[1].temperature == pytest.approx(25.0)
 
-    def test_uses_station_coordinates_not_daily(self):
-        """Station lat/lon/elevation come from the station lookup, not the raw daily."""
-        station = _make_station(100, lat=51.0, lon=-125.0, elevation=999)
-        raw = _make_raw_daily(100, lat=49.0, lon=-123.0, temperature=5.0)
+    def test_uses_daily_station_metadata(self):
+        raw = _make_raw_daily(100, lat=49.0, lon=-123.0, elevation=150, temperature=5.0)
 
-        result = sfms_daily_actuals_mapper([raw], [station])
+        result = sfms_daily_actuals_mapper([raw])
 
-        assert result[0].lat == pytest.approx(51.0)
-        assert result[0].lon == pytest.approx(-125.0)
-        assert result[0].elevation == 999
+        assert result[0].lat == pytest.approx(49.0)
+        assert result[0].lon == pytest.approx(-123.0)
+        assert result[0].elevation == 150

--- a/backend/packages/wps-wf1/src/wps_wf1/tests/test_wfwx_api.py
+++ b/backend/packages/wps-wf1/src/wps_wf1/tests/test_wfwx_api.py
@@ -255,8 +255,8 @@ async def test_get_stations_by_codes_filters_and_parses(monkeypatch, wfwx_api):
     ]
 
     # Make the client generator yield our stations
-    wfwx_api.wfwx_client.fetch_paged_response_generator = (
-        lambda headers, qb, key, use_cache, ttl: async_gen(raw_stations)
+    wfwx_api.wfwx_client.fetch_paged_response_generator = lambda headers, qb, key, use_cache, ttl: (
+        async_gen(raw_stations)
     )
 
     # is_station_valid: True for code 100 and 300, False for 200
@@ -280,8 +280,8 @@ async def test_get_stations_by_codes_filters_and_parses(monkeypatch, wfwx_api):
 async def test_get_station_data_uses_mapper_and_headers(monkeypatch, wfwx_api):
     # Make generator yield some station items
     items = [{"stationCode": 1}, {"stationCode": 2}]
-    wfwx_api.wfwx_client.fetch_paged_response_generator = (
-        lambda headers, qb, key, use_cache, ttl: async_gen(items)
+    wfwx_api.wfwx_client.fetch_paged_response_generator = lambda headers, qb, key, use_cache, ttl: (
+        async_gen(items)
     )
 
     # Mapper that collects items from async generator
@@ -315,8 +315,8 @@ async def test_get_detailed_geojson_stations_filters_inactive(monkeypatch, wfwx_
             "latitude": 49.2,
         },
     ]
-    wfwx_api.wfwx_client.fetch_paged_response_generator = (
-        lambda headers, qb, key, use_cache, ttl: async_gen(raw_stations)
+    wfwx_api.wfwx_client.fetch_paged_response_generator = lambda headers, qb, key, use_cache, ttl: (
+        async_gen(raw_stations)
     )
 
     import wps_wf1.util as util_mod
@@ -473,8 +473,8 @@ async def test_get_hourly_for_station_filters_actual(monkeypatch, wfwx_api):
 @pytest.mark.anyio
 async def test_get_hourly_readings_runs_tasks(monkeypatch, wfwx_api):
     raw_stations = [{"stationCode": 101}, {"stationCode": 202}]
-    wfwx_api.wfwx_client.fetch_paged_response_generator = (
-        lambda headers, qb, key, use_cache, ttl: async_gen(raw_stations)
+    wfwx_api.wfwx_client.fetch_paged_response_generator = lambda headers, qb, key, use_cache, ttl: (
+        async_gen(raw_stations)
     )
 
     # stub get_hourly_for_station to return sentinel objects
@@ -640,8 +640,8 @@ async def test_get_wfwx_stations_from_station_codes_specific(monkeypatch, wfwx_a
 @pytest.mark.anyio
 async def test_get_raw_dailies_in_range_generator(monkeypatch, wfwx_api):
     items = [{"a": 1}, {"b": 2}]
-    wfwx_api.wfwx_client.fetch_paged_response_generator = (
-        lambda headers, qb, key, use_cache, ttl: async_gen(items)
+    wfwx_api.wfwx_client.fetch_paged_response_generator = lambda headers, qb, key, use_cache, ttl: (
+        async_gen(items)
     )
 
     gen = await wfwx_api.get_raw_dailies_in_range_generator(
@@ -889,29 +889,19 @@ async def test_post_forecasts(wfwx_api):
 # ---------------------------
 # Helpers for get_sfms_daily_actuals_all_stations tests
 # ---------------------------
-def _setup_sfms_daily_actuals(
-    monkeypatch, wfwx_api, stations=None, raw_dailies=None, mapper_result=None
-):
+def _setup_sfms_daily_actuals(monkeypatch, wfwx_api, raw_dailies=None, mapper_result=None):
     """Common setup for get_sfms_daily_actuals_all_stations tests.
 
     Returns a dict for capturing arguments passed to mocked dependencies.
     """
     import wps_wf1.wfwx_api as api_mod
 
-    if stations is None:
-        stations = []
     if raw_dailies is None:
         raw_dailies = []
     if mapper_result is None:
         mapper_result = []
 
     captured = {}
-
-    async def fake_wfwx_station_list_mapper(raw_gen):
-        _ = [item async for item in raw_gen]
-        return stations
-
-    monkeypatch.setattr(api_mod, "wfwx_station_list_mapper", fake_wfwx_station_list_mapper)
 
     async def fake_fetch_raw_dailies(headers, time_of_interest):
         captured["headers"] = headers
@@ -920,9 +910,13 @@ def _setup_sfms_daily_actuals(
 
     wfwx_api.wfwx_client.fetch_raw_dailies_for_all_stations = fake_fetch_raw_dailies
 
-    def fake_sfms_mapper(raw, stn):
+    async def fail_get_station_data(*args, **kwargs):
+        raise AssertionError("SFMS actuals should not fetch cached station data")
+
+    wfwx_api.get_station_data = fail_get_station_data
+
+    def fake_sfms_mapper(raw):
         captured["mapper_raw_dailies"] = raw
-        captured["mapper_stations"] = stn
         return mapper_result
 
     monkeypatch.setattr(api_mod, "sfms_daily_actuals_mapper", fake_sfms_mapper)
@@ -932,29 +926,9 @@ def _setup_sfms_daily_actuals(
 
 @pytest.mark.anyio
 async def test_get_sfms_daily_actuals_all_stations(monkeypatch, wfwx_api):
-    """Verify auth header, time_of_interest, stations, and raw dailies are forwarded correctly and the mapper result is returned."""
+    """Verify auth header, time_of_interest, and raw dailies are forwarded correctly and the mapper result is returned."""
     from wps_shared.schemas.sfms import SFMSDailyActual
 
-    fake_stations = [
-        types.SimpleNamespace(
-            wfwx_id="wfwx-1",
-            code=100,
-            name="S100",
-            lat=49.0,
-            long=-123.0,
-            elevation=100,
-            zone_code=None,
-        ),
-        types.SimpleNamespace(
-            wfwx_id="wfwx-2",
-            code=200,
-            name="S200",
-            lat=50.0,
-            long=-124.0,
-            elevation=300,
-            zone_code="K1",
-        ),
-    ]
     fake_raw_dailies = [
         {"stationData": {"stationCode": 100}, "temperature": 15.0},
         {"stationData": {"stationCode": 200}, "temperature": 20.0},
@@ -968,7 +942,6 @@ async def test_get_sfms_daily_actuals_all_stations(monkeypatch, wfwx_api):
     captured = _setup_sfms_daily_actuals(
         monkeypatch,
         wfwx_api,
-        stations=fake_stations,
         raw_dailies=fake_raw_dailies,
         mapper_result=expected,
     )
@@ -979,26 +952,12 @@ async def test_get_sfms_daily_actuals_all_stations(monkeypatch, wfwx_api):
     assert captured["headers"] == {"Authorization": "Bearer token123"}
     assert captured["time_of_interest"] == toi
     assert captured["mapper_raw_dailies"] is fake_raw_dailies
-    assert captured["mapper_stations"] is fake_stations
 
 
 @pytest.mark.anyio
 async def test_get_sfms_daily_actuals_all_stations_empty_dailies(monkeypatch, wfwx_api):
     """When no raw dailies exist, an empty list is returned."""
-    fake_stations = [
-        types.SimpleNamespace(
-            wfwx_id="wfwx-1",
-            code=100,
-            name="S100",
-            lat=49.0,
-            long=-123.0,
-            elevation=100,
-            zone_code=None,
-        ),
-    ]
-    _setup_sfms_daily_actuals(
-        monkeypatch, wfwx_api, stations=fake_stations, raw_dailies=[], mapper_result=[]
-    )
+    _setup_sfms_daily_actuals(monkeypatch, wfwx_api, raw_dailies=[], mapper_result=[])
 
     result = await wfwx_api.get_sfms_daily_actuals_all_stations(datetime(2025, 7, 1))
     assert result == []

--- a/backend/packages/wps-wf1/src/wps_wf1/wfwx_api.py
+++ b/backend/packages/wps-wf1/src/wps_wf1/wfwx_api.py
@@ -316,14 +316,11 @@ class WfwxApi:
         self, time_of_interest: datetime
     ) -> List[SFMSDailyActual]:
         header = await self._get_auth_header()
-        stations: List[WFWXWeatherStation] = await self.get_station_data(
-            mapper=wfwx_station_list_mapper
-        )
-        logger.info(f"Computing SFMS actuals with {len(stations)} stations")
+        logger.info("Computing SFMS actuals")
         raw_dailies = await self.wfwx_client.fetch_raw_dailies_for_all_stations(
             header, time_of_interest
         )
-        station_dailies = sfms_daily_actuals_mapper(raw_dailies, stations)
+        station_dailies = sfms_daily_actuals_mapper(raw_dailies)
         return station_dailies
 
     async def get_hourly_actuals_all_stations(


### PR DESCRIPTION
In `sfms_daily_actuals_mapper` we were joining station data (cached from WF1 stations endpoint) to station dailies. We cache the station data for 604800s (7 days). If we get daily data from a new/updated station but that station is not in our cached stations, the daily SFMS job would crash.

Rather than handling errors like that, this PR removes the joining of station data and just uses station information from the dailies since they contain everything we need.

Fixes:
> 2026-06-16 21:20:26,807 - __main__ - INFO - Starting SFMS daily actuals for 2026-06-16
2026-06-16 21:20:26,871 - wps_shared.db.crud.fuel_layer - INFO - Queried for fuel type raster for year 2026, found: sfms/static/fuel/2025/fbp2025_v2.tif
2026-06-16 21:20:26,872 - __main__ - INFO - Using reference raster: /vsis3/lwzrin/sfms/static/fuel/2025/fbp2025_v2.tif
2026-06-16 21:20:27,366 - __main__ - ERROR - An exception occurred while running SFMS daily actuals
Traceback (most recent call last):
  File "/app/app/jobs/sfms_daily_actuals.py", line 449, in main
    loop.run_until_complete(run_sfms_daily_actuals(target_date))
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/app/app/jobs/sfms_daily_actuals.py", line 381, in run_sfms_daily_actuals
    sfms_actuals = await wfwx_api.get_sfms_daily_actuals_all_stations(datetime_to_process)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/wps-wf1/src/wps_wf1/wfwx_api.py", line 326, in get_sfms_daily_actuals_all_stations
    station_dailies = sfms_daily_actuals_mapper(raw_dailies, stations)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/packages/wps-wf1/src/wps_wf1/parsers.py", line 371, in sfms_daily_actuals_mapper
    station = station_lookup[station_code]
              ~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 352


# Test Links:
[Landing Page](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5516-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
