### PR TITLE
useExhaustiveDeps - WeatherToolKit

### DIFF
--- a/web/apps/wps-web/src/features/weatherToolkit/hooks/useWxChartCache.ts
+++ b/web/apps/wps-web/src/features/weatherToolkit/hooks/useWxChartCache.ts
@@ -1,6 +1,6 @@
 import { getWxChart } from '@wps/api/weatherToolkitAPI'
 import type { DateTime } from 'luxon'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { type ModelRunHour, type ModelType, modelRegistry } from '@/features/weatherToolkit/weatherToolkitTypes'
 
 // The number of charts to pre-fetch to improve the user perception of performance.
@@ -18,6 +18,10 @@ export const buildChartKey = (
   return `wx_4panel_charts/${dateStr}/${ecccPath}/${resolution}/${modelRunHour}/${hourStr}/${model}_${dateStr}T${modelRunHour}Z_F${hourStr}_4panel.png`
 }
 
+export const buildModelRunKey = (model: ModelType, modelRunDate: DateTime, modelRunHour: ModelRunHour): string => {
+  return `${model}:${modelRunDate.toISODate()}:${modelRunHour}`
+}
+
 export interface WxChartCacheResult {
   cache: Map<string, string>
   failed: Set<string>
@@ -31,6 +35,9 @@ export function useWxChartCache(
 ): WxChartCacheResult {
   const [cache, setCache] = useState<Map<string, string>>(new Map())
   const [failed, setFailed] = useState<Set<string>>(new Set())
+  const modelRunKey = useMemo(() => {
+    return buildModelRunKey(model, modelRunDate, modelRunHour)
+  }, [model, modelRunDate, modelRunHour])
   const stateRef = useRef({
     cache: new Map<string, string>(),
     failed: new Set<string>(),
@@ -39,8 +46,8 @@ export function useWxChartCache(
   })
 
   // Reset when model params change
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps are captured via closure correctly
   useEffect(() => {
+    if (!modelRunKey) return
     const state = stateRef.current
     state.generation++
     state.cache.forEach(url => {
@@ -51,7 +58,7 @@ export function useWxChartCache(
     state.fetching = new Set()
     setCache(new Map())
     setFailed(new Set())
-  }, [model, modelRunDate, modelRunHour])
+  }, [modelRunKey])
 
   // Prefetch rolling window of PREFETCH_AHEAD frames ahead of currentHour
   useEffect(() => {

--- a/web/apps/wps-web/src/features/weatherToolkit/pages/WeatherToolkitPage.tsx
+++ b/web/apps/wps-web/src/features/weatherToolkit/pages/WeatherToolkitPage.tsx
@@ -9,7 +9,7 @@ import Footer from '@/features/landingPage/components/Footer'
 import ChartPanel from '@/features/weatherToolkit/components/ChartPanel'
 import SidePanel from '@/features/weatherToolkit/components/SidePanel'
 import TimelineController from '@/features/weatherToolkit/components/TimelineController'
-import { buildChartKey, useWxChartCache } from '@/features/weatherToolkit/hooks/useWxChartCache'
+import { buildChartKey, buildModelRunKey, useWxChartCache } from '@/features/weatherToolkit/hooks/useWxChartCache'
 import { ModelRunHour, ModelType, modelRegistry } from '@/features/weatherToolkit/weatherToolkitTypes'
 
 const WeatherToolkitPage = () => {
@@ -24,14 +24,17 @@ const WeatherToolkitPage = () => {
   const chartKey = useMemo(() => {
     return buildChartKey(model, modelRunDate, modelRunHour, currentHour)
   }, [currentHour, model, modelRunDate, modelRunHour])
+  const modelRunKey = useMemo(() => {
+    return buildModelRunKey(model, modelRunDate, modelRunHour)
+  }, [model, modelRunDate, modelRunHour])
 
   const { cache: chartCache, failed: chartFailed } = useWxChartCache(model, modelRunDate, modelRunHour, currentHour)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset on model/run change only
   useEffect(() => {
+    if (!modelRunKey) return
     // Reset current hour back to zero as hourly intervals for models don't overlap
     setCurrentHour(0)
-  }, [model, modelRunDate, modelRunHour])
+  }, [modelRunKey])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/web/apps/wps-web/src/features/weatherToolkit/pages/weatherToolkitPage.test.tsx
+++ b/web/apps/wps-web/src/features/weatherToolkit/pages/weatherToolkitPage.test.tsx
@@ -6,7 +6,8 @@ import WeatherToolkitPage from './WeatherToolkitPage'
 
 vi.mock('@/features/weatherToolkit/hooks/useWxChartCache', () => ({
   useWxChartCache: () => ({ cache: new Map(), failed: new Set() }),
-  buildChartKey: () => 'mock-chart-key'
+  buildChartKey: () => 'mock-chart-key',
+  buildModelRunKey: () => 'mock-model-run-key'
 }))
 
 vi.mock('@/features/weatherToolkit/components/SidePanel', () => ({


### PR DESCRIPTION
- Added `buildModelRunKey` to centralize model/run identity
- Updated chart hour reset and cache reset effects to depend on `modelRunKey`
# Test Links:
[Landing Page](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5548-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
