### PR TITLE
Dev: Fix useExhaustiveDependencies — MoreCast2

### DIFF
--- a/web/apps/wps-web/src/features/moreCast2/components/EditInputCell.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/EditInputCell.tsx
@@ -15,10 +15,9 @@ export const EditInputCell = (props: GridRenderEditCellParams) => {
   const inputRef = useRef<HTMLInputElement | null>(null)
   const dispatch: AppDispatch = useDispatch()
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — run on mount only
   useEffect(() => {
     dispatch(setInputValid(isEmpty(error)))
-  }, [])
+  }, [dispatch, error])
 
   useEffect(() => {
     if (hasFocus && inputRef.current) {

--- a/web/apps/wps-web/src/features/moreCast2/components/StationGroupDropdown.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/StationGroupDropdown.tsx
@@ -19,19 +19,18 @@ const StationGroupDropdown = ({
 }: StationGroupDropdownProps) => {
   const [onlyMine, toggleOnlyMine] = useState<boolean>(true)
   const [options, setOptions] = useState<StationGroup[]>([...stationGroupOptions])
-  const [localSelectedGroup, setLocalSelectedGroup] = useState<StationGroup | null>(
-    selectedStationGroup ? selectedStationGroup : null
-  )
+  const [localSelectedGroup, setLocalSelectedGroup] = useState<StationGroup | null>(selectedStationGroup ?? null)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps are captured via closure correctly
   useEffect(() => {
     if (onlyMine && !isUndefined(idir)) {
-      const myGroups = options.filter(option => option.group_owner_user_id.toLowerCase().includes(idir.toLowerCase()))
+      const myGroups = stationGroupOptions.filter(option =>
+        option.group_owner_user_id.toLowerCase().includes(idir.toLowerCase())
+      )
       setOptions(myGroups)
     } else {
       setOptions([...stationGroupOptions])
     }
-  }, [onlyMine])
+  }, [onlyMine, idir, stationGroupOptions])
   const changeHandler = (_: React.ChangeEvent<unknown>, value: any | null) => {
     // Solution for: https://github.com/facebook/react/issues/6222#issuecomment-1188729134
     setLocalSelectedGroup(value)

--- a/web/apps/wps-web/src/features/moreCast2/components/StationPanel.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/StationPanel.tsx
@@ -99,7 +99,7 @@ const StationPanel = (props: StationPanelProps) => {
     dispatch(selectedStationsChanged(updatedSelectedStations))
   }
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — setSelectAll is stable
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedStationGroup triggers the reset but isn't read in the body
   useEffect(() => {
     setSelectAll(false)
   }, [selectedStationGroup])

--- a/web/apps/wps-web/src/features/moreCast2/components/StationPanel.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/StationPanel.tsx
@@ -99,9 +99,10 @@ const StationPanel = (props: StationPanelProps) => {
     dispatch(selectedStationsChanged(updatedSelectedStations))
   }
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedStationGroup triggers the reset but isn't read in the body
   useEffect(() => {
-    setSelectAll(false)
+    if (selectedStationGroup) {
+      setSelectAll(false)
+    }
   }, [selectedStationGroup])
 
   return (

--- a/web/apps/wps-web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -36,7 +36,7 @@ import { selectAllMoreCast2Rows, selectWeatherIndeterminatesLoading } from 'feat
 import { selectSelectedStations } from 'features/moreCast2/slices/selectedStationsSlice'
 import { fillStationGrassCuringForward, simulateFireWeatherIndices } from 'features/moreCast2/util'
 import { cloneDeep, groupBy, isEqual, isNull, isUndefined } from 'lodash'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import type { AppDispatch } from '@/app/store'
 import MorecastAboutDataContent from '@/features/moreCast2/components/MorecastAboutDataContent'
@@ -50,6 +50,61 @@ export interface ColumnClickHandlerProps {
   } | null
   updateColumnWithModel: (modelType: ModelType, colDef: GridColDef) => void
   handleClose: () => void
+}
+
+const saveShowHideColumnsModelToLocalStorage = (model: Record<string, ColumnVis[]>) => {
+  const modelAsString = JSON.stringify(model)
+  window.localStorage.setItem(SHOW_HIDE_COLUMNS_LOCAL_STORAGE_KEY, modelAsString)
+}
+
+const getColumnDisplayName = (name: string) => {
+  if (name.endsWith('_BIAS')) {
+    const index = name.indexOf('_BIAS')
+    return `${name.slice(0, index)} bias`
+  }
+  return name
+}
+
+const groupByWeatherParam = (ungroupedState: ColumnVis[]) => {
+  const grouper = (item: ColumnVis) => {
+    const field = item.columnName
+    if (field.startsWith('temp')) {
+      return 'temp'
+    }
+    if (field.startsWith('rh')) {
+      return 'rh'
+    }
+    if (field.startsWith('precip')) {
+      return 'precip'
+    }
+    if (field.startsWith('windDirection')) {
+      return 'windDirection'
+    }
+    if (field.startsWith('windSpeed')) {
+      return 'windSpeed'
+    }
+  }
+  const groupedState = groupBy(ungroupedState, grouper)
+  return groupedState
+}
+
+const getVisibleColumnsByWeatherParam = (
+  weatherParam: string,
+  visible: boolean,
+  columnVisibilityModel: GridColumnVisibilityModel,
+  showHideColumnsModel: Record<string, ColumnVis[]>
+) => {
+  const updatedColumnVisibilityModel = DataGridColumns.updateGridColumnVisibilityModel(
+    [{ columnName: weatherParam, visible: visible }],
+    columnVisibilityModel
+  )
+  if (visible) {
+    const showHideColumns = showHideColumnsModel[weatherParam] || []
+    for (const column of showHideColumns) {
+      updatedColumnVisibilityModel[column.columnName] = column.visible
+    }
+  }
+  return updatedColumnVisibilityModel
 }
 
 export const Root = styled('div')({
@@ -153,37 +208,6 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
     }
   }
 
-  const groupByWeatherParam = (ungroupedState: ColumnVis[]) => {
-    const grouper = (item: ColumnVis) => {
-      const field = item.columnName
-      if (field.startsWith('temp')) {
-        return 'temp'
-      }
-      if (field.startsWith('rh')) {
-        return 'rh'
-      }
-      if (field.startsWith('precip')) {
-        return 'precip'
-      }
-      if (field.startsWith('windDirection')) {
-        return 'windDirection'
-      }
-      if (field.startsWith('windSpeed')) {
-        return 'windSpeed'
-      }
-    }
-    const groupedState = groupBy(ungroupedState, grouper)
-    return groupedState
-  }
-
-  const getColumnDisplayName = (name: string) => {
-    if (name.endsWith('_BIAS')) {
-      const index = name.indexOf('_BIAS')
-      return `${name.slice(0, index)} bias`
-    }
-    return name
-  }
-
   // Gets the previously stored set of weather model columns for each weather paramter (aka tab).
   const getShowHideColumnsModelFromLocalStorage = () => {
     const modelAsString = window.localStorage.getItem(SHOW_HIDE_COLUMNS_LOCAL_STORAGE_KEY)
@@ -218,73 +242,47 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
     initShowHideColumnsModel()
   )
 
-  // Given an array of weather parameters (aka tabs) return a GridColumnVisibilityModel object that
-  // contains all weather model columns that are visible for each weather parameter.
-  const getVisibleColumns = (weatherParams: string[]) => {
+  const showHideColumnsModelRef = useRef(showHideColumnsModel)
+  showHideColumnsModelRef.current = showHideColumnsModel
+  const tabVisRef = useRef({ tempVisible, rhVisible, precipVisible, windDirectionVisible, windSpeedVisible })
+  tabVisRef.current = { tempVisible, rhVisible, precipVisible, windDirectionVisible, windSpeedVisible }
+
+  const handleShowHideChange: handleShowHideChangeType = useCallback((
+    weatherParam: keyof MoreCastParams,
+    columnName: string,
+    value: boolean
+  ) => {
+    setShowHideColumnsModel(prev => {
+      const newModel = cloneDeep(prev)
+      const changedColumn = newModel[weatherParam].filter(column => column.columnName === columnName)[0]
+      changedColumn.visible = value
+      saveShowHideColumnsModelToLocalStorage(newModel)
+      return newModel
+    })
+  }, [])
+
+  useEffect(() => {
+    const colGroupingModel = getTabColumnGroupModel(showHideColumnsModel, handleShowHideChange)
+    setColumnGroupingModel(colGroupingModel)
+  }, [showHideColumnsModel, handleShowHideChange])
+
+  useEffect(() => {
+    const { tempVisible, rhVisible, precipVisible, windDirectionVisible, windSpeedVisible } = tabVisRef.current
+    const visibleTabs: string[] = []
+    tempVisible && visibleTabs.push('temp')
+    rhVisible && visibleTabs.push('rh')
+    precipVisible && visibleTabs.push('precip')
+    windDirectionVisible && visibleTabs.push('windDirection')
+    windSpeedVisible && visibleTabs.push('windSpeed')
     const visibleColumns: GridColumnVisibilityModel = {}
-    for (const param of weatherParams) {
+    for (const param of visibleTabs) {
       if (param in showHideColumnsModel) {
         for (const column of showHideColumnsModel[param]) {
           visibleColumns[column.columnName] = column.visible
         }
       }
     }
-    return visibleColumns
-  }
-
-  const getVisibleColumnsByWeatherParam = (weatherParam: string, visible: boolean) => {
-    const updatedColumnVisibilityModel = DataGridColumns.updateGridColumnVisibilityModel(
-      [{ columnName: weatherParam, visible: visible }],
-      columnVisibilityModel
-    )
-    if (visible) {
-      const showHideColumns = showHideColumnsModel[weatherParam] || []
-      for (const column of showHideColumns) {
-        updatedColumnVisibilityModel[column.columnName] = column.visible
-      }
-    }
-    return updatedColumnVisibilityModel
-  }
-
-  // Save the current set of weather model columns for each weather parameter (aka tab) as selected
-  // by the user.
-  const saveShowHideColumnsModelToLocalStorage = (model: Record<string, ColumnVis[]>) => {
-    const modelAsString = JSON.stringify(model)
-    window.localStorage.setItem(SHOW_HIDE_COLUMNS_LOCAL_STORAGE_KEY, modelAsString)
-  }
-
-  // Return an array of strings representing which weather parameters (aka tabs) are currently visible.
-  const getVisibleTabs = () => {
-    const visibleTabs = []
-    tempVisible && visibleTabs.push('temp')
-    rhVisible && visibleTabs.push('rh')
-    precipVisible && visibleTabs.push('precip')
-    windDirectionVisible && visibleTabs.push('windDirection')
-    windSpeedVisible && visibleTabs.push('windSpeed')
-    return visibleTabs
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — init on mount only
-  useEffect(() => {
-    const initialShowHideColumnsModel = initShowHideColumnsModel()
-    setShowHideColumnsModel(initialShowHideColumnsModel)
-  }, [])
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — handleShowHideChange is stable
-  useEffect(() => {
-    const colGroupingModel = getTabColumnGroupModel(showHideColumnsModel, handleShowHideChange)
-    setColumnGroupingModel(colGroupingModel)
-  }, [showHideColumnsModel])
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — getVisibleTabs/getVisibleColumns close over state correctly
-  useEffect(() => {
-    const visibleTabs = getVisibleTabs()
-    const visibleColumns = getVisibleColumns(visibleTabs)
-    const newColumnVisibilityModel = {
-      ...columnVisibilityModel,
-      ...visibleColumns
-    }
-    setColumnVisibilityModel(newColumnVisibilityModel)
+    setColumnVisibilityModel(prev => ({ ...prev, ...visibleColumns }))
   }, [showHideColumnsModel])
 
   useEffect(() => {
@@ -304,47 +302,34 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
 
   /********** Start useEffects for managing visibility of column groups *************/
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — getVisibleColumnsByWeatherParam is stable
   useEffect(() => {
     tempVisible && setForecastSummaryVisible(false)
-    const updatedColumnVisibilityModel = getVisibleColumnsByWeatherParam('temp', tempVisible)
-    setColumnVisibilityModel(updatedColumnVisibilityModel)
+    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('temp', tempVisible, prev, showHideColumnsModelRef.current))
   }, [tempVisible])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — getVisibleColumnsByWeatherParam is stable
   useEffect(() => {
     rhVisible && setForecastSummaryVisible(false)
-    const updatedColumnVisibilityModel = getVisibleColumnsByWeatherParam('rh', rhVisible)
-    setColumnVisibilityModel(updatedColumnVisibilityModel)
+    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('rh', rhVisible, prev, showHideColumnsModelRef.current))
   }, [rhVisible])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — getVisibleColumnsByWeatherParam is stable
   useEffect(() => {
     precipVisible && setForecastSummaryVisible(false)
-    const updatedColumnVisibilityModel = getVisibleColumnsByWeatherParam('precip', precipVisible)
-    setColumnVisibilityModel(updatedColumnVisibilityModel)
+    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('precip', precipVisible, prev, showHideColumnsModelRef.current))
   }, [precipVisible])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — getVisibleColumnsByWeatherParam is stable
   useEffect(() => {
     windDirectionVisible && setForecastSummaryVisible(false)
-    const updatedColumnVisibilityModel = getVisibleColumnsByWeatherParam('windDirection', windDirectionVisible)
-    setColumnVisibilityModel(updatedColumnVisibilityModel)
+    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('windDirection', windDirectionVisible, prev, showHideColumnsModelRef.current))
   }, [windDirectionVisible])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — getVisibleColumnsByWeatherParam is stable
   useEffect(() => {
-    setForecastSummaryVisible(false)
     windSpeedVisible && setForecastSummaryVisible(false)
-    const updatedColumnVisibilityModel = getVisibleColumnsByWeatherParam('windSpeed', windSpeedVisible)
-    setColumnVisibilityModel(updatedColumnVisibilityModel)
+    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('windSpeed', windSpeedVisible, prev, showHideColumnsModelRef.current))
   }, [windSpeedVisible])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — getVisibleColumnsByWeatherParam is stable
   useEffect(() => {
     grassCuringVisible && setForecastSummaryVisible(false)
-    const updatedColumnVisibilityModel = getVisibleColumnsByWeatherParam('grassCuring', grassCuringVisible)
-    setColumnVisibilityModel(updatedColumnVisibilityModel)
+    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('grassCuring', grassCuringVisible, prev, showHideColumnsModelRef.current))
   }, [grassCuringVisible])
 
   useEffect(() => {
@@ -499,18 +484,6 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
   // Checks if the displayed rows includes non-Actual rows
   const hasForecastRow = () => {
     return visibleRows.filter(isForecastRowPredicate).length > 0
-  }
-
-  const handleShowHideChange: handleShowHideChangeType = (
-    weatherParam: keyof MoreCastParams,
-    columnName: string,
-    value: boolean
-  ) => {
-    const newModel = cloneDeep(showHideColumnsModel)
-    const changedColumn = newModel[weatherParam].filter(column => column.columnName === columnName)[0]
-    changedColumn.visible = value
-    saveShowHideColumnsModelToLocalStorage(newModel)
-    setShowHideColumnsModel(newModel)
   }
 
   // Handler passed to our datagrids that runs after a row is updated.

--- a/web/apps/wps-web/src/features/moreCast2/components/TabbedDataGrid.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/TabbedDataGrid.tsx
@@ -247,19 +247,18 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
   const tabVisRef = useRef({ tempVisible, rhVisible, precipVisible, windDirectionVisible, windSpeedVisible })
   tabVisRef.current = { tempVisible, rhVisible, precipVisible, windDirectionVisible, windSpeedVisible }
 
-  const handleShowHideChange: handleShowHideChangeType = useCallback((
-    weatherParam: keyof MoreCastParams,
-    columnName: string,
-    value: boolean
-  ) => {
-    setShowHideColumnsModel(prev => {
-      const newModel = cloneDeep(prev)
-      const changedColumn = newModel[weatherParam].filter(column => column.columnName === columnName)[0]
-      changedColumn.visible = value
-      saveShowHideColumnsModelToLocalStorage(newModel)
-      return newModel
-    })
-  }, [])
+  const handleShowHideChange: handleShowHideChangeType = useCallback(
+    (weatherParam: keyof MoreCastParams, columnName: string, value: boolean) => {
+      setShowHideColumnsModel(prev => {
+        const newModel = cloneDeep(prev)
+        const changedColumn = newModel[weatherParam].filter(column => column.columnName === columnName)[0]
+        changedColumn.visible = value
+        saveShowHideColumnsModelToLocalStorage(newModel)
+        return newModel
+      })
+    },
+    []
+  )
 
   useEffect(() => {
     const colGroupingModel = getTabColumnGroupModel(showHideColumnsModel, handleShowHideChange)
@@ -304,32 +303,44 @@ const TabbedDataGrid = ({ fromTo, setFromTo, fetchWeatherIndeterminates }: Tabbe
 
   useEffect(() => {
     tempVisible && setForecastSummaryVisible(false)
-    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('temp', tempVisible, prev, showHideColumnsModelRef.current))
+    setColumnVisibilityModel(prev =>
+      getVisibleColumnsByWeatherParam('temp', tempVisible, prev, showHideColumnsModelRef.current)
+    )
   }, [tempVisible])
 
   useEffect(() => {
     rhVisible && setForecastSummaryVisible(false)
-    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('rh', rhVisible, prev, showHideColumnsModelRef.current))
+    setColumnVisibilityModel(prev =>
+      getVisibleColumnsByWeatherParam('rh', rhVisible, prev, showHideColumnsModelRef.current)
+    )
   }, [rhVisible])
 
   useEffect(() => {
     precipVisible && setForecastSummaryVisible(false)
-    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('precip', precipVisible, prev, showHideColumnsModelRef.current))
+    setColumnVisibilityModel(prev =>
+      getVisibleColumnsByWeatherParam('precip', precipVisible, prev, showHideColumnsModelRef.current)
+    )
   }, [precipVisible])
 
   useEffect(() => {
     windDirectionVisible && setForecastSummaryVisible(false)
-    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('windDirection', windDirectionVisible, prev, showHideColumnsModelRef.current))
+    setColumnVisibilityModel(prev =>
+      getVisibleColumnsByWeatherParam('windDirection', windDirectionVisible, prev, showHideColumnsModelRef.current)
+    )
   }, [windDirectionVisible])
 
   useEffect(() => {
     windSpeedVisible && setForecastSummaryVisible(false)
-    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('windSpeed', windSpeedVisible, prev, showHideColumnsModelRef.current))
+    setColumnVisibilityModel(prev =>
+      getVisibleColumnsByWeatherParam('windSpeed', windSpeedVisible, prev, showHideColumnsModelRef.current)
+    )
   }, [windSpeedVisible])
 
   useEffect(() => {
     grassCuringVisible && setForecastSummaryVisible(false)
-    setColumnVisibilityModel(prev => getVisibleColumnsByWeatherParam('grassCuring', grassCuringVisible, prev, showHideColumnsModelRef.current))
+    setColumnVisibilityModel(prev =>
+      getVisibleColumnsByWeatherParam('grassCuring', grassCuringVisible, prev, showHideColumnsModelRef.current)
+    )
   }, [grassCuringVisible])
 
   useEffect(() => {

--- a/web/apps/wps-web/src/features/moreCast2/pages/MoreCast2Page.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/pages/MoreCast2Page.tsx
@@ -13,7 +13,7 @@ import { getWeatherIndeterminates } from 'features/moreCast2/slices/dataSlice'
 import { selectedStationsChanged } from 'features/moreCast2/slices/selectedStationsSlice'
 import { isEmpty } from 'lodash'
 import { DateTime } from 'luxon'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 export const Root = styled('div')({
@@ -69,42 +69,37 @@ const MoreCast2Page = () => {
   })
   const [selectedGroupsMembers, setSelectedGroupsMembers] = useState([...members])
 
-  const fetchWeatherIndeterminates = () => {
+  const fetchWeatherIndeterminates = useCallback(() => {
     if (fromTo?.startDate && fromTo?.endDate) {
       dispatch(
         getWeatherIndeterminates(members, DateTime.fromJSDate(fromTo.startDate), DateTime.fromJSDate(fromTo.endDate))
       )
     }
-  }
+  }, [dispatch, members, fromTo.startDate, fromTo.endDate])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — fetch on mount only
   useEffect(() => {
     document.title = MORE_CAST_DOC_TITLE
     dispatch(fetchStationGroups())
-  }, [])
+  }, [dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when members changes
   useEffect(() => {
     if (!isEmpty(members)) {
       dispatch(selectedStationsChanged([members[0]]))
       setSelectedGroupsMembers(members)
     }
-    fetchWeatherIndeterminates()
-  }, [members])
+  }, [members, dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when station group changes
   useEffect(() => {
-    if (!isEmpty(selectedStationGroup)) {
-      dispatch(fetchStationGroupsMembers([selectedStationGroup.id]))
-    } else {
+    if (isEmpty(selectedStationGroup)) {
       setSelectedGroupsMembers([])
+    } else {
+      dispatch(fetchStationGroupsMembers([selectedStationGroup.id]))
     }
-  }, [selectedStationGroup])
+  }, [selectedStationGroup, dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when date range changes
   useEffect(() => {
     fetchWeatherIndeterminates()
-  }, [fromTo.startDate, fromTo.endDate])
+  }, [fetchWeatherIndeterminates])
 
   return (
     <Root data-testid="more-cast-2-page">


### PR DESCRIPTION
Removes all `biome-ignore lint/correctness/useExhaustiveDependencies` suppressions from the MoreCast2 feature by properly fixing the dep arrays rather than silencing the linter.

  **Changes by file:**

  - **`TabbedDataGrid.tsx`**: Largest change. Moved four pure functions (`saveShowHideColumnsModelToLocalStorage`, `getColumnDisplayName`, `groupByWeatherParam`, `getVisibleColumnsByWeatherParam`) to module level to make them stable references. Made `handleShowHideChange` a stable `useCallback([])` using a functional updater. Removed a redundant mount-only init effect (state was already lazily initialized via `useState`). Added `useRef` mirrors for `showHideColumnsModel` and tab visibility states so the tab-toggle and show/hide-column effects can read current values without
  adding deps that would change their trigger semantics.
  - **`MoreCast2Page.tsx`**: Wrapped `fetchWeatherIndeterminates` in `useCallback`; removed its call from the members effect and consolidated all fetching into a single effect that depends on the callback's identity (which covers both members and date-range changes). Added `dispatch` to the two effects that were missing it.
  - **`StationGroupDropdown.tsx`**: Fixed filter to always operate on `stationGroupOptions` rather than the already-filtered local `options` state (was a latent stale-closure bug). Added `idir` and `stationGroupOptions` to deps.
  - **`EditInputCell.tsx`**: Added `dispatch` and `error` to effect deps; now also correctly re-validates when `error` changes while a cell is being
  edited.


  Closes #5520. 
# Test Links:
[Landing Page](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5546-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
