### PR TITLE
Dev: Bump frontend to Node 24

### DIFF
--- a/.github/actions/asa-go-setup/action.yml
+++ b/.github/actions/asa-go-setup/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v6
       with:
-        node-version: "20"
+        node-version: "24"
 
     - uses: actions/cache@v5
       id: asa-go-keycloak-cache

--- a/.github/workflows/asa_go_integration.yml
+++ b/.github/workflows/asa_go_integration.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     name: Test JS
     steps:
       - name: Checkout

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/web/apps/wps-web/package.json
+++ b/web/apps/wps-web/package.json
@@ -2,7 +2,7 @@
   "name": "@wps/wps-web",
   "version": "0.1.0",
   "engines": {
-    "node": ">=20",
+    "node": ">=24",
     "npm": ">=10.7.0"
   },
   "type": "module",


### PR DESCRIPTION
  Updates all remaining Node 20 references to Node 24. The Dockerfiles (`Dockerfile.web` and `web/apps/wps-web/Dockerfile`) were already on `node:24-alpine`;
  this PR brings CI and the package engine constraint in line with them.

  Changes:
  - `.github/actions/asa-go-setup/action.yml` — `setup-node` `"20"` → `"24"`
  - `.github/workflows/asa_go_integration.yml` — `matrix [20.x]` → `[24.x]`
  - `.github/workflows/integration.yml` — `matrix [20.x] → [24.x]`
  - `web/apps/wps-web/package.json` — engine constraint `>=20 → >=24`
# Test Links:
[Landing Page](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5545-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
