### PR TITLE
Dev: Fix useExhaustiveDependencies — HFI Calculator

### DIFF
--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/ManageStationsModal.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/ManageStationsModal.tsx
@@ -83,10 +83,8 @@ export const ManageStationsModal = ({
   )
 
   useEffect(() => {
-    if (!isUndefined(selectedFireCentre)) {
-      dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
-    }
-  }, [selectedFireCentre, dispatch])
+    dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
+  }, [dispatch])
 
   const handleClose = () => {
     setModalOpen(false)

--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/ManageStationsModal.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/ManageStationsModal.tsx
@@ -82,12 +82,11 @@ export const ManageStationsModal = ({
     'planningAreaId'
   )
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when selected fire centre changes
   useEffect(() => {
     if (!isUndefined(selectedFireCentre)) {
       dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
     }
-  }, [])
+  }, [selectedFireCentre, dispatch])
 
   const handleClose = () => {
     setModalOpen(false)

--- a/web/apps/wps-web/src/features/hfiCalculator/pages/HfiCalculatorPage.test.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/pages/HfiCalculatorPage.test.tsx
@@ -1,0 +1,155 @@
+import { render, waitFor } from '@testing-library/react'
+import type { FireCentre } from '@wps/api/hfiCalculatorAPI'
+import { setSelectedFireCentre } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
+import { getHFIStationsSuccess } from 'features/hfiCalculator/slices/stationsSlice'
+import { Provider } from 'react-redux'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from '@/test/testUtils'
+import HfiCalculatorPage from './HfiCalculatorPage'
+
+const mockFetchHFIStations = vi.fn(() => ({ type: 'hfiStations/mock' }))
+const mockFetchFuelTypes = vi.fn(() => ({ type: 'hfiCalc/fetchFuelTypes/mock' }))
+const mockFetchGetPrepDateRange = vi.fn()
+const mockFetchAllReadyStates = vi.fn()
+const mockFetchToggleReadyState = vi.fn()
+
+vi.mock('features/hfiCalculator/slices/stationsSlice', async importOriginal => {
+  const actual = await importOriginal<typeof import('features/hfiCalculator/slices/stationsSlice')>()
+  return { ...actual, fetchHFIStations: () => mockFetchHFIStations() }
+})
+
+vi.mock('features/hfiCalculator/slices/hfiCalculatorSlice', async importOriginal => {
+  const actual = await importOriginal<typeof import('features/hfiCalculator/slices/hfiCalculatorSlice')>()
+  return {
+    ...actual,
+    fetchFuelTypes: () => mockFetchFuelTypes(),
+    fetchGetPrepDateRange: (fire_center_id: number, start_date?: string, end_date?: string) => {
+      mockFetchGetPrepDateRange(fire_center_id, start_date, end_date)
+      return { type: 'mock' }
+    }
+  }
+})
+
+vi.mock('features/hfiCalculator/slices/hfiReadySlice', async importOriginal => {
+  const actual = await importOriginal<typeof import('features/hfiCalculator/slices/hfiReadySlice')>()
+  return {
+    ...actual,
+    fetchAllReadyStates: (fire_centre_id: number, date_range: import('@wps/api/hfiCalculatorAPI').PrepDateRange) => {
+      mockFetchAllReadyStates(fire_centre_id, date_range)
+      return { type: 'mock' }
+    },
+    fetchToggleReadyState: (
+      fire_centre_id: number,
+      planning_area_id: number,
+      date_range: import('@wps/api/hfiCalculatorAPI').PrepDateRange
+    ) => {
+      mockFetchToggleReadyState(fire_centre_id, planning_area_id, date_range)
+      return { type: 'mock' }
+    }
+  }
+})
+
+// Stub out heavy child components
+vi.mock('features/hfiCalculator/components/HFIPageSubHeader', () => ({
+  HFIPageSubHeader: () => <div data-testid="hfi-page-sub-header" />
+}))
+vi.mock('features/hfiCalculator/components/HFILoadingDataContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+vi.mock('features/hfiCalculator/components/ViewSwitcherToggles', () => ({
+  default: () => null
+}))
+vi.mock('features/hfiCalculator/components/LastUpdatedHeader', () => ({
+  default: () => null
+}))
+vi.mock('features/hfiCalculator/components/DownloadPDFButton', () => ({
+  default: () => null
+}))
+vi.mock('features/hfiCalculator/components/ViewSwitcher', () => ({
+  default: () => null
+}))
+vi.mock('features/hfiCalculator/components/HFISuccessAlert', () => ({
+  default: () => null
+}))
+vi.mock('@wps/ui/GeneralHeader', () => ({
+  GeneralHeader: () => null
+}))
+
+const mockFireCentre: FireCentre = {
+  id: 1,
+  name: 'Kamloops Fire Centre',
+  planning_areas: []
+}
+
+const mockFireCentres: FireCentre[] = [mockFireCentre]
+
+const renderPage = (store: ReturnType<typeof createTestStore>) =>
+  render(
+    <Provider store={store}>
+      <HfiCalculatorPage />
+    </Provider>
+  )
+
+describe('HfiCalculatorPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('fetches stations and fuel types on mount', async () => {
+    const store = createTestStore()
+    renderPage(store)
+
+    await waitFor(() => {
+      expect(mockFetchHFIStations).toHaveBeenCalledTimes(1)
+      expect(mockFetchFuelTypes).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('fetches prep date range when selected fire centre changes', async () => {
+    const store = createTestStore()
+    renderPage(store)
+
+    store.dispatch(setSelectedFireCentre(mockFireCentre))
+
+    await waitFor(() => {
+      expect(mockFetchGetPrepDateRange).toHaveBeenCalledWith(mockFireCentre.id, undefined, undefined)
+    })
+  })
+
+  it('stores selected fire centre name in localStorage when fire centre changes', async () => {
+    const store = createTestStore()
+    renderPage(store)
+
+    store.dispatch(setSelectedFireCentre(mockFireCentre))
+
+    await waitFor(() => {
+      expect(localStorage.getItem('hfiCalcPreferredFireCentre')).toBe(mockFireCentre.name)
+    })
+  })
+
+  it('restores fire centre from localStorage when fire centres load', async () => {
+    localStorage.setItem('hfiCalcPreferredFireCentre', mockFireCentre.name)
+    const store = createTestStore()
+    renderPage(store)
+
+    store.dispatch(getHFIStationsSuccess({ fire_centres: mockFireCentres }))
+
+    await waitFor(() => {
+      expect(store.getState().hfiCalculatorDailies.selectedFireCentre?.name).toBe(mockFireCentre.name)
+    })
+  })
+
+  it('does not call fetchAllReadyStates when fire centre changes before dateRange is set', async () => {
+    const store = createTestStore()
+    renderPage(store)
+
+    store.dispatch(setSelectedFireCentre(mockFireCentre))
+
+    // dateRange is still undefined — fetchAllReadyStates must NOT fire yet
+    await waitFor(() => {
+      expect(mockFetchGetPrepDateRange).toHaveBeenCalled()
+    })
+    expect(mockFetchAllReadyStates).not.toHaveBeenCalled()
+  })
+})

--- a/web/apps/wps-web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/pages/HfiCalculatorPage.tsx
@@ -38,7 +38,7 @@ import { fetchAllReadyStates, fetchToggleReadyState } from 'features/hfiCalculat
 import { fetchHFIStations } from 'features/hfiCalculator/slices/stationsSlice'
 import { isNull, isUndefined } from 'lodash'
 import { DateTime } from 'luxon'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 export const HFIPageContainer = styled(Container)({
@@ -80,6 +80,15 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
     updatedPlanningAreaId
   } = useSelector(selectHFICalculatorState)
   const { planningAreaReadyDetails } = useSelector(selectHFIReadyState)
+
+  const resultRef = useRef(result)
+  resultRef.current = result
+  const planningAreaReadyDetailsRef = useRef(planningAreaReadyDetails)
+  planningAreaReadyDetailsRef.current = planningAreaReadyDetails
+  const selectedFireCentreRef = useRef(selectedFireCentre)
+  selectedFireCentreRef.current = selectedFireCentre
+  const dateRangeRef = useRef(dateRange)
+  dateRangeRef.current = dateRange
 
   const setSelectedStation = (planningAreaId: number, code: number, selected: boolean) => {
     if (!isUndefined(result) && !isUndefined(result.date_range.start_date)) {
@@ -155,25 +164,14 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
     }
   }
 
-  const setSelectedFireCentreFromLocalStorage = () => {
-    const findCentre = (name: string | null): FireCentre | undefined => {
-      const fireCentresArray = Object.values(fireCentres)
-      return fireCentresArray.find(centre => centre.name === name)
-    }
-    const storedFireCentre = findCentre(localStorage.getItem('hfiCalcPreferredFireCentre'))
-    if (!isUndefined(storedFireCentre) && storedFireCentre !== selectedFireCentre) {
-      dispatch(setSelectedFireCentre(storedFireCentre))
-    }
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — fetch on mount only
   useEffect(() => {
     dispatch(fetchHFIStations())
     dispatch(fetchFuelTypes())
-  }, [])
+  }, [dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when updatedPlanningAreaId changes
   useEffect(() => {
+    const result = resultRef.current
+    const planningAreaReadyDetails = planningAreaReadyDetailsRef.current
     if (
       !isUndefined(result) &&
       !isUndefined(result.date_range) &&
@@ -185,9 +183,8 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
         fetchToggleReadyState(result.selected_fire_center_id, updatedPlanningAreaId.planning_area_id, result.date_range)
       )
     }
-  }, [updatedPlanningAreaId])
+  }, [updatedPlanningAreaId, dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when selected fire centre changes
   useEffect(() => {
     if (selectedFireCentre && selectedFireCentre?.name !== localStorage.getItem('hfiCalcPreferredFireCentre')) {
       localStorage.setItem('hfiCalcPreferredFireCentre', selectedFireCentre?.name)
@@ -197,24 +194,30 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
       // back to "Prep Period" tab instead of a specific date that may no longer be relevant
       dispatch(fetchGetPrepDateRange(selectedFireCentre.id))
     }
-  }, [selectedFireCentre])
+  }, [selectedFireCentre, dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when dateRange changes
   useEffect(() => {
+    const selectedFireCentre = selectedFireCentreRef.current
     if (!isUndefined(selectedFireCentre) && !isUndefined(dateRange)) {
       dispatch(fetchAllReadyStates(selectedFireCentre.id, dateRange))
     }
-  }, [dateRange])
+  }, [dateRange, dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — setSelectedFireCentreFromLocalStorage closes over state correctly
   useEffect(() => {
     if (Object.keys(fireCentres).length > 0) {
-      setSelectedFireCentreFromLocalStorage()
+      const storedFireCentre = Object.values(fireCentres).find(
+        centre => centre.name === localStorage.getItem('hfiCalcPreferredFireCentre')
+      )
+      if (!isUndefined(storedFireCentre) && storedFireCentre !== selectedFireCentreRef.current) {
+        dispatch(setSelectedFireCentre(storedFireCentre))
+      }
     }
-  }, [fireCentres])
+  }, [fireCentres, dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when updatedPlanningAreaId changes
   useEffect(() => {
+    const planningAreaReadyDetails = planningAreaReadyDetailsRef.current
+    const selectedFireCentre = selectedFireCentreRef.current
+    const dateRange = dateRangeRef.current
     if (
       !isNull(updatedPlanningAreaId) &&
       isUndefined(planningAreaReadyDetails[updatedPlanningAreaId.planning_area_id]) &&
@@ -224,15 +227,16 @@ const HfiCalculatorPage: React.FunctionComponent = () => {
       // Request all ready states for hfi request unique by date and fire centre
       dispatch(fetchAllReadyStates(selectedFireCentre.id, dateRange))
     }
-  }, [updatedPlanningAreaId])
+  }, [updatedPlanningAreaId, dispatch])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run after station admin updates complete
   useEffect(() => {
+    const selectedFireCentre = selectedFireCentreRef.current
+    const dateRange = dateRangeRef.current
     if (!stationsUpdateLoading && !isUndefined(selectedFireCentre) && !isUndefined(dateRange)) {
       dispatch(fetchHFIStations())
       dispatch(fetchAllReadyStates(selectedFireCentre.id, dateRange))
     }
-  }, [stationsUpdateLoading])
+  }, [stationsUpdateLoading, dispatch])
 
   const selectNewFireCentre = (newSelection: FireCentre | undefined) => {
     dispatch(setSelectedFireCentre(newSelection))


### PR DESCRIPTION
Removes all `biome-ignore lint/correctness/useExhaustiveDependencies` comments from `HfiCalculatorPage.tsx` and `ManageStationsModal.tsx` by properly fixing dependency arrays

  `HfiCalculatorPage` has several effects that trigger on one value (e.g. `dateRange`) but need to read others (e.g. `selectedFireCentre`) without subscribing to them.
  Adding those reads to the dep arrays causes cascading re-fires — notably the known API flood loop when switching fire centres. The fix uses the "latest ref" pattern: refs are updated every render so effects can read current values without listing them as deps.

  `ManageStationsModal` had a misleading `[]` dep array (comment said "re-run when fire centre changes" but it never did). Changed to `[selectedFireCentre, dispatch]`
  to match the stated intent.

  #### Changes
  - `HfiCalculatorPage.tsx`: add `useRef`, inline `setSelectedFireCentreFromLocalStorage`, fix all 7 effect dep arrays
  - `ManageStationsModal.tsx`:  fix dep array from `[]` to `[selectedFireCentre, dispatch]`
  - `HfiCalculatorPage.test.tsx`:  new page-level test suite covering mount fetches, fire centre selection, localStorage restore, and the no-flood-loop invariant

Closes #5518

# Test Links:
[Landing Page](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5549-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
