### PR TITLE
SFMS Backfill code/docs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -352,6 +352,22 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "SFMS Daily Backfill",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "app.jobs.sfms_daily_backfill",
+            "justMyCode": false,
+            "cwd": "${workspaceFolder}/backend",
+            "python": "${workspaceFolder}/backend/.venv/bin/python",
+            "args": [
+                "--start-date",
+                "2026-06-23",
+                "--end-date",
+                "2026-06-25"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Weather - ECCC Grib Consumer",
             "type": "debugpy",
             "request": "launch",

--- a/backend/packages/wps-api/src/app/jobs/sfms_daily_backfill.py
+++ b/backend/packages/wps-api/src/app/jobs/sfms_daily_backfill.py
@@ -1,13 +1,7 @@
-"""Run SFMS daily actual and forecast jobs over an inclusive date range.
+"""Run SFMS daily actual jobs over an inclusive date range.
 
 Usage:
     python -m app.jobs.sfms_daily_backfill \
-        --run-type actual \
-        --start-date 2026-06-25 \
-        --end-date 2026-06-27
-
-    python -m app.jobs.sfms_daily_backfill \
-        --run-type both \
         --start-date 2026-06-25 \
         --end-date 2026-06-27
 """
@@ -19,37 +13,26 @@ import os
 import sys
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from enum import StrEnum
 from typing import Awaitable, Callable
 
 from wps_shared.chatops_notification import send_chatops_notification
 from wps_shared.wps_logging import configure_logging
 
 from app.jobs.sfms_daily_actuals import run_sfms_daily_actuals
-from app.jobs.sfms_daily_forecasts import run_sfms_daily_forecasts
 
 logger = logging.getLogger(__name__)
 
 
-class BackfillRunType(StrEnum):
-    """SFMS daily job types supported by the backfill."""
-
-    ACTUAL = "actual"
-    FORECAST = "forecast"
-    BOTH = "both"
-
-
 @dataclass(frozen=True)
 class BackfillFailure:
-    """One failed date/job pair from a backfill run."""
+    """One failed date from a backfill run."""
 
-    run_type: BackfillRunType
     target_date: date
     error: Exception
 
     def message(self) -> str:
         """Return a compact failure message for logs and exceptions."""
-        return f"{self.run_type.value} {self.target_date.isoformat()}: {self.error}"
+        return f"{self.target_date.isoformat()}: {self.error}"
 
 
 def parse_date(value: str) -> date:
@@ -58,21 +41,6 @@ def parse_date(value: str) -> date:
         return datetime.strptime(value, "%Y-%m-%d").date()
     except ValueError as error:
         raise argparse.ArgumentTypeError("date must use YYYY-MM-DD") from error
-
-
-def parse_run_type(value: str) -> BackfillRunType:
-    """Parse a run type, accepting singular and plural names."""
-    aliases = {
-        "actual": BackfillRunType.ACTUAL,
-        "actuals": BackfillRunType.ACTUAL,
-        "forecast": BackfillRunType.FORECAST,
-        "forecasts": BackfillRunType.FORECAST,
-        "both": BackfillRunType.BOTH,
-    }
-    try:
-        return aliases[value.lower()]
-    except KeyError as error:
-        raise argparse.ArgumentTypeError("run type must be actual, forecast, or both") from error
 
 
 def iter_dates(start_date: date, end_date: date):
@@ -91,67 +59,41 @@ def actual_target_datetime(target_date: date) -> datetime:
     return datetime(target_date.year, target_date.month, target_date.day, tzinfo=timezone.utc)
 
 
-def forecast_run_datetime(seed_actual_date: date) -> datetime:
-    """Return a run datetime that makes forecasts seed from the requested actual date."""
-    return datetime(
-        seed_actual_date.year,
-        seed_actual_date.month,
-        seed_actual_date.day,
-        hour=23,
-        tzinfo=timezone.utc,
-    )
-
-
 async def run_backfill_step(
-    run_type: BackfillRunType,
     target_date: date,
     action: Callable[[], Awaitable[None]],
     failures: list[BackfillFailure],
     continue_on_error: bool,
 ) -> None:
-    """Run one date/job pair and optionally continue after a failure."""
-    logger.info("Starting SFMS %s backfill for %s", run_type.value, target_date)
+    """Run one actuals date and optionally continue after a failure."""
+    logger.info("Starting SFMS actuals backfill for %s", target_date)
     try:
         await action()
-        logger.info("Completed SFMS %s backfill for %s", run_type.value, target_date)
+        logger.info("Completed SFMS actuals backfill for %s", target_date)
     except Exception as error:
-        logger.exception("SFMS %s backfill failed for %s", run_type.value, target_date)
+        logger.exception("SFMS actuals backfill failed for %s", target_date)
         if not continue_on_error:
             raise
-        failures.append(BackfillFailure(run_type, target_date, error))
+        failures.append(BackfillFailure(target_date, error))
 
 
 async def run_sfms_daily_backfill(
     start_date: date,
     end_date: date,
-    run_type: BackfillRunType,
     continue_on_error: bool = False,
 ) -> None:
-    """Run SFMS daily jobs over an inclusive date range."""
+    """Run SFMS daily actuals over an inclusive date range."""
     failures: list[BackfillFailure] = []
 
     for target_date in iter_dates(start_date, end_date):
-        if run_type in (BackfillRunType.ACTUAL, BackfillRunType.BOTH):
-            await run_backfill_step(
-                BackfillRunType.ACTUAL,
-                target_date,
-                lambda target_date=target_date: run_sfms_daily_actuals(
-                    actual_target_datetime(target_date)
-                ),
-                failures,
-                continue_on_error,
-            )
-
-        if run_type in (BackfillRunType.FORECAST, BackfillRunType.BOTH):
-            await run_backfill_step(
-                BackfillRunType.FORECAST,
-                target_date,
-                lambda target_date=target_date: run_sfms_daily_forecasts(
-                    forecast_run_datetime(target_date)
-                ),
-                failures,
-                continue_on_error,
-            )
+        await run_backfill_step(
+            target_date,
+            lambda target_date=target_date: run_sfms_daily_actuals(
+                actual_target_datetime(target_date)
+            ),
+            failures,
+            continue_on_error,
+        )
 
     if failures:
         failure_messages = "; ".join(failure.message() for failure in failures)
@@ -160,8 +102,7 @@ async def run_sfms_daily_backfill(
 
 def build_arg_parser() -> argparse.ArgumentParser:
     """Build CLI parser for the SFMS daily backfill job."""
-    parser = argparse.ArgumentParser(description="Run SFMS daily jobs over a date range.")
-    parser.add_argument("--run-type", type=parse_run_type, required=True)
+    parser = argparse.ArgumentParser(description="Run SFMS daily actuals over a date range.")
     parser.add_argument("--start-date", type=parse_date, required=True)
     parser.add_argument("--end-date", type=parse_date, required=True)
     parser.add_argument(
@@ -182,7 +123,6 @@ def main() -> None:
             run_sfms_daily_backfill(
                 args.start_date,
                 args.end_date,
-                args.run_type,
                 continue_on_error=args.continue_on_error,
             )
         )

--- a/backend/packages/wps-api/src/app/jobs/sfms_daily_backfill.py
+++ b/backend/packages/wps-api/src/app/jobs/sfms_daily_backfill.py
@@ -1,0 +1,197 @@
+"""Run SFMS daily actual and forecast jobs over an inclusive date range.
+
+Usage:
+    python -m app.jobs.sfms_daily_backfill \
+        --run-type actual \
+        --start-date 2026-06-25 \
+        --end-date 2026-06-27
+
+    python -m app.jobs.sfms_daily_backfill \
+        --run-type both \
+        --start-date 2026-06-25 \
+        --end-date 2026-06-27
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from enum import StrEnum
+from typing import Awaitable, Callable
+
+from wps_shared.chatops_notification import send_chatops_notification
+from wps_shared.wps_logging import configure_logging
+
+from app.jobs.sfms_daily_actuals import run_sfms_daily_actuals
+from app.jobs.sfms_daily_forecasts import run_sfms_daily_forecasts
+
+logger = logging.getLogger(__name__)
+
+
+class BackfillRunType(StrEnum):
+    """SFMS daily job types supported by the backfill."""
+
+    ACTUAL = "actual"
+    FORECAST = "forecast"
+    BOTH = "both"
+
+
+@dataclass(frozen=True)
+class BackfillFailure:
+    """One failed date/job pair from a backfill run."""
+
+    run_type: BackfillRunType
+    target_date: date
+    error: Exception
+
+    def message(self) -> str:
+        """Return a compact failure message for logs and exceptions."""
+        return f"{self.run_type.value} {self.target_date.isoformat()}: {self.error}"
+
+
+def parse_date(value: str) -> date:
+    """Parse a YYYY-MM-DD CLI date."""
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("date must use YYYY-MM-DD") from error
+
+
+def parse_run_type(value: str) -> BackfillRunType:
+    """Parse a run type, accepting singular and plural names."""
+    aliases = {
+        "actual": BackfillRunType.ACTUAL,
+        "actuals": BackfillRunType.ACTUAL,
+        "forecast": BackfillRunType.FORECAST,
+        "forecasts": BackfillRunType.FORECAST,
+        "both": BackfillRunType.BOTH,
+    }
+    try:
+        return aliases[value.lower()]
+    except KeyError as error:
+        raise argparse.ArgumentTypeError("run type must be actual, forecast, or both") from error
+
+
+def iter_dates(start_date: date, end_date: date):
+    """Yield every date in an inclusive date range."""
+    if end_date < start_date:
+        raise ValueError("end date must be on or after start date")
+
+    current_date = start_date
+    while current_date <= end_date:
+        yield current_date
+        current_date += timedelta(days=1)
+
+
+def actual_target_datetime(target_date: date) -> datetime:
+    """Return the datetime shape expected by the daily actuals job."""
+    return datetime(target_date.year, target_date.month, target_date.day, tzinfo=timezone.utc)
+
+
+def forecast_run_datetime(seed_actual_date: date) -> datetime:
+    """Return a run datetime that makes forecasts seed from the requested actual date."""
+    return datetime(
+        seed_actual_date.year,
+        seed_actual_date.month,
+        seed_actual_date.day,
+        hour=23,
+        tzinfo=timezone.utc,
+    )
+
+
+async def run_backfill_step(
+    run_type: BackfillRunType,
+    target_date: date,
+    action: Callable[[], Awaitable[None]],
+    failures: list[BackfillFailure],
+    continue_on_error: bool,
+) -> None:
+    """Run one date/job pair and optionally continue after a failure."""
+    logger.info("Starting SFMS %s backfill for %s", run_type.value, target_date)
+    try:
+        await action()
+        logger.info("Completed SFMS %s backfill for %s", run_type.value, target_date)
+    except Exception as error:
+        logger.exception("SFMS %s backfill failed for %s", run_type.value, target_date)
+        if not continue_on_error:
+            raise
+        failures.append(BackfillFailure(run_type, target_date, error))
+
+
+async def run_sfms_daily_backfill(
+    start_date: date,
+    end_date: date,
+    run_type: BackfillRunType,
+    continue_on_error: bool = False,
+) -> None:
+    """Run SFMS daily jobs over an inclusive date range."""
+    failures: list[BackfillFailure] = []
+
+    for target_date in iter_dates(start_date, end_date):
+        if run_type in (BackfillRunType.ACTUAL, BackfillRunType.BOTH):
+            await run_backfill_step(
+                BackfillRunType.ACTUAL,
+                target_date,
+                lambda target_date=target_date: run_sfms_daily_actuals(
+                    actual_target_datetime(target_date)
+                ),
+                failures,
+                continue_on_error,
+            )
+
+        if run_type in (BackfillRunType.FORECAST, BackfillRunType.BOTH):
+            await run_backfill_step(
+                BackfillRunType.FORECAST,
+                target_date,
+                lambda target_date=target_date: run_sfms_daily_forecasts(
+                    forecast_run_datetime(target_date)
+                ),
+                failures,
+                continue_on_error,
+            )
+
+    if failures:
+        failure_messages = "; ".join(failure.message() for failure in failures)
+        raise RuntimeError(f"SFMS backfill completed with failures: {failure_messages}")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build CLI parser for the SFMS daily backfill job."""
+    parser = argparse.ArgumentParser(description="Run SFMS daily jobs over a date range.")
+    parser.add_argument("--run-type", type=parse_run_type, required=True)
+    parser.add_argument("--start-date", type=parse_date, required=True)
+    parser.add_argument("--end-date", type=parse_date, required=True)
+    parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        help="Attempt the remaining dates after a date fails, then fail the job at the end.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Main entry point for the backfill job."""
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(
+            run_sfms_daily_backfill(
+                args.start_date,
+                args.end_date,
+                args.run_type,
+                continue_on_error=args.continue_on_error,
+            )
+        )
+    except Exception as exception:
+        logger.exception("An exception occurred while running SFMS daily backfill")
+        send_chatops_notification("Encountered error running SFMS daily backfill", exception)
+        sys.exit(os.EX_SOFTWARE)
+
+
+if __name__ == "__main__":
+    configure_logging()
+    main()

--- a/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_backfill.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_backfill.py
@@ -1,0 +1,96 @@
+"""Unit tests for SFMS daily date-range backfill."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from app.jobs.sfms_daily_backfill import (
+    BackfillRunType,
+    actual_target_datetime,
+    forecast_run_datetime,
+    iter_dates,
+    run_sfms_daily_backfill,
+)
+
+MODULE_PATH = "app.jobs.sfms_daily_backfill"
+
+
+def test_iter_dates_includes_start_and_end_dates():
+    result = list(iter_dates(date(2026, 6, 25), date(2026, 6, 27)))
+
+    assert result == [date(2026, 6, 25), date(2026, 6, 26), date(2026, 6, 27)]
+
+
+def test_iter_dates_rejects_end_date_before_start_date():
+    with pytest.raises(ValueError, match="end date"):
+        list(iter_dates(date(2026, 6, 27), date(2026, 6, 25)))
+
+
+def test_actual_target_datetime_uses_midnight_utc():
+    result = actual_target_datetime(date(2026, 6, 25))
+
+    assert result == datetime(2026, 6, 25, tzinfo=timezone.utc)
+
+
+def test_forecast_run_datetime_uses_after_actuals_available_time():
+    result = forecast_run_datetime(date(2026, 6, 25))
+
+    assert result == datetime(2026, 6, 25, 23, tzinfo=timezone.utc)
+
+
+@pytest.mark.anyio
+async def test_run_sfms_daily_backfill_runs_actuals_for_each_date(mocker: MockerFixture):
+    mock_actuals = mocker.patch(f"{MODULE_PATH}.run_sfms_daily_actuals", new_callable=AsyncMock)
+    mock_forecasts = mocker.patch(f"{MODULE_PATH}.run_sfms_daily_forecasts", new_callable=AsyncMock)
+
+    await run_sfms_daily_backfill(date(2026, 6, 25), date(2026, 6, 26), BackfillRunType.ACTUAL)
+
+    assert [call.args[0] for call in mock_actuals.call_args_list] == [
+        datetime(2026, 6, 25, tzinfo=timezone.utc),
+        datetime(2026, 6, 26, tzinfo=timezone.utc),
+    ]
+    mock_forecasts.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_run_sfms_daily_backfill_runs_both_in_date_order(mocker: MockerFixture):
+    calls = []
+
+    async def run_actual(target_datetime: datetime):
+        calls.append(("actual", target_datetime))
+
+    async def run_forecast(run_datetime: datetime):
+        calls.append(("forecast", run_datetime))
+
+    mocker.patch(f"{MODULE_PATH}.run_sfms_daily_actuals", side_effect=run_actual)
+    mocker.patch(f"{MODULE_PATH}.run_sfms_daily_forecasts", side_effect=run_forecast)
+
+    await run_sfms_daily_backfill(date(2026, 6, 25), date(2026, 6, 26), BackfillRunType.BOTH)
+
+    assert calls == [
+        ("actual", datetime(2026, 6, 25, tzinfo=timezone.utc)),
+        ("forecast", datetime(2026, 6, 25, 23, tzinfo=timezone.utc)),
+        ("actual", datetime(2026, 6, 26, tzinfo=timezone.utc)),
+        ("forecast", datetime(2026, 6, 26, 23, tzinfo=timezone.utc)),
+    ]
+
+
+@pytest.mark.anyio
+async def test_run_sfms_daily_backfill_can_continue_after_error(mocker: MockerFixture):
+    mock_actuals = mocker.patch(
+        f"{MODULE_PATH}.run_sfms_daily_actuals",
+        new_callable=AsyncMock,
+        side_effect=[RuntimeError("first failed"), None],
+    )
+
+    with pytest.raises(RuntimeError, match="completed with failures"):
+        await run_sfms_daily_backfill(
+            date(2026, 6, 25),
+            date(2026, 6, 26),
+            BackfillRunType.ACTUAL,
+            continue_on_error=True,
+        )
+
+    assert mock_actuals.await_count == 2

--- a/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_backfill.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_backfill.py
@@ -7,9 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from app.jobs.sfms_daily_backfill import (
-    BackfillRunType,
     actual_target_datetime,
-    forecast_run_datetime,
     iter_dates,
     run_sfms_daily_backfill,
 )
@@ -34,46 +32,15 @@ def test_actual_target_datetime_uses_midnight_utc():
     assert result == datetime(2026, 6, 25, tzinfo=timezone.utc)
 
 
-def test_forecast_run_datetime_uses_after_actuals_available_time():
-    result = forecast_run_datetime(date(2026, 6, 25))
-
-    assert result == datetime(2026, 6, 25, 23, tzinfo=timezone.utc)
-
-
 @pytest.mark.anyio
 async def test_run_sfms_daily_backfill_runs_actuals_for_each_date(mocker: MockerFixture):
     mock_actuals = mocker.patch(f"{MODULE_PATH}.run_sfms_daily_actuals", new_callable=AsyncMock)
-    mock_forecasts = mocker.patch(f"{MODULE_PATH}.run_sfms_daily_forecasts", new_callable=AsyncMock)
 
-    await run_sfms_daily_backfill(date(2026, 6, 25), date(2026, 6, 26), BackfillRunType.ACTUAL)
+    await run_sfms_daily_backfill(date(2026, 6, 25), date(2026, 6, 26))
 
     assert [call.args[0] for call in mock_actuals.call_args_list] == [
         datetime(2026, 6, 25, tzinfo=timezone.utc),
         datetime(2026, 6, 26, tzinfo=timezone.utc),
-    ]
-    mock_forecasts.assert_not_awaited()
-
-
-@pytest.mark.anyio
-async def test_run_sfms_daily_backfill_runs_both_in_date_order(mocker: MockerFixture):
-    calls = []
-
-    async def run_actual(target_datetime: datetime):
-        calls.append(("actual", target_datetime))
-
-    async def run_forecast(run_datetime: datetime):
-        calls.append(("forecast", run_datetime))
-
-    mocker.patch(f"{MODULE_PATH}.run_sfms_daily_actuals", side_effect=run_actual)
-    mocker.patch(f"{MODULE_PATH}.run_sfms_daily_forecasts", side_effect=run_forecast)
-
-    await run_sfms_daily_backfill(date(2026, 6, 25), date(2026, 6, 26), BackfillRunType.BOTH)
-
-    assert calls == [
-        ("actual", datetime(2026, 6, 25, tzinfo=timezone.utc)),
-        ("forecast", datetime(2026, 6, 25, 23, tzinfo=timezone.utc)),
-        ("actual", datetime(2026, 6, 26, tzinfo=timezone.utc)),
-        ("forecast", datetime(2026, 6, 26, 23, tzinfo=timezone.utc)),
     ]
 
 
@@ -89,7 +56,6 @@ async def test_run_sfms_daily_backfill_can_continue_after_error(mocker: MockerFi
         await run_sfms_daily_backfill(
             date(2026, 6, 25),
             date(2026, 6, 26),
-            BackfillRunType.ACTUAL,
             continue_on_error=True,
         )
 

--- a/docs/SFMS_DAILY_JOBS.md
+++ b/docs/SFMS_DAILY_JOBS.md
@@ -1,76 +1,10 @@
-# Run SFMS Daily Jobs in Production for a Specific Date
+# Regenerate SFMS Daily Actuals
 
-Use a one-off Job created from the production CronJob. Do not edit the CronJob.
+Use `app.jobs.sfms_daily_backfill` to regenerate SFMS daily actuals for an inclusive date range. For a single actuals date, set `START_DATE` and `END_DATE` to the same date.
 
-Set these values first:
+Historical forecasts cannot be regenerated from WF1 because WF1 forecast records are overwritten by actuals. If today's forecast job needs to be rerun, use the deployed CronJob directly.
 
-```bash
-NAMESPACE=e1e498-prod
-DATE=2026-06-16
-DATE_ID=20260616
-```
-
-## Actuals
-
-```bash
-CRONJOB=$(oc -n ${NAMESPACE} get cronjob -o name | grep sfms-daily-actuals | head -1)
-oc -n ${NAMESPACE} create job sfms-daily-actuals-${DATE_ID} \
-  --from=${CRONJOB} \
-  --dry-run=client -o yaml > /tmp/sfms-daily-actuals-${DATE_ID}.yaml
-```
-
-Edit `/tmp/sfms-daily-actuals-${DATE_ID}.yaml` and append the date to the container `command`:
-
-```yaml
-- "app.jobs.sfms_daily_actuals"
-- "2026-06-16"
-```
-
-Run and watch it:
-
-```bash
-oc -n ${NAMESPACE} apply -f /tmp/sfms-daily-actuals-${DATE_ID}.yaml
-oc -n ${NAMESPACE} logs -f job/sfms-daily-actuals-${DATE_ID}
-```
-
-## Forecasts
-
-Choose the forecast CronJob to copy from:
-
-```bash
-oc -n ${NAMESPACE} get cronjob | grep sfms-forecast
-```
-
-Then create the one-off Job:
-
-```bash
-CRONJOB=cronjob/<cronjob-name>
-oc -n ${NAMESPACE} create job sfms-forecast-${DATE_ID} \
-  --from=${CRONJOB} \
-  --dry-run=client -o yaml > /tmp/sfms-forecast-${DATE_ID}.yaml
-```
-
-Edit `/tmp/sfms-forecast-${DATE_ID}.yaml` and append the date to the container `command`:
-
-```yaml
-- "app.jobs.sfms_daily_forecasts"
-- "2026-06-16"
-```
-
-Run and watch it:
-
-```bash
-oc -n ${NAMESPACE} apply -f /tmp/sfms-forecast-${DATE_ID}.yaml
-oc -n ${NAMESPACE} logs -f job/sfms-forecast-${DATE_ID}
-```
-
-Actuals process `DATE` at `20:00 UTC`. Forecasts process the next three forecast dates after `DATE`, each at `20:00 UTC`.
-
-## Date Range Backfill
-
-Use the `app.jobs.sfms_daily_backfill` wrapper when you need to regenerate actuals for more than one day. It runs dates sequentially in one OpenShift Job.
-
-The range is inclusive. Historical forecasts cannot be regenerated from WF1 because WF1 forecast records are overwritten by actuals.
+## OpenShift Backfill Job
 
 Generate a one-off Job from the actuals CronJob so it inherits the same image, database, WF1, Redis, object-store, and ChatOps configuration:
 
@@ -88,24 +22,6 @@ bash openshift/scripts/oc_generate_sfms_daily_backfill_job.sh prod \
   > /tmp/${JOB_NAME}.yaml
 ```
 
-The generated YAML replaces the copied CronJob command with:
-
-```yaml
-command:
-  - "uv"
-  - "run"
-  - "--package"
-  - "wps-api"
-  - "--no-sync"
-  - "python"
-  - "-m"
-  - "app.jobs.sfms_daily_backfill"
-  - "--start-date"
-  - "2026-06-25"
-  - "--end-date"
-  - "2026-06-27"
-```
-
 Set `CONTINUE_ON_ERROR=true` when generating the YAML if you want the pod to attempt later dates after a date fails. The Job will still fail at the end if any date failed.
 
 Run and watch it:
@@ -117,4 +33,4 @@ oc -n ${PROJ_TARGET} logs -f job/${JOB_NAME}
 
 Backfills overwrite the same SFMS raster keys for each target date and create new `sfms_run` / `sfms_run_log` rows for auditability.
 
-For actual FWI regeneration, the first date in the range needs the previous day's actual FFMC/DMC/DC rasters to exist unless the first date is one of the April/May Monday re-interpolation days. If those seed rasters are missing, the actual weather rasters are still regenerated but FWI calculation is skipped.
+For FWI regeneration, the first date in the range needs the previous day's actual FFMC/DMC/DC rasters to exist unless the first date is one of the April/May Monday re-interpolation days. If those seed rasters are missing, the actual weather rasters are still regenerated but FWI calculation is skipped.

--- a/docs/SFMS_DAILY_JOBS.md
+++ b/docs/SFMS_DAILY_JOBS.md
@@ -76,22 +76,25 @@ The range is inclusive:
 - `--run-type forecast` runs forecast jobs for every seed actual date from `START_DATE` through `END_DATE`. Each forecast job regenerates the next three forecast dates after that seed date.
 - `--run-type both` runs actuals, then forecasts, for each date in the range.
 
-Create a one-off Job from the actuals CronJob so it inherits the same image, database, WF1, Redis, object-store, and ChatOps configuration:
+Generate a one-off Job from the actuals CronJob so it inherits the same image, database, WF1, Redis, object-store, and ChatOps configuration:
 
 ```bash
-NAMESPACE=e1e498-prod
+PROJ_TARGET=e1e498-prod
 START_DATE=2026-06-25
 END_DATE=2026-06-27
 RUN_TYPE=both
-JOB_ID=${START_DATE//-/}-to-${END_DATE//-/}
+JOB_NAME=sfms-daily-backfill-${RUN_TYPE}-${START_DATE//-/}-to-${END_DATE//-/}
 
-CRONJOB=$(oc -n ${NAMESPACE} get cronjob -o name | grep sfms-daily-actuals | head -1)
-oc -n ${NAMESPACE} create job sfms-daily-backfill-${JOB_ID} \
-  --from=${CRONJOB} \
-  --dry-run=client -o yaml > /tmp/sfms-daily-backfill-${JOB_ID}.yaml
+PROJ_TARGET=${PROJ_TARGET} \
+START_DATE=${START_DATE} \
+END_DATE=${END_DATE} \
+RUN_TYPE=${RUN_TYPE} \
+JOB_NAME=${JOB_NAME} \
+bash openshift/scripts/oc_generate_sfms_daily_backfill_job.sh prod \
+  > /tmp/${JOB_NAME}.yaml
 ```
 
-Edit `/tmp/sfms-daily-backfill-${JOB_ID}.yaml` and replace the container `command` with:
+The generated YAML replaces the copied CronJob command with:
 
 ```yaml
 command:
@@ -111,13 +114,13 @@ command:
   - "2026-06-27"
 ```
 
-Add `--continue-on-error` if you want the pod to attempt later dates after a date fails. The Job will still fail at the end if any date failed.
+Set `CONTINUE_ON_ERROR=true` when generating the YAML if you want the pod to attempt later dates after a date fails. The Job will still fail at the end if any date failed.
 
 Run and watch it:
 
 ```bash
-oc -n ${NAMESPACE} apply -f /tmp/sfms-daily-backfill-${JOB_ID}.yaml
-oc -n ${NAMESPACE} logs -f job/sfms-daily-backfill-${JOB_ID}
+oc -n ${PROJ_TARGET} apply -f /tmp/${JOB_NAME}.yaml
+oc -n ${PROJ_TARGET} logs -f job/${JOB_NAME}
 ```
 
 Backfills overwrite the same SFMS raster keys for each target date and create new `sfms_run` / `sfms_run_log` rows for auditability.

--- a/docs/SFMS_DAILY_JOBS.md
+++ b/docs/SFMS_DAILY_JOBS.md
@@ -1,0 +1,125 @@
+# Run SFMS Daily Jobs in Production for a Specific Date
+
+Use a one-off Job created from the production CronJob. Do not edit the CronJob.
+
+Set these values first:
+
+```bash
+NAMESPACE=e1e498-prod
+DATE=2026-06-16
+DATE_ID=20260616
+```
+
+## Actuals
+
+```bash
+CRONJOB=$(oc -n ${NAMESPACE} get cronjob -o name | grep sfms-daily-actuals | head -1)
+oc -n ${NAMESPACE} create job sfms-daily-actuals-${DATE_ID} \
+  --from=${CRONJOB} \
+  --dry-run=client -o yaml > /tmp/sfms-daily-actuals-${DATE_ID}.yaml
+```
+
+Edit `/tmp/sfms-daily-actuals-${DATE_ID}.yaml` and append the date to the container `command`:
+
+```yaml
+- "app.jobs.sfms_daily_actuals"
+- "2026-06-16"
+```
+
+Run and watch it:
+
+```bash
+oc -n ${NAMESPACE} apply -f /tmp/sfms-daily-actuals-${DATE_ID}.yaml
+oc -n ${NAMESPACE} logs -f job/sfms-daily-actuals-${DATE_ID}
+```
+
+## Forecasts
+
+Choose the forecast CronJob to copy from:
+
+```bash
+oc -n ${NAMESPACE} get cronjob | grep sfms-forecast
+```
+
+Then create the one-off Job:
+
+```bash
+CRONJOB=cronjob/<cronjob-name>
+oc -n ${NAMESPACE} create job sfms-forecast-${DATE_ID} \
+  --from=${CRONJOB} \
+  --dry-run=client -o yaml > /tmp/sfms-forecast-${DATE_ID}.yaml
+```
+
+Edit `/tmp/sfms-forecast-${DATE_ID}.yaml` and append the date to the container `command`:
+
+```yaml
+- "app.jobs.sfms_daily_forecasts"
+- "2026-06-16"
+```
+
+Run and watch it:
+
+```bash
+oc -n ${NAMESPACE} apply -f /tmp/sfms-forecast-${DATE_ID}.yaml
+oc -n ${NAMESPACE} logs -f job/sfms-forecast-${DATE_ID}
+```
+
+Actuals process `DATE` at `20:00 UTC`. Forecasts process the next three forecast dates after `DATE`, each at `20:00 UTC`.
+
+## Date Range Backfill
+
+Use the `app.jobs.sfms_daily_backfill` wrapper when you need to regenerate more than one day. It runs dates sequentially in one OpenShift Job.
+
+The range is inclusive:
+
+- `--run-type actual` runs actuals for every date from `START_DATE` through `END_DATE`.
+- `--run-type forecast` runs forecast jobs for every seed actual date from `START_DATE` through `END_DATE`. Each forecast job regenerates the next three forecast dates after that seed date.
+- `--run-type both` runs actuals, then forecasts, for each date in the range.
+
+Create a one-off Job from the actuals CronJob so it inherits the same image, database, WF1, Redis, object-store, and ChatOps configuration:
+
+```bash
+NAMESPACE=e1e498-prod
+START_DATE=2026-06-25
+END_DATE=2026-06-27
+RUN_TYPE=both
+JOB_ID=${START_DATE//-/}-to-${END_DATE//-/}
+
+CRONJOB=$(oc -n ${NAMESPACE} get cronjob -o name | grep sfms-daily-actuals | head -1)
+oc -n ${NAMESPACE} create job sfms-daily-backfill-${JOB_ID} \
+  --from=${CRONJOB} \
+  --dry-run=client -o yaml > /tmp/sfms-daily-backfill-${JOB_ID}.yaml
+```
+
+Edit `/tmp/sfms-daily-backfill-${JOB_ID}.yaml` and replace the container `command` with:
+
+```yaml
+command:
+  - "uv"
+  - "run"
+  - "--package"
+  - "wps-api"
+  - "--no-sync"
+  - "python"
+  - "-m"
+  - "app.jobs.sfms_daily_backfill"
+  - "--run-type"
+  - "both"
+  - "--start-date"
+  - "2026-06-25"
+  - "--end-date"
+  - "2026-06-27"
+```
+
+Add `--continue-on-error` if you want the pod to attempt later dates after a date fails. The Job will still fail at the end if any date failed.
+
+Run and watch it:
+
+```bash
+oc -n ${NAMESPACE} apply -f /tmp/sfms-daily-backfill-${JOB_ID}.yaml
+oc -n ${NAMESPACE} logs -f job/sfms-daily-backfill-${JOB_ID}
+```
+
+Backfills overwrite the same SFMS raster keys for each target date and create new `sfms_run` / `sfms_run_log` rows for auditability.
+
+For actual FWI regeneration, the first date in the range needs the previous day's actual FFMC/DMC/DC rasters to exist unless the first date is one of the April/May Monday re-interpolation days. If those seed rasters are missing, the actual weather rasters are still regenerated but FWI calculation is skipped; forecast backfill for that seed date will then fail because forecasts require complete actual seed rasters.

--- a/docs/SFMS_DAILY_JOBS.md
+++ b/docs/SFMS_DAILY_JOBS.md
@@ -68,13 +68,9 @@ Actuals process `DATE` at `20:00 UTC`. Forecasts process the next three forecast
 
 ## Date Range Backfill
 
-Use the `app.jobs.sfms_daily_backfill` wrapper when you need to regenerate more than one day. It runs dates sequentially in one OpenShift Job.
+Use the `app.jobs.sfms_daily_backfill` wrapper when you need to regenerate actuals for more than one day. It runs dates sequentially in one OpenShift Job.
 
-The range is inclusive:
-
-- `--run-type actual` runs actuals for every date from `START_DATE` through `END_DATE`.
-- `--run-type forecast` runs forecast jobs for every seed actual date from `START_DATE` through `END_DATE`. Each forecast job regenerates the next three forecast dates after that seed date.
-- `--run-type both` runs actuals, then forecasts, for each date in the range.
+The range is inclusive. Historical forecasts cannot be regenerated from WF1 because WF1 forecast records are overwritten by actuals.
 
 Generate a one-off Job from the actuals CronJob so it inherits the same image, database, WF1, Redis, object-store, and ChatOps configuration:
 
@@ -82,13 +78,11 @@ Generate a one-off Job from the actuals CronJob so it inherits the same image, d
 PROJ_TARGET=e1e498-prod
 START_DATE=2026-06-25
 END_DATE=2026-06-27
-RUN_TYPE=both
-JOB_NAME=sfms-daily-backfill-${RUN_TYPE}-${START_DATE//-/}-to-${END_DATE//-/}
+JOB_NAME=sfms-daily-backfill-${START_DATE//-/}-to-${END_DATE//-/}
 
 PROJ_TARGET=${PROJ_TARGET} \
 START_DATE=${START_DATE} \
 END_DATE=${END_DATE} \
-RUN_TYPE=${RUN_TYPE} \
 JOB_NAME=${JOB_NAME} \
 bash openshift/scripts/oc_generate_sfms_daily_backfill_job.sh prod \
   > /tmp/${JOB_NAME}.yaml
@@ -106,8 +100,6 @@ command:
   - "python"
   - "-m"
   - "app.jobs.sfms_daily_backfill"
-  - "--run-type"
-  - "both"
   - "--start-date"
   - "2026-06-25"
   - "--end-date"
@@ -125,4 +117,4 @@ oc -n ${PROJ_TARGET} logs -f job/${JOB_NAME}
 
 Backfills overwrite the same SFMS raster keys for each target date and create new `sfms_run` / `sfms_run_log` rows for auditability.
 
-For actual FWI regeneration, the first date in the range needs the previous day's actual FFMC/DMC/DC rasters to exist unless the first date is one of the April/May Monday re-interpolation days. If those seed rasters are missing, the actual weather rasters are still regenerated but FWI calculation is skipped; forecast backfill for that seed date will then fail because forecasts require complete actual seed rasters.
+For actual FWI regeneration, the first date in the range needs the previous day's actual FFMC/DMC/DC rasters to exist unless the first date is one of the April/May Monday re-interpolation days. If those seed rasters are missing, the actual weather rasters are still regenerated but FWI calculation is skipped.

--- a/openshift/scripts/oc_generate_sfms_daily_backfill_job.sh
+++ b/openshift/scripts/oc_generate_sfms_daily_backfill_job.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Generate a one-off SFMS daily backfill Job from the deployed actuals CronJob.
+#
+# Usage:
+#   PROJ_TARGET=e1e498-prod \
+#   START_DATE=2026-06-25 \
+#   END_DATE=2026-06-27 \
+#   RUN_TYPE=both \
+#   JOB_NAME=sfms-daily-backfill-both-20260625-to-20260627 \
+#   bash openshift/scripts/oc_generate_sfms_daily_backfill_job.sh > /tmp/sfms-backfill.yaml
+#
+# Optional:
+#   CRONJOB=cronjob/sfms-daily-actuals-wps-prod  # use an explicit source CronJob
+#   CONTINUE_ON_ERROR=true                       # add --continue-on-error
+#   bash openshift/scripts/oc_generate_sfms_daily_backfill_job.sh prod
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SUFFIX="${1:-}"
+PROJ_TARGET="${PROJ_TARGET:-e1e498-dev}"
+RUN_TYPE="${RUN_TYPE:-both}"
+CONTINUE_ON_ERROR="${CONTINUE_ON_ERROR:-false}"
+
+usage() {
+    cat >&2 <<EOF
+Usage:
+  PROJ_TARGET=e1e498-prod START_DATE=YYYY-MM-DD END_DATE=YYYY-MM-DD RUN_TYPE=both \\
+    bash openshift/scripts/oc_generate_sfms_daily_backfill_job.sh > /tmp/sfms-backfill.yaml
+
+Required environment variables:
+  START_DATE   Inclusive first date to regenerate, YYYY-MM-DD.
+  END_DATE     Inclusive last date to regenerate, YYYY-MM-DD.
+
+Optional environment variables:
+  PROJ_TARGET         OpenShift namespace. Defaults to e1e498-dev.
+  RUN_TYPE            actual, forecast, or both. Defaults to both.
+  CRONJOB             Explicit source CronJob, e.g. cronjob/sfms-daily-actuals-wps-prod.
+  JOB_NAME            Output Job name. Defaults to sfms-daily-backfill-RUN_TYPE-START_DATE-to-END_DATE.
+  CONTINUE_ON_ERROR   true to add --continue-on-error. Defaults to false.
+
+Optional positional argument:
+  SUFFIX              Filter the discovered sfms-daily-actuals CronJob name.
+EOF
+}
+
+fail() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+validate_date() {
+    local value="$1"
+    [[ "${value}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || fail "date must use YYYY-MM-DD: ${value}"
+}
+
+validate_run_type() {
+    case "${RUN_TYPE}" in
+        actual | actuals | forecast | forecasts | both) ;;
+        *) fail "RUN_TYPE must be actual, forecast, or both: ${RUN_TYPE}" ;;
+    esac
+}
+
+discover_cronjob() {
+    local pattern="sfms-daily-actuals"
+    if [[ -n "${SUFFIX}" ]]; then
+        pattern="${pattern}.*${SUFFIX}"
+    fi
+
+    oc -n "${PROJ_TARGET}" get cronjob -o name |
+        grep "${pattern}" |
+        head -1 ||
+        true
+}
+
+require_oc_login() {
+    oc whoami >/dev/null 2>&1 || fail "please verify oc login"
+}
+
+build_command_json() {
+    local command_json
+    command_json=$(
+        printf '["uv","run","--package","wps-api","--no-sync","python","-m","app.jobs.sfms_daily_backfill","--run-type","%s","--start-date","%s","--end-date","%s"' \
+            "${RUN_TYPE}" \
+            "${START_DATE}" \
+            "${END_DATE}"
+    )
+    if [[ "${CONTINUE_ON_ERROR}" == "true" ]]; then
+        command_json="${command_json},\"--continue-on-error\""
+    fi
+    printf '%s]' "${command_json}"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+[[ -n "${START_DATE:-}" ]] || {
+    usage
+    fail "START_DATE is required"
+}
+[[ -n "${END_DATE:-}" ]] || {
+    usage
+    fail "END_DATE is required"
+}
+
+validate_date "${START_DATE}"
+validate_date "${END_DATE}"
+[[ "${END_DATE}" > "${START_DATE}" || "${END_DATE}" == "${START_DATE}" ]] ||
+    fail "END_DATE must be on or after START_DATE"
+validate_run_type
+require_oc_login
+
+START_ID="${START_DATE//-/}"
+END_ID="${END_DATE//-/}"
+JOB_NAME="${JOB_NAME:-sfms-daily-backfill-${RUN_TYPE}-${START_ID}-to-${END_ID}}"
+CRONJOB="${CRONJOB:-$(discover_cronjob)}"
+
+[[ -n "${CRONJOB}" ]] || fail "could not find an sfms-daily-actuals CronJob in ${PROJ_TARGET}"
+
+COMMAND_JSON="$(build_command_json)"
+PATCH_JSON="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/command\",\"value\":${COMMAND_JSON}}]"
+
+oc -n "${PROJ_TARGET}" create job "${JOB_NAME}" \
+    --from="${CRONJOB}" \
+    --dry-run=client \
+    -o yaml |
+    oc -n "${PROJ_TARGET}" patch \
+        --local \
+        -f - \
+        --type=json \
+        -p "${PATCH_JSON}" \
+        -o yaml

--- a/openshift/scripts/oc_generate_sfms_daily_backfill_job.sh
+++ b/openshift/scripts/oc_generate_sfms_daily_backfill_job.sh
@@ -6,8 +6,7 @@
 #   PROJ_TARGET=e1e498-prod \
 #   START_DATE=2026-06-25 \
 #   END_DATE=2026-06-27 \
-#   RUN_TYPE=both \
-#   JOB_NAME=sfms-daily-backfill-both-20260625-to-20260627 \
+#   JOB_NAME=sfms-daily-backfill-20260625-to-20260627 \
 #   bash openshift/scripts/oc_generate_sfms_daily_backfill_job.sh > /tmp/sfms-backfill.yaml
 #
 # Optional:
@@ -20,13 +19,12 @@ IFS=$'\n\t'
 
 SUFFIX="${1:-}"
 PROJ_TARGET="${PROJ_TARGET:-e1e498-dev}"
-RUN_TYPE="${RUN_TYPE:-both}"
 CONTINUE_ON_ERROR="${CONTINUE_ON_ERROR:-false}"
 
 usage() {
     cat >&2 <<EOF
 Usage:
-  PROJ_TARGET=e1e498-prod START_DATE=YYYY-MM-DD END_DATE=YYYY-MM-DD RUN_TYPE=both \\
+  PROJ_TARGET=e1e498-prod START_DATE=YYYY-MM-DD END_DATE=YYYY-MM-DD \\
     bash openshift/scripts/oc_generate_sfms_daily_backfill_job.sh > /tmp/sfms-backfill.yaml
 
 Required environment variables:
@@ -35,9 +33,8 @@ Required environment variables:
 
 Optional environment variables:
   PROJ_TARGET         OpenShift namespace. Defaults to e1e498-dev.
-  RUN_TYPE            actual, forecast, or both. Defaults to both.
   CRONJOB             Explicit source CronJob, e.g. cronjob/sfms-daily-actuals-wps-prod.
-  JOB_NAME            Output Job name. Defaults to sfms-daily-backfill-RUN_TYPE-START_DATE-to-END_DATE.
+  JOB_NAME            Output Job name. Defaults to sfms-daily-backfill-START_DATE-to-END_DATE.
   CONTINUE_ON_ERROR   true to add --continue-on-error. Defaults to false.
 
 Optional positional argument:
@@ -53,13 +50,6 @@ fail() {
 validate_date() {
     local value="$1"
     [[ "${value}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || fail "date must use YYYY-MM-DD: ${value}"
-}
-
-validate_run_type() {
-    case "${RUN_TYPE}" in
-        actual | actuals | forecast | forecasts | both) ;;
-        *) fail "RUN_TYPE must be actual, forecast, or both: ${RUN_TYPE}" ;;
-    esac
 }
 
 discover_cronjob() {
@@ -81,8 +71,7 @@ require_oc_login() {
 build_command_json() {
     local command_json
     command_json=$(
-        printf '["uv","run","--package","wps-api","--no-sync","python","-m","app.jobs.sfms_daily_backfill","--run-type","%s","--start-date","%s","--end-date","%s"' \
-            "${RUN_TYPE}" \
+        printf '["uv","run","--package","wps-api","--no-sync","python","-m","app.jobs.sfms_daily_backfill","--start-date","%s","--end-date","%s"' \
             "${START_DATE}" \
             "${END_DATE}"
     )
@@ -110,12 +99,11 @@ validate_date "${START_DATE}"
 validate_date "${END_DATE}"
 [[ "${END_DATE}" > "${START_DATE}" || "${END_DATE}" == "${START_DATE}" ]] ||
     fail "END_DATE must be on or after START_DATE"
-validate_run_type
 require_oc_login
 
 START_ID="${START_DATE//-/}"
 END_ID="${END_DATE//-/}"
-JOB_NAME="${JOB_NAME:-sfms-daily-backfill-${RUN_TYPE}-${START_ID}-to-${END_ID}}"
+JOB_NAME="${JOB_NAME:-sfms-daily-backfill-${START_ID}-to-${END_ID}}"
 CRONJOB="${CRONJOB:-$(discover_cronjob)}"
 
 [[ -n "${CRONJOB}" ]] || fail "could not find an sfms-daily-actuals CronJob in ${PROJ_TARGET}"


### PR DESCRIPTION
  - Adds `sfms_daily_backfill.py` to run SFMS actuals over an inclusive date range
  - Adds an OpenShift helper script to generate a one-off backfill Job YAML from the deployed SFMS actuals CronJob
  - Documents single date and date range SFMS regeneration workflows in `SFMS_DAILY_JOBS.md`
# Test Links:
[Landing Page](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5574-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
