### PR TITLE
SFMS Forecasts: Dates/times

### DIFF
--- a/backend/packages/wps-api/src/app/jobs/sfms_daily_forecasts.py
+++ b/backend/packages/wps-api/src/app/jobs/sfms_daily_forecasts.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import os
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from aiohttp import ClientSession
 from wps_sfms.sfmsng_raster_addresser import SFMSNGRasterAddresser
@@ -21,32 +21,87 @@ from wps_shared.db.database import get_async_read_session_scope, get_async_write
 from wps_shared.db.models.auto_spatial_advisory import RunTypeEnum
 from wps_shared.run_type import RunType
 from wps_shared.utils.s3_client import S3Client
-from wps_shared.utils.time import assert_all_utc, get_utc_now
+from wps_shared.utils.time import (
+    assert_all_utc,
+    get_utc_now,
+    vancouver_tz,
+)
 from wps_shared.wps_logging import configure_logging
 from wps_wf1.wfwx_api import WfwxApi
 
-from app.jobs.sfms_run_pipeline import run_fwi_calculations, run_weather_interpolation
+from app.jobs.sfms_run_pipeline import (
+    _missing_seed_keys,
+    run_fwi_calculations,
+    run_weather_interpolation,
+)
 
 logger = logging.getLogger(__name__)
 
 FORECAST_DAYS = 3
+ACTUALS_AVAILABLE_HOUR_PDT = 15
 
 
-def forecast_datetimes(target_date: datetime) -> list[datetime]:
+def forecast_datetimes(seed_actual_date: date) -> list[datetime]:
     """Return the next three forecast dates normalized to 20:00 UTC."""
-    assert_all_utc(target_date)
-    base_datetime = target_date.replace(hour=20, minute=0, second=0, microsecond=0)
+    base_datetime = datetime(
+        seed_actual_date.year,
+        seed_actual_date.month,
+        seed_actual_date.day,
+        hour=20,
+        tzinfo=timezone.utc,
+    )
     return [base_datetime + timedelta(days=day) for day in range(1, FORECAST_DAYS + 1)]
 
 
-async def run_sfms_daily_forecasts(target_date: datetime) -> None:
+def expected_actual_target_date(run_datetime: datetime) -> date:
+    """Return the actual target date this forecast run is expected to seed from."""
+    assert_all_utc(run_datetime)
+    run_datetime_local = run_datetime.astimezone(vancouver_tz)
+    target_date = run_datetime_local.date()
+    if run_datetime_local.hour < ACTUALS_AVAILABLE_HOUR_PDT:
+        return target_date - timedelta(days=1)
+    return target_date
+
+
+def run_datetime_for_cli_date(run_date: date, current_datetime: datetime) -> datetime:
+    """Return a UTC run datetime for the CLI date at the current local time."""
+    assert_all_utc(current_datetime)
+    current_datetime_local = current_datetime.astimezone(vancouver_tz)
+    cli_datetime = datetime(
+        run_date.year,
+        run_date.month,
+        run_date.day,
+        current_datetime_local.hour,
+        current_datetime_local.minute,
+        current_datetime_local.second,
+        tzinfo=vancouver_tz,
+    )
+    return cli_datetime.astimezone(timezone.utc)
+
+
+async def run_sfms_daily_forecasts(run_datetime: datetime) -> None:
     """Run SFMS forecast weather interpolation and FWI updates for the next three days."""
-    logger.info("Starting SFMS daily forecasts from %s", target_date.date())
+    assert_all_utc(run_datetime)
+    logger.info("Starting SFMS daily forecasts from %s", run_datetime.date())
 
     raster_addresser = SFMSNGRasterAddresser()
-    datetimes_to_process = forecast_datetimes(target_date)
+    seed_actual_date = expected_actual_target_date(run_datetime)
+    logger.info("Using %s actual rasters as forecast seed", seed_actual_date)
+    datetimes_to_process = forecast_datetimes(seed_actual_date)
 
     async with S3Client() as s3_client:
+        missing_actual_seed_keys = await _missing_seed_keys(
+            datetimes_to_process[0],
+            raster_addresser,
+            s3_client,
+            RunType.ACTUAL,
+        )
+        if missing_actual_seed_keys:
+            raise RuntimeError(
+                f"Missing actual seed rasters for {seed_actual_date}: "
+                f"{', '.join(missing_actual_seed_keys)}"
+            )
+
         async with ClientSession() as client_session:
             wfwx_api = WfwxApi(client_session)
 
@@ -103,14 +158,15 @@ async def run_sfms_daily_forecasts(target_date: datetime) -> None:
                             raise_on_missing_seed_keys=True,
                         )
 
-    logger.info("SFMS daily forecasts completed successfully from %s", target_date.date())
+    logger.info("SFMS daily forecasts completed successfully from %s", run_datetime.date())
 
 
 def main():
     """Main entry point for the job."""
     if len(sys.argv) > 1:
         try:
