### PR TITLE
Dev: Fix useExhaustiveDependencies — Auth (AuthWrapper)

### DIFF
--- a/web/apps/wps-web/src/features/auth/components/AuthWrapper.tsx
+++ b/web/apps/wps-web/src/features/auth/components/AuthWrapper.tsx
@@ -27,7 +27,6 @@ const AuthWrapper = ({ children }: Props) => {
   const dispatch: AppDispatch = useDispatch()
   const { isAuthenticated, authenticating, error, email } = useSelector(selectAuthentication)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — dispatch is stable and adding it changes nothing
   useEffect(() => {
     if (TEST_AUTH || window.Playwright) {
       dispatch(testAuthenticate(true, 'test token', 'test id token'))
@@ -35,7 +34,7 @@ const AuthWrapper = ({ children }: Props) => {
       dispatch(authenticate())
       dispatch(setAxiosRequestInterceptors())
     }
-  }, [])
+  }, [dispatch])
 
   if (error) {
     return <div>{error}</div>


### PR DESCRIPTION
Remove the `biome-ignore` comment from `AuthWrapper` by adding dispatch to the effect's dependency array.

Closes #5528
# Test Links:
[Landing Page](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5531-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
