### PR TITLE
Fix useExhaustiveDeps - FireCalc

### DIFF
--- a/web/apps/wps-web/src/features/fbaCalculator/components/FBATable.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/FBATable.tsx
@@ -43,9 +43,9 @@ import { isPrecipInvalid, isWindSpeedInvalid, rowShouldUpdate } from 'features/f
 import { DataTableCell } from 'features/hfiCalculator/components/StyledPlanningAreaComponents'
 import { fetchWxStations } from 'features/stations/slices/stationsSlice'
 import { CsvBuilder } from 'filefy'
-import { difference, filter, findIndex, isEmpty, isEqual, isUndefined } from 'lodash'
+import { difference, filter, findIndex, isEmpty, isEqual, isNull, isUndefined } from 'lodash'
 import { DateTime } from 'luxon'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { FBAAboutDataContent } from '@/features/fbaCalculator/components/FbaAboutDataContent'
@@ -132,7 +132,13 @@ const FBATable = (props: FBATableProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const dispatch: AppDispatch = useDispatch()
+  const locationSearch = location.search
 
+  // selectors
+  const { stations, error: stationsError } = useSelector(selectFireWeatherStations)
+  const { fireBehaviourResultStations, loading, error: fbaResultsError } = useSelector(selectFireBehaviourCalcResult)
+
+  // state
   const [headerSelected, setHeaderSelect] = useState<boolean>(false)
   const [dateOfInterest, setDateOfInterest] = useState(DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`))
   const [rowIdsToUpdate, setRowIdsToUpdate] = useState<Set<number>>(new Set())
@@ -142,33 +148,68 @@ const FBATable = (props: FBATableProps) => {
   const [order, setOrder] = useState<Order>('desc')
   const [rows, setRows] = useState<FBATableRow[]>([])
   const [modalOpen, setModalOpen] = useState<boolean>(false)
-  const { stations, error: stationsError } = useSelector(selectFireWeatherStations)
-  const { fireBehaviourResultStations, loading, error: fbaResultsError } = useSelector(selectFireBehaviourCalcResult)
   const [calculatedResults, setCalculatedResults] = useState<FBAStation[]>(fireBehaviourResultStations)
   const [visibleColumns, setVisibleColumns] = useState<ColumnLabel[]>(tableColumnLabels)
   const [showResetDialog, setShowResetDialog] = useState<boolean>(false)
 
-  const stationMenuOptions: GridMenuOption[] = (stations as GeoJsonStation[]).map(station => ({
-    value: String(station.properties.code),
-    label: `${station.properties.name} (${station.properties.code})`
-  }))
+  // derived
+  const dateOfInterestKey = dateOfInterest.toISODate()
 
-  const fuelTypeMenuOptions: GridMenuOption[] = Object.entries(FuelTypes.get()).map(([key, value]) => ({
-    value: key,
-    label: value.friendlyName
-  }))
+  // refs
+  const initialLocationSearch = useRef(locationSearch)
+  // keep current values available to effects that intentionally run on url and station triggers
+  const dateOfInterestRef = useRef(dateOfInterest)
+  const rowsRef = useRef(rows)
+  const rowIdsToUpdateRef = useRef(rowIdsToUpdate)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — fetch on mount only
+  const stationMenuOptions: GridMenuOption[] = useMemo(
+    () =>
+      (stations as GeoJsonStation[]).map(station => ({
+        value: String(station.properties.code),
+        label: `${station.properties.name} (${station.properties.code})`
+      })),
+    [stations]
+  )
+
+  const fuelTypeMenuOptions: GridMenuOption[] = useMemo(
+    () =>
+      Object.entries(FuelTypes.get()).map(([key, value]) => ({
+        value: key,
+        label: value.friendlyName
+      })),
+    []
+  )
+
+  const updateQueryParams = useCallback(
+    (queryParams: string) => {
+      navigate({
+        search: queryParams
+      })
+    },
+    [navigate]
+  )
+
+  useEffect(() => {
+    dateOfInterestRef.current = dateOfInterest
+  }, [dateOfInterest])
+
+  useEffect(() => {
+    rowsRef.current = rows
+  }, [rows])
+
+  useEffect(() => {
+    rowIdsToUpdateRef.current = rowIdsToUpdate
+  }, [rowIdsToUpdate])
+
   useEffect(() => {
     // Strip the wind query parameters if present and update the URL
-    updateQueryParams(stripWindFromQueryParams(location.search))
+    updateQueryParams(stripWindFromQueryParams(initialLocationSearch.current))
     dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
-  }, [])
+  }, [dispatch, updateQueryParams])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when stations change
   useEffect(() => {
     if (stations.length > 0) {
-      const rowsFromQuery = getRowsFromUrlParams(location.search)
+      const rowsFromQuery = getRowsFromUrlParams(locationSearch)
       const stationCodeMap = new Map(stationMenuOptions.map(station => [station.value, station.label]))
 
       const sortedRows = RowManager.sortRows(
@@ -178,35 +219,31 @@ const FBATable = (props: FBATableProps) => {
           ...RowManager.buildFBATableRow(inputRow, stationCodeMap)
         }))
       )
-      if (rows.length > 0 || sortedRows.length > 0) {
-        setRows(sortedRows)
-      }
+      setRows(currentRows => (currentRows.length > 0 || sortedRows.length > 0 ? sortedRows : currentRows))
 
-      dispatch(fetchFireBehaviourStations(dateOfInterest, sortedRows))
+      dispatch(fetchFireBehaviourStations(dateOfInterestRef.current, sortedRows))
     }
-  }, [stations])
+  }, [dispatch, locationSearch, order, sortByColumn, stationMenuOptions, stations.length])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when location changes
   useEffect(() => {
     if (stations.length > 0) {
-      const rowsToUpdate = rows.filter(row => rowIdsToUpdate.has(row.id))
-      if (!isEmpty(rowsToUpdate)) {
-        dispatch(fetchFireBehaviourStations(dateOfInterest, rowsToUpdate))
+      const rowsToUpdate = rowsRef.current.filter(row => rowIdsToUpdateRef.current.has(row.id))
+      if (!isEmpty(rowsToUpdate) && !isUndefined(locationSearch)) {
+        dispatch(fetchFireBehaviourStations(dateOfInterestRef.current, rowsToUpdate))
       }
     }
-  }, [location])
+  }, [dispatch, locationSearch, stations.length])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps are captured via closure correctly
   useEffect(() => {
     // Row updates
     if (!isEmpty(rowIdsToUpdate) && fireBehaviourResultStations.length > 0) {
-      const updatedRows = RowManager.updateRows(
-        rows.filter(row => !isUndefined(row)),
-        fireBehaviourResultStations
-      )
-      if (rows.length > 0 || updatedRows.length > 0) {
-        setRows(updatedRows)
-      }
+      setRows(currentRows => {
+        const updatedRows = RowManager.updateRows(
+          currentRows.filter(row => !isUndefined(row)),
+          fireBehaviourResultStations
+        )
+        return currentRows.length > 0 || updatedRows.length > 0 ? updatedRows : currentRows
+      })
 
       const updatedRowIds = difference(
         Array.from(rowIdsToUpdate),
@@ -216,51 +253,49 @@ const FBATable = (props: FBATableProps) => {
     }
     // Initial row list page load
     if (initialLoad && fireBehaviourResultStations.length > 0) {
+      setRows(currentRows => {
+        const sortedRows = RowManager.sortRows(
+          sortByColumn,
+          order,
+          RowManager.updateRows(
+            currentRows.filter(row => !isUndefined(row)),
+            fireBehaviourResultStations
+          )
+        )
+        return currentRows.length > 0 || sortedRows.length > 0 ? sortedRows : currentRows
+      })
+      setInitialLoad(false)
+    }
+    setCalculatedResults(currentResults => RowManager.updateRows(currentResults, fireBehaviourResultStations))
+  }, [fireBehaviourResultStations, initialLoad, order, rowIdsToUpdate, sortByColumn])
+
+  useEffect(() => {
+    if (isNull(dateOfInterestKey)) return
+
+    setRows(currentRows => {
       const sortedRows = RowManager.sortRows(
         sortByColumn,
         order,
         RowManager.updateRows(
-          rows.filter(row => !isUndefined(row)),
+          currentRows.filter(row => !isUndefined(row)),
           fireBehaviourResultStations
         )
       )
-      if (rows.length > 0 || sortedRows.length > 0) {
-        setRows(sortedRows)
-      }
-      setInitialLoad(false)
-    }
-    const updatedCalculatedResults = RowManager.updateRows(calculatedResults, fireBehaviourResultStations)
-    setCalculatedResults(updatedCalculatedResults)
-  }, [fireBehaviourResultStations, stations])
+      return currentRows.length > 0 || sortedRows.length > 0 ? sortedRows : currentRows
+    })
+    setCalculatedResults(currentResults => RowManager.updateRows(currentResults, fireBehaviourResultStations))
+  }, [dateOfInterestKey, fireBehaviourResultStations, order, sortByColumn])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps are captured via closure correctly
   useEffect(() => {
-    const sortedRows = RowManager.sortRows(
-      sortByColumn,
-      order,
-      RowManager.updateRows(
-        rows.filter(row => !isUndefined(row)),
-        fireBehaviourResultStations
+    setRows(currentRows => {
+      const sortedRows = RowManager.sortRows(
+        sortByColumn,
+        order,
+        currentRows.filter(row => !isUndefined(row))
       )
-    )
-    const updatedCalculatedResults = RowManager.updateRows(calculatedResults, fireBehaviourResultStations)
-    setCalculatedResults(updatedCalculatedResults)
-    if (rows.length > 0 || sortedRows.length > 0) {
-      setRows(sortedRows)
-    }
-  }, [dateOfInterest, fireBehaviourResultStations])
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps are captured via closure correctly
-  useEffect(() => {
-    const sortedRows = RowManager.sortRows(
-      sortByColumn,
-      order,
-      rows.filter(row => !isUndefined(row))
-    )
-    if (rows.length > 0 || sortedRows.length > 0) {
-      setRows(sortedRows)
-    }
-  }, [order])
+      return currentRows.length > 0 || sortedRows.length > 0 ? sortedRows : currentRows
+    })
+  }, [order, sortByColumn])
 
   const addStation = () => {
     const newRowId = getNextRowIdFromRows(rows.filter(row => !isUndefined(row)))
@@ -323,12 +358,6 @@ const FBATable = (props: FBATableProps) => {
     if (dispatchUpdate) {
       dispatch(fetchFireBehaviourStations(dateOfInterest, newRows))
     }
-  }
-
-  const updateQueryParams = (queryParams: string) => {
-    navigate({
-      search: queryParams
-    })
   }
 
   const updateDate = (newDate: DateTime) => {

--- a/web/apps/wps-web/src/features/fbaCalculator/components/FBATable.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/FBATable.tsx
@@ -314,9 +314,10 @@ const FBATable = (props: FBATableProps) => {
   const deleteSelectedStations = () => {
     const selectedSet = new Set<number>(selected)
     const unselectedRows = rows.filter(row => !selectedSet.has(row.id))
-    const updatedCalculateRows = filter(calculatedResults, (_, i) => !selectedSet.has(i))
+    const updatedCalculateRows = filter(calculatedResults, row => !selectedSet.has(row.id))
     setRows(unselectedRows)
     setCalculatedResults(updatedCalculateRows)
+    setRowIdsToUpdate(currentRowIds => new Set(Array.from(currentRowIds).filter(rowId => !selectedSet.has(rowId))))
     updateQueryParams(getUrlParamsFromRows(unselectedRows))
     setSelected([])
   }
@@ -338,11 +339,8 @@ const FBATable = (props: FBATableProps) => {
     newRows[index] = updatedRow
     setRows(newRows)
 
-    if (!rowIdsToUpdate.has(id)) {
-      rowIdsToUpdate.add(id)
-      const toUpdate = new Set(rowIdsToUpdate)
-      setRowIdsToUpdate(toUpdate)
-    }
+    setRowIdsToUpdate(currentRowIds => new Set([...currentRowIds, id]))
+
     return newRows
   }
 
@@ -385,13 +383,22 @@ const FBATable = (props: FBATableProps) => {
 
   const handleResetSelected = () => {
     setShowResetDialog(false)
-    const rowsToUpdate = rows.filter(row => selected.includes(row.id))
-    const updatedRows = rowsToUpdate.map(rowToUpdate => {
-      rowToUpdate.precip = undefined
-      rowToUpdate.windSpeed = undefined
-      return rowToUpdate
+    const selectedSet = new Set<number>(selected)
+    const updatedRows = rows.map(rowToUpdate => {
+      if (!selectedSet.has(rowToUpdate.id)) {
+        return rowToUpdate
+      }
+
+      return {
+        ...rowToUpdate,
+        precip: undefined,
+        windSpeed: undefined
+      }
     })
-    dispatch(fetchFireBehaviourStations(dateOfInterest, updatedRows))
+    const rowsToUpdate = updatedRows.filter(row => selectedSet.has(row.id))
+    setRows(updatedRows)
+    setRowIdsToUpdate(currentRowIds => new Set([...currentRowIds, ...rowsToUpdate.map(row => row.id)]))
+    dispatch(fetchFireBehaviourStations(dateOfInterest, rowsToUpdate))
   }
 
   const filterColumnsCallback = (filterByColumns: ColumnLabel[]) => {

--- a/web/apps/wps-web/src/features/fbaCalculator/components/fbaTable.test.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/fbaTable.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { fetchFireBehaviourStations } from 'features/fbaCalculator/slices/fbaCalculatorSlice'
+import { fetchWxStations } from 'features/stations/slices/stationsSlice'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from '@/test/testUtils'
+import FBATable from './FBATable'
+
+vi.mock('@wps/api/stationAPI', () => ({
+  getStations: vi.fn(() => Promise.resolve([])),
+  StationSource: { wildfire_one: 'wildfire_one' }
+}))
+
+vi.mock('features/stations/slices/stationsSlice', async () => {
+  const actual = await vi.importActual<typeof import('features/stations/slices/stationsSlice')>(
+    'features/stations/slices/stationsSlice'
+  )
+  return { ...actual, fetchWxStations: vi.fn(() => () => {}) }
+})
+
+vi.mock('features/fbaCalculator/slices/fbaCalculatorSlice', async () => {
+  const actual = await vi.importActual<typeof import('features/fbaCalculator/slices/fbaCalculatorSlice')>(
+    'features/fbaCalculator/slices/fbaCalculatorSlice'
+  )
+  return { ...actual, fetchFireBehaviourStations: vi.fn(() => () => {}) }
+})
+
+vi.mock('@wps/ui/WPSDatePicker', () => ({
+  default: () => <div data-testid="date-picker" />
+}))
+
+vi.mock('@wps/ui/AboutDataPopover', () => ({
+  default: () => <div data-testid="about-data" />
+}))
+
+vi.mock('./FilterColumnsModal', () => ({
+  default: () => <div data-testid="filter-columns-modal" />
+}))
+
+const preloadedState = {
+  fireWeatherStations: {
+    loading: false,
+    error: null,
+    stations: [
+      {
+        type: 'Feature',
+        geometry: null,
+        properties: {
+          code: 322,
+          name: 'AFTON'
+        }
+      },
+      {
+        type: 'Feature',
+        geometry: null,
+        properties: {
+          code: 209,
+          name: 'ALEXIS CREEK'
+        }
+      }
+    ],
+    stationsByCode: {},
+    selectedStationsByCode: [],
+    codesOfRetrievedStationData: []
+  },
+  fbaCalculatorResults: {
+    loading: false,
+    error: null,
+    fireBehaviourResultStations: [],
+    date: null
+  }
+}
+
+const renderTable = (search = '?s=322&f=c1&c=1') =>
+  render(
+    <Provider store={createTestStore(preloadedState)}>
+      <MemoryRouter initialEntries={[`/${search}`]}>
+        <FBATable />
+      </MemoryRouter>
+    </Provider>
+  )
+
+const getInput = (testId: string) => screen.getByTestId(testId).querySelector('input') as HTMLInputElement
+
+describe('FBATable', () => {
+  beforeEach(() => {
+    vi.mocked(fetchWxStations).mockClear()
+    vi.mocked(fetchFireBehaviourStations).mockClear()
+  })
+
+  it('resets adjusted weather values for selected rows', async () => {
+    renderTable()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('precipInput-fba-0')).toBeInTheDocument()
+    })
+
+    fireEvent.change(getInput('precipInput-fba-0'), { target: { value: '7' } })
+    fireEvent.blur(getInput('precipInput-fba-0'))
+    fireEvent.change(getInput('windSpeedInput-fba-0'), { target: { value: '12' } })
+    fireEvent.blur(getInput('windSpeedInput-fba-0'))
+
+    await waitFor(() => {
+      expect(fetchFireBehaviourStations).toHaveBeenCalledWith(expect.anything(), [
+        expect.objectContaining({ id: 0, precip: 7, windSpeed: 12 })
+      ])
+    })
+
+    fireEvent.click(within(screen.getByTestId('selection-checkbox-fba')).getByRole('checkbox'))
+    fireEvent.click(screen.getByTestId('reset-selected-btn'))
+    fireEvent.click(screen.getByTestId('reset-dialog-confirm-button'))
+
+    await waitFor(() => {
+      expect(fetchFireBehaviourStations).toHaveBeenLastCalledWith(expect.anything(), [
+        expect.objectContaining({ id: 0, precip: undefined, windSpeed: undefined })
+      ])
+    })
+  })
+
+  it('removes selected rows from the table', async () => {
+    renderTable('?s=322&f=c1&c=1,s=209&f=c2&c=2')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('precipInput-fba-0')).toBeInTheDocument()
+      expect(screen.getByTestId('precipInput-fba-1')).toBeInTheDocument()
+    })
+
+    const firstRow = screen.getByTestId('precipInput-fba-0').closest('tr') as HTMLTableRowElement
+    const firstRowCheckbox = within(firstRow).getByRole('checkbox')
+    fireEvent.click(firstRowCheckbox)
+    await waitFor(() => {
+      expect(firstRowCheckbox).toBeChecked()
+    })
+
+    fireEvent.click(screen.getByTestId('remove-rows'))
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/precipInput-fba-/)).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
- Removed useExhaustiveDependencies suppressions from `FBATable`
  - Fixed reset selected behavior for adjusted weather values
  - Added `FBATable` tests for reset selected and remove selected rows
# Test Links:
[Landing Page](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5551-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