-            target_date = datetime.strptime(sys.argv[1], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            run_date = datetime.strptime(sys.argv[1], "%Y-%m-%d").date()
+            target_date = run_datetime_for_cli_date(run_date, get_utc_now())
         except ValueError:
             logger.error("Error: Please provide the date in 'YYYY-MM-DD' format")
             sys.exit(1)

--- a/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_forecasts.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_forecasts.py
@@ -3,7 +3,7 @@
 import os
 import sys
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import NamedTuple
 from unittest.mock import AsyncMock, MagicMock
 
@@ -19,7 +19,13 @@ from wps_shared.db.models.auto_spatial_advisory import RunTypeEnum
 from wps_shared.run_type import RunType
 from wps_shared.sfms.raster_addresser import FWIParameter
 
-from app.jobs.sfms_daily_forecasts import forecast_datetimes, main, run_sfms_daily_forecasts
+from app.jobs.sfms_daily_forecasts import (
+    expected_actual_target_date,
+    forecast_datetimes,
+    main,
+    run_datetime_for_cli_date,
+    run_sfms_daily_forecasts,
+)
 from app.tests.conftest import create_mock_sfms_actuals
 
 MODULE_PATH = "app.jobs.sfms_daily_forecasts"
@@ -69,10 +75,9 @@ def mock_dependencies(
         return_value=mock_fuel_type_raster,
     )
 
-    mock_read_session = MagicMock(spec=AsyncSession)
-
     @asynccontextmanager
     async def _read_scope():
+        mock_read_session = MagicMock(spec=AsyncSession)
         yield mock_read_session
 
     mocker.patch(f"{MODULE_PATH}.get_async_read_session_scope", _read_scope)
@@ -141,9 +146,9 @@ def mock_dependencies(
 
 
 def test_forecast_datetimes_processes_next_three_days():
-    target_date = datetime(2024, 7, 4, hour=10, minute=30, tzinfo=timezone.utc)
+    seed_actual_date = date(2024, 7, 4)
 
-    result = forecast_datetimes(target_date)
+    result = forecast_datetimes(seed_actual_date)
 
     assert result == [
         datetime(2024, 7, 5, 20, 0, tzinfo=timezone.utc),
@@ -152,16 +157,41 @@ def test_forecast_datetimes_processes_next_three_days():
     ]
 
 
-def test_forecast_datetimes_rejects_naive_datetime():
+def test_expected_actual_target_date_uses_yesterday_before_actuals_available():
+    run_datetime = datetime(2024, 7, 4, 15, 0, tzinfo=timezone.utc)
+
+    result = expected_actual_target_date(run_datetime)
+
+    assert result == date(2024, 7, 3)
+
+
+def test_expected_actual_target_date_uses_today_after_actuals_available():
+    run_datetime = datetime(2024, 7, 5, 0, 45, tzinfo=timezone.utc)
+
+    result = expected_actual_target_date(run_datetime)
+
+    assert result == date(2024, 7, 4)
+
+
+def test_expected_actual_target_date_rejects_naive_datetime():
     with pytest.raises(AssertionError, match="timezone-aware"):
-        forecast_datetimes(datetime(2024, 7, 4))
+        expected_actual_target_date(datetime(2024, 7, 4))
 
 
-def test_forecast_datetimes_rejects_non_utc_datetime():
-    target_date = datetime(2024, 7, 4, tzinfo=timezone(timedelta(hours=-7)))
+def test_run_datetime_for_cli_date_uses_current_pdt_time():
+    current_datetime = datetime(2024, 7, 5, 0, 45, tzinfo=timezone.utc)
 
-    with pytest.raises(AssertionError, match="not in UTC"):
-        forecast_datetimes(target_date)
+    result = run_datetime_for_cli_date(date(2024, 7, 4), current_datetime)
+
+    assert result == datetime(2024, 7, 5, 0, 45, tzinfo=timezone.utc)
+
+
+def test_run_datetime_for_cli_date_before_actuals_available():
+    current_datetime = datetime(2024, 7, 5, 15, 30, tzinfo=timezone.utc)
+
+    result = run_datetime_for_cli_date(date(2024, 7, 4), current_datetime)
+
+    assert result == datetime(2024, 7, 4, 15, 30, tzinfo=timezone.utc)
 
 
 class TestRunSfmsDailyForecasts:
@@ -169,7 +199,7 @@ class TestRunSfmsDailyForecasts:
 
     @pytest.mark.anyio
     async def test_runs_three_days(self, mock_dependencies: MockDailyForecastsDeps):
-        target_date = datetime(2024, 7, 4, tzinfo=timezone.utc)
+        target_date = datetime(2024, 7, 5, 0, 45, tzinfo=timezone.utc)
 
         await run_sfms_daily_forecasts(target_date)
 
@@ -185,7 +215,7 @@ class TestRunSfmsDailyForecasts:
 
     @pytest.mark.anyio
     async def test_saves_forecast_runs(self, mock_dependencies: MockDailyForecastsDeps):
-        target_date = datetime(2024, 7, 4, tzinfo=timezone.utc)
+        target_date = datetime(2024, 7, 5, 0, 45, tzinfo=timezone.utc)
 
         await run_sfms_daily_forecasts(target_date)
 
@@ -199,8 +229,26 @@ class TestRunSfmsDailyForecasts:
         ]
 
     @pytest.mark.anyio
+    async def test_forecasts_from_expected_successful_actual(
+        self, mock_dependencies: MockDailyForecastsDeps
+    ):
+        run_datetime = datetime(2024, 7, 4, 15, tzinfo=timezone.utc)
+
+        await run_sfms_daily_forecasts(run_datetime)
+
+        requested_datetimes = [
+            call.args[0]
+            for call in mock_dependencies.wfwx_api.get_sfms_daily_forecasts_all_stations.call_args_list
+        ]
+        assert requested_datetimes == [
+            datetime(2024, 7, 4, 20, 0, tzinfo=timezone.utc),
+            datetime(2024, 7, 5, 20, 0, tzinfo=timezone.utc),
+            datetime(2024, 7, 6, 20, 0, tzinfo=timezone.utc),
+        ]
+
+    @pytest.mark.anyio
     async def test_chains_fwi_seeds(self, mock_dependencies: MockDailyForecastsDeps):
-        target_date = datetime(2024, 7, 4, tzinfo=timezone.utc)
+        target_date = datetime(2024, 7, 5, 0, 45, tzinfo=timezone.utc)
 
         await run_sfms_daily_forecasts(target_date)
 
@@ -218,7 +266,7 @@ class TestRunSfmsDailyForecasts:
             return_value=[]
         )
 
