### PR TITLE
Fix useExhaustiveDeps - FireCalc

### DIFF
--- a/web/apps/wps-web/playwright/fire-behaviour-calculator-page.spec.ts
+++ b/web/apps/wps-web/playwright/fire-behaviour-calculator-page.spec.ts
@@ -29,6 +29,12 @@ async function selectFuelType(page: Page, fuelType: string, rowId: number) {
   await input.press('Enter')
 }
 
+async function selectFuelTypeAndWaitForFBAResponse(page: Page, fuelType: string, rowId: number) {
+  const fbaResponse = page.waitForResponse(r => r.url().includes('/api/fba-calc/stations'))
+  await selectFuelType(page, fuelType, rowId)
+  await fbaResponse
+}
+
 async function setGrassCure(page: Page, value: string, rowId: number) {
   const input = page.getByTestId(`grassCureInput-fba-${rowId}`).locator('input')
   await input.fill(value)
@@ -338,8 +344,7 @@ test.describe('FireCalc Page', () => {
       await addRow(page)
       await setGrassCure(page, '1', 1)
       await selectStation(page, 322, 1)
-      await selectFuelType(page, 'C4', 1)
-      await page.waitForResponse(r => r.url().includes('/api/fba-calc/stations'))
+      await selectFuelTypeAndWaitForFBAResponse(page, 'C4', 1)
       await expect(page.getByTestId('filter-columns-btn')).toBeEnabled()
     })
 
@@ -352,14 +357,12 @@ test.describe('FireCalc Page', () => {
       await addRow(page)
       await setGrassCure(page, '1', 1)
       await selectStation(page, 322, 1)
-      await selectFuelType(page, 'C4', 1)
+      await selectFuelTypeAndWaitForFBAResponse(page, 'C4', 1)
 
       await addRow(page)
       await setGrassCure(page, '1', 1)
       await selectStation(page, 209, 2)
-      await selectFuelType(page, 'C1', 2)
-
-      await page.waitForResponse(r => r.url().includes('/api/fba-calc/stations'))
+      await selectFuelTypeAndWaitForFBAResponse(page, 'C1', 2)
       await expect(page.getByTestId('filter-columns-btn')).toBeEnabled()
 
       await page.getByTestId('filter-columns-btn').click()

--- a/web/apps/wps-web/src/features/fbaCalculator/components/FBATable.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/FBATable.tsx
@@ -45,7 +45,7 @@ import { fetchWxStations } from 'features/stations/slices/stationsSlice'
 import { CsvBuilder } from 'filefy'
 import { difference, filter, findIndex, isEmpty, isEqual, isUndefined } from 'lodash'
 import { DateTime } from 'luxon'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { FBAAboutDataContent } from '@/features/fbaCalculator/components/FbaAboutDataContent'
@@ -135,11 +135,18 @@ const updateRowsIfPresent = (currentRows: FBATableRow[], updatedRows: FBATableRo
 }
 
 const FBATable = (props: FBATableProps) => {
+  // routing
   const navigate = useNavigate()
   const location = useLocation()
-  const dispatch: AppDispatch = useDispatch()
-  const initialLocationSearch = useRef(location.search)
 
+  // dispatch
+  const dispatch: AppDispatch = useDispatch()
+
+  // selectors
+  const { stations, error: stationsError } = useSelector(selectFireWeatherStations)
+  const { fireBehaviourResultStations, loading, error: fbaResultsError } = useSelector(selectFireBehaviourCalcResult)
+
+  // state
   const [headerSelected, setHeaderSelect] = useState<boolean>(false)
   const [dateOfInterest, setDateOfInterest] = useState<DateTime<boolean>>(
     DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`)
@@ -151,28 +158,13 @@ const FBATable = (props: FBATableProps) => {
   const [order, setOrder] = useState<Order>('desc')
   const [rows, setRows] = useState<FBATableRow[]>([])
   const [modalOpen, setModalOpen] = useState<boolean>(false)
-  const { stations, error: stationsError } = useSelector(selectFireWeatherStations)
-  const { fireBehaviourResultStations, loading, error: fbaResultsError } = useSelector(selectFireBehaviourCalcResult)
   const [calculatedResults, setCalculatedResults] = useState<FBAStation[]>(fireBehaviourResultStations)
   const [visibleColumns, setVisibleColumns] = useState<ColumnLabel[]>(tableColumnLabels)
   const [showResetDialog, setShowResetDialog] = useState<boolean>(false)
+  const [initialLocationSearch] = useState(location.search)
+  const [hydratedStationOptionsKey, setHydratedStationOptionsKey] = useState<string | null>(null)
 
-  const locationSearchRef = useRef(location.search)
-  const rowsRef = useRef(rows)
-  const rowIdsToUpdateRef = useRef(rowIdsToUpdate)
-  const dateOfInterestRef = useRef(dateOfInterest)
-  const sortByColumnRef = useRef(sortByColumn)
-  const orderRef = useRef(order)
-  const stationsRef = useRef(stations)
-
-  locationSearchRef.current = location.search
-  rowsRef.current = rows
-  rowIdsToUpdateRef.current = rowIdsToUpdate
-  dateOfInterestRef.current = dateOfInterest
-  sortByColumnRef.current = sortByColumn
-  orderRef.current = order
-  stationsRef.current = stations
-
+  // derived data
   const stationMenuOptions: GridMenuOption[] = useMemo(
     () =>
       (stations as GeoJsonStation[]).map(station => ({
@@ -187,6 +179,11 @@ const FBATable = (props: FBATableProps) => {
     [stationMenuOptions]
   )
 
+  const stationOptionsKey = useMemo(
+    () => stationMenuOptions.map(station => `${station.value}:${station.label}`).join('|'),
+    [stationMenuOptions]
+  )
+
   const fuelTypeMenuOptions: GridMenuOption[] = useMemo(
     () =>
       Object.entries(FuelTypes.get()).map(([key, value]) => ({
@@ -196,100 +193,69 @@ const FBATable = (props: FBATableProps) => {
     []
   )
 
-  const updateQueryParams = useCallback(
-    (queryParams: string) => {
-      navigate({
-        search: queryParams
-      })
-    },
-    [navigate]
-  )
-
+  // effects
   useEffect(() => {
-    // Strip the wind query parameters if present and update the URL
-    updateQueryParams(stripWindFromQueryParams(initialLocationSearch.current))
+    // strip the wind query parameters if present and update the URL
+    navigate({
+      search: stripWindFromQueryParams(initialLocationSearch)
+    })
     dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
-  }, [dispatch, updateQueryParams])
+  }, [dispatch, initialLocationSearch, navigate])
 
   useEffect(() => {
-    if (stations.length > 0) {
-      const rowsFromQuery = getRowsFromUrlParams(locationSearchRef.current)
+    if (stations.length > 0 && stationOptionsKey !== hydratedStationOptionsKey) {
+      const rowsFromQuery = getRowsFromUrlParams(location.search)
 
       const sortedRows = RowManager.sortRows(
-        sortByColumnRef.current,
-        orderRef.current,
+        sortByColumn,
+        order,
         rowsFromQuery.map(inputRow => ({
           ...RowManager.buildFBATableRow(inputRow, stationCodeMap)
         }))
       )
       setRows(currentRows => updateRowsIfPresent(currentRows, sortedRows))
 
-      dispatch(fetchFireBehaviourStations(dateOfInterestRef.current, sortedRows))
+      setHydratedStationOptionsKey(stationOptionsKey)
+      dispatch(fetchFireBehaviourStations(dateOfInterest, sortedRows))
     }
-  }, [dispatch, stationCodeMap, stations])
+  }, [
+    dateOfInterest,
+    dispatch,
+    hydratedStationOptionsKey,
+    location.search,
+    order,
+    sortByColumn,
+    stationCodeMap,
+    stationOptionsKey,
+    stations.length
+  ])
 
   useEffect(() => {
-    locationSearchRef.current = location.search
-    if (stationsRef.current.length > 0) {
-      const rowsToUpdate = rowsRef.current.filter(row => rowIdsToUpdateRef.current.has(row.id))
-      if (!isEmpty(rowsToUpdate)) {
-        dispatch(fetchFireBehaviourStations(dateOfInterestRef.current, rowsToUpdate))
-      }
-    }
-  }, [dispatch, location.search])
-
-  useEffect(() => {
-    // Row updates
-    if (!isEmpty(rowIdsToUpdateRef.current) && fireBehaviourResultStations.length > 0) {
-      setRows(currentRows => {
-        const updatedRows = RowManager.updateRows(getDefinedRows(currentRows), fireBehaviourResultStations)
-        return updateRowsIfPresent(currentRows, updatedRows)
-      })
-
-      const updatedRowIds = difference(
-        Array.from(rowIdsToUpdateRef.current),
-        fireBehaviourResultStations.map(result => result.id)
-      )
-      setRowIdsToUpdate(new Set(updatedRowIds))
-    }
-    // Initial row list page load
-    if (initialLoad && fireBehaviourResultStations.length > 0) {
-      setRows(currentRows => {
-        const sortedRows = RowManager.sortRows(
-          sortByColumnRef.current,
-          orderRef.current,
-          RowManager.updateRows(getDefinedRows(currentRows), fireBehaviourResultStations)
-        )
-        return updateRowsIfPresent(currentRows, sortedRows)
-      })
-      setInitialLoad(false)
-    }
-    setCalculatedResults(currentCalculatedResults =>
-      RowManager.updateRows(currentCalculatedResults, fireBehaviourResultStations)
-    )
-  }, [fireBehaviourResultStations, initialLoad])
-
-  useEffect(() => {
-    dateOfInterestRef.current = dateOfInterest
     setRows(currentRows => {
       const sortedRows = RowManager.sortRows(
-        sortByColumnRef.current,
-        orderRef.current,
+        sortByColumn,
+        order,
         RowManager.updateRows(getDefinedRows(currentRows), fireBehaviourResultStations)
       )
       return updateRowsIfPresent(currentRows, sortedRows)
     })
+    setInitialLoad(currentInitialLoad =>
+      currentInitialLoad && fireBehaviourResultStations.length > 0 ? false : currentInitialLoad
+    )
+    setRowIdsToUpdate(currentRowIdsToUpdate => {
+      if (isEmpty(currentRowIdsToUpdate) || fireBehaviourResultStations.length === 0) {
+        return currentRowIdsToUpdate
+      }
+      const updatedRowIds = difference(
+        Array.from(currentRowIdsToUpdate),
+        fireBehaviourResultStations.map(result => result.id)
+      )
+      return new Set(updatedRowIds)
+    })
     setCalculatedResults(currentCalculatedResults =>
       RowManager.updateRows(currentCalculatedResults, fireBehaviourResultStations)
     )
-  }, [dateOfInterest, fireBehaviourResultStations])
-
-  useEffect(() => {
-    setRows(currentRows => {
-      const sortedRows = RowManager.sortRows(sortByColumnRef.current, order, getDefinedRows(currentRows))
-      return updateRowsIfPresent(currentRows, sortedRows)
-    })
-  }, [order])
+  }, [fireBehaviourResultStations, order, sortByColumn])
 
   const addStation = () => {
     const newRowId = getNextRowIdFromRows(rows.filter(row => !isUndefined(row)))
@@ -325,33 +291,45 @@ const FBATable = (props: FBATableProps) => {
     csvBuilder.exportFile()
   }
 
+  const updateQueryParams = (queryParams: string) => {
+    navigate({
+      search: queryParams
+    })
+  }
+
+  const markRowForUpdate = (id: number) => {
+    const updatedRowIds = new Set(rowIdsToUpdate)
+    updatedRowIds.add(id)
+    setRowIdsToUpdate(updatedRowIds)
+    return updatedRowIds
+  }
+
   const getNewRows = (id: number, updatedRow: FBATableRow) => {
     const newRows = getDefinedRows(rows)
     const index = findIndex(newRows, row => row.id === id)
 
     newRows[index] = updatedRow
     setRows(newRows)
-
-    setRowIdsToUpdate(currentRowIds => {
-      if (currentRowIds.has(id)) {
-        return currentRowIds
-      }
-      const rowIds = new Set(currentRowIds)
-      rowIds.add(id)
-      return rowIds
-    })
     return newRows
   }
 
   const updateRow = (id: number, updatedRow: FBATableRow, dispatchUpdate = true) => {
     const newRows = getNewRows(id, updatedRow)
+    const updatedRowIds = markRowForUpdate(id)
     if (dispatchUpdate) {
       updateQueryParams(getUrlParamsFromRows(newRows))
+      dispatch(
+        fetchFireBehaviourStations(
+          dateOfInterest,
+          newRows.filter(row => updatedRowIds.has(row.id))
+        )
+      )
     }
   }
 
   const updateRowDirect = (id: number, updatedRow: FBATableRow, dispatchUpdate = true) => {
     const newRows = getNewRows(id, updatedRow)
+    markRowForUpdate(id)
     if (dispatchUpdate) {
       dispatch(fetchFireBehaviourStations(dateOfInterest, newRows))
     }

--- a/web/apps/wps-web/src/features/fbaCalculator/components/FBATable.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/FBATable.tsx
@@ -45,7 +45,7 @@ import { fetchWxStations } from 'features/stations/slices/stationsSlice'
 import { CsvBuilder } from 'filefy'
 import { difference, filter, findIndex, isEmpty, isEqual, isUndefined } from 'lodash'
 import { DateTime } from 'luxon'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { FBAAboutDataContent } from '@/features/fbaCalculator/components/FbaAboutDataContent'
@@ -128,10 +128,17 @@ const tableColumnLabels: ColumnLabel[] = [
   '60 min fire size (ha)'
 ]
 
+const getDefinedRows = (rows: FBATableRow[]) => rows.filter(row => !isUndefined(row))
+
+const updateRowsIfPresent = (currentRows: FBATableRow[], updatedRows: FBATableRow[]) => {
+  return currentRows.length > 0 || updatedRows.length > 0 ? updatedRows : currentRows
+}
+
 const FBATable = (props: FBATableProps) => {
   const navigate = useNavigate()
   const location = useLocation()
   const dispatch: AppDispatch = useDispatch()
+  const initialLocationSearch = useRef(location.search)
 
   const [headerSelected, setHeaderSelect] = useState<boolean>(false)
   const [dateOfInterest, setDateOfInterest] = useState<DateTime<boolean>>(
@@ -150,118 +157,138 @@ const FBATable = (props: FBATableProps) => {
   const [visibleColumns, setVisibleColumns] = useState<ColumnLabel[]>(tableColumnLabels)
   const [showResetDialog, setShowResetDialog] = useState<boolean>(false)
 
-  const stationMenuOptions: GridMenuOption[] = (stations as GeoJsonStation[]).map(station => ({
-    value: String(station.properties.code),
-    label: `${station.properties.name} (${station.properties.code})`
-  }))
+  const locationSearchRef = useRef(location.search)
+  const rowsRef = useRef(rows)
+  const rowIdsToUpdateRef = useRef(rowIdsToUpdate)
+  const dateOfInterestRef = useRef(dateOfInterest)
+  const sortByColumnRef = useRef(sortByColumn)
+  const orderRef = useRef(order)
+  const stationsRef = useRef(stations)
 
-  const fuelTypeMenuOptions: GridMenuOption[] = Object.entries(FuelTypes.get()).map(([key, value]) => ({
-    value: key,
-    label: value.friendlyName
-  }))
+  locationSearchRef.current = location.search
+  rowsRef.current = rows
+  rowIdsToUpdateRef.current = rowIdsToUpdate
+  dateOfInterestRef.current = dateOfInterest
+  sortByColumnRef.current = sortByColumn
+  orderRef.current = order
+  stationsRef.current = stations
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — fetch on mount only
+  const stationMenuOptions: GridMenuOption[] = useMemo(
+    () =>
+      (stations as GeoJsonStation[]).map(station => ({
+        value: String(station.properties.code),
+        label: `${station.properties.name} (${station.properties.code})`
+      })),
+    [stations]
+  )
+
+  const stationCodeMap = useMemo(
+    () => new Map(stationMenuOptions.map(station => [station.value, station.label])),
+    [stationMenuOptions]
+  )
+
+  const fuelTypeMenuOptions: GridMenuOption[] = useMemo(
+    () =>
+      Object.entries(FuelTypes.get()).map(([key, value]) => ({
+        value: key,
+        label: value.friendlyName
+      })),
+    []
+  )
+
+  const updateQueryParams = useCallback(
+    (queryParams: string) => {
+      navigate({
+        search: queryParams
+      })
+    },
+    [navigate]
+  )
+
   useEffect(() => {
     // Strip the wind query parameters if present and update the URL
-    updateQueryParams(stripWindFromQueryParams(location.search))
+    updateQueryParams(stripWindFromQueryParams(initialLocationSearch.current))
     dispatch(fetchWxStations(getStations, StationSource.wildfire_one))
-  }, [])
+  }, [dispatch, updateQueryParams])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when stations change
   useEffect(() => {
     if (stations.length > 0) {
-      const rowsFromQuery = getRowsFromUrlParams(location.search)
-      const stationCodeMap = new Map(stationMenuOptions.map(station => [station.value, station.label]))
+      const rowsFromQuery = getRowsFromUrlParams(locationSearchRef.current)
 
       const sortedRows = RowManager.sortRows(
-        sortByColumn,
-        order,
+        sortByColumnRef.current,
+        orderRef.current,
         rowsFromQuery.map(inputRow => ({
           ...RowManager.buildFBATableRow(inputRow, stationCodeMap)
         }))
       )
-      if (rows.length > 0 || sortedRows.length > 0) {
-        setRows(sortedRows)
-      }
+      setRows(currentRows => updateRowsIfPresent(currentRows, sortedRows))
 
-      dispatch(fetchFireBehaviourStations(dateOfInterest, sortedRows))
+      dispatch(fetchFireBehaviourStations(dateOfInterestRef.current, sortedRows))
     }
-  }, [stations])
+  }, [dispatch, stationCodeMap, stations])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-run when location changes
   useEffect(() => {
-    if (stations.length > 0) {
-      const rowsToUpdate = rows.filter(row => rowIdsToUpdate.has(row.id))
+    locationSearchRef.current = location.search
+    if (stationsRef.current.length > 0) {
+      const rowsToUpdate = rowsRef.current.filter(row => rowIdsToUpdateRef.current.has(row.id))
       if (!isEmpty(rowsToUpdate)) {
-        dispatch(fetchFireBehaviourStations(dateOfInterest, rowsToUpdate))
+        dispatch(fetchFireBehaviourStations(dateOfInterestRef.current, rowsToUpdate))
       }
     }
-  }, [location])
+  }, [dispatch, location.search])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps are captured via closure correctly
   useEffect(() => {
     // Row updates
-    if (!isEmpty(rowIdsToUpdate) && fireBehaviourResultStations.length > 0) {
-      const updatedRows = RowManager.updateRows(
-        rows.filter(row => !isUndefined(row)),
-        fireBehaviourResultStations
-      )
-      if (rows.length > 0 || updatedRows.length > 0) {
-        setRows(updatedRows)
-      }
+    if (!isEmpty(rowIdsToUpdateRef.current) && fireBehaviourResultStations.length > 0) {
+      setRows(currentRows => {
+        const updatedRows = RowManager.updateRows(getDefinedRows(currentRows), fireBehaviourResultStations)
+        return updateRowsIfPresent(currentRows, updatedRows)
+      })
 
       const updatedRowIds = difference(
-        Array.from(rowIdsToUpdate),
+        Array.from(rowIdsToUpdateRef.current),
         fireBehaviourResultStations.map(result => result.id)
       )
       setRowIdsToUpdate(new Set(updatedRowIds))
     }
     // Initial row list page load
     if (initialLoad && fireBehaviourResultStations.length > 0) {
-      const sortedRows = RowManager.sortRows(
-        sortByColumn,
-        order,
-        RowManager.updateRows(
-          rows.filter(row => !isUndefined(row)),
-          fireBehaviourResultStations
+      setRows(currentRows => {
+        const sortedRows = RowManager.sortRows(
+          sortByColumnRef.current,
+          orderRef.current,
+          RowManager.updateRows(getDefinedRows(currentRows), fireBehaviourResultStations)
         )
-      )
-      if (rows.length > 0 || sortedRows.length > 0) {
-        setRows(sortedRows)
-      }
+        return updateRowsIfPresent(currentRows, sortedRows)
+      })
       setInitialLoad(false)
     }
-    const updatedCalculatedResults = RowManager.updateRows(calculatedResults, fireBehaviourResultStations)
-    setCalculatedResults(updatedCalculatedResults)
-  }, [fireBehaviourResultStations, stations])
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps are captured via closure correctly
-  useEffect(() => {
-    const sortedRows = RowManager.sortRows(
-      sortByColumn,
-      order,
-      RowManager.updateRows(
-        rows.filter(row => !isUndefined(row)),
-        fireBehaviourResultStations
-      )
+    setCalculatedResults(currentCalculatedResults =>
+      RowManager.updateRows(currentCalculatedResults, fireBehaviourResultStations)
     )
-    const updatedCalculatedResults = RowManager.updateRows(calculatedResults, fireBehaviourResultStations)
-    setCalculatedResults(updatedCalculatedResults)
-    if (rows.length > 0 || sortedRows.length > 0) {
-      setRows(sortedRows)
-    }
+  }, [fireBehaviourResultStations, initialLoad])
+
+  useEffect(() => {
+    dateOfInterestRef.current = dateOfInterest
+    setRows(currentRows => {
+      const sortedRows = RowManager.sortRows(
+        sortByColumnRef.current,
+        orderRef.current,
+        RowManager.updateRows(getDefinedRows(currentRows), fireBehaviourResultStations)
+      )
+      return updateRowsIfPresent(currentRows, sortedRows)
+    })
+    setCalculatedResults(currentCalculatedResults =>
+      RowManager.updateRows(currentCalculatedResults, fireBehaviourResultStations)
+    )
   }, [dateOfInterest, fireBehaviourResultStations])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps are captured via closure correctly
   useEffect(() => {
-    const sortedRows = RowManager.sortRows(
-      sortByColumn,
-      order,
-      rows.filter(row => !isUndefined(row))
-    )
-    if (rows.length > 0 || sortedRows.length > 0) {
-      setRows(sortedRows)
-    }
+    setRows(currentRows => {
+      const sortedRows = RowManager.sortRows(sortByColumnRef.current, order, getDefinedRows(currentRows))
+      return updateRowsIfPresent(currentRows, sortedRows)
+    })
   }, [order])
 
   const addStation = () => {
@@ -299,17 +326,20 @@ const FBATable = (props: FBATableProps) => {
   }
 
   const getNewRows = (id: number, updatedRow: FBATableRow) => {
-    const newRows = [...rows].filter(row => !isUndefined(row))
+    const newRows = getDefinedRows(rows)
     const index = findIndex(newRows, row => row.id === id)
 
     newRows[index] = updatedRow
     setRows(newRows)
 
-    if (!rowIdsToUpdate.has(id)) {
-      rowIdsToUpdate.add(id)
-      const toUpdate = new Set(rowIdsToUpdate)
-      setRowIdsToUpdate(toUpdate)
-    }
+    setRowIdsToUpdate(currentRowIds => {
+      if (currentRowIds.has(id)) {
+        return currentRowIds
+      }
+      const rowIds = new Set(currentRowIds)
+      rowIds.add(id)
+      return rowIds
+    })
     return newRows
   }
 
@@ -325,12 +355,6 @@ const FBATable = (props: FBATableProps) => {
     if (dispatchUpdate) {
       dispatch(fetchFireBehaviourStations(dateOfInterest, newRows))
     }
-  }
-
-  const updateQueryParams = (queryParams: string) => {
-    navigate({
-      search: queryParams
-    })
   }
 
   const updateDate = (newDate: DateTime) => {


### PR DESCRIPTION
- Memoized derived station/fuel option data
- Simplified FBA result merging, sorting, and row update handling
- Fixed a Playwright race by registering the FBA response wait before selecting fuel type
- closes #5521 

# Test Links:
[Landing Page](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5553-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