-        target_date = datetime(2024, 7, 4, tzinfo=timezone.utc)
+        target_date = datetime(2024, 7, 5, 0, 45, tzinfo=timezone.utc)
 
         with pytest.raises(RuntimeError, match="No station forecasts found"):
             await run_sfms_daily_forecasts(target_date)
@@ -226,17 +274,31 @@ class TestRunSfmsDailyForecasts:
         mock_dependencies.temp_processor.process.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_raises_when_previous_indices_missing(
+    async def test_raises_when_actual_seed_rasters_missing(
         self, mock_dependencies: MockDailyForecastsDeps
     ):
         mock_dependencies.s3_client.all_objects_exist = AsyncMock(return_value=False)
 
-        target_date = datetime(2024, 7, 4, tzinfo=timezone.utc)
+        target_date = datetime(2024, 7, 5, 0, 45, tzinfo=timezone.utc)
 
-        with pytest.raises(RuntimeError, match="Missing previous-day actual index rasters"):
+        with pytest.raises(RuntimeError, match="Missing actual seed rasters for 2024-07-04"):
             await run_sfms_daily_forecasts(target_date)
 
+        mock_dependencies.get_fuel_type_raster_by_year.assert_not_called()
+        mock_dependencies.wfwx_api.get_sfms_daily_forecasts_all_stations.assert_not_called()
         mock_dependencies.fwi_processor.calculate_index.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_rejects_naive_run_datetime(self, mock_dependencies: MockDailyForecastsDeps):
+        with pytest.raises(AssertionError, match="timezone-aware"):
+            await run_sfms_daily_forecasts(datetime(2024, 7, 4))
+
+    @pytest.mark.anyio
+    async def test_rejects_non_utc_run_datetime(self, mock_dependencies: MockDailyForecastsDeps):
+        run_datetime = datetime(2024, 7, 4, tzinfo=timezone(timedelta(hours=-7)))
+
+        with pytest.raises(AssertionError, match="not in UTC"):
+            await run_sfms_daily_forecasts(run_datetime)
 
 
 class TestMain:
@@ -244,15 +306,14 @@ class TestMain:
 
     def test_main_with_valid_date(self, mocker: MockerFixture):
         mocker.patch.object(sys, "argv", ["sfms_daily_forecasts.py", "2025-07-15"])
+        mock_now = datetime(2025, 7, 16, 0, 45, tzinfo=timezone.utc)
+        mocker.patch(f"{MODULE_PATH}.get_utc_now", return_value=mock_now)
         mock_run = mocker.patch(f"{MODULE_PATH}.run_sfms_daily_forecasts", new_callable=AsyncMock)
 
         main()
 
         call_args = mock_run.call_args[0][0]
-        assert call_args.year == 2025
-        assert call_args.month == 7
-        assert call_args.day == 15
-        assert call_args.tzinfo == timezone.utc
+        assert call_args == run_datetime_for_cli_date(date(2025, 7, 15), mock_now)
 
     def test_main_without_date_uses_current(self, mocker: MockerFixture):
         mocker.patch.object(sys, "argv", ["sfms_daily_forecasts.py"])


### PR DESCRIPTION
Updates SFMS daily forecasts to seed from the expected actual rasters based on PDT run time.
  - Morning runs use yesterday’s actual rasters
  - Evening runs use today’s actual rasters
  - Forecast dates are generated from the selected actual seed date
  - The job checks S3 for required actual FFMC/DMC/DC seed rasters before fetching forecasts
  - CLI date runs use the provided date with the current PDT time

# Test Links:
[Landing Page](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5547-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
