### PR TITLE
HFI Calc Admin tweak

### DIFF
--- a/backend/packages/wps-api/src/app/tests/hfi/test_hfi_admin.py
+++ b/backend/packages/wps-api/src/app/tests/hfi/test_hfi_admin.py
@@ -1,82 +1,105 @@
 from datetime import datetime
 from wps_shared.db.models.hfi_calc import PlanningWeatherStation
-from app.hfi.hfi_admin import add_stations, get_next_order, get_next_order_by_planning_area, get_unique_planning_area_ids, remove_stations, update_station_ordering
+from app.hfi.hfi_admin import (
+    add_stations,
+    get_next_order,
+    get_next_order_by_planning_area,
+    get_unique_planning_area_ids,
+    remove_stations,
+    update_station_ordering,
+)
 from wps_shared.schemas.hfi_calc import HFIAdminAddedStation
 
 timestamp = datetime.fromisoformat("2019-06-10T18:42:49")
 
 
 def test_get_unique_planning_areas_dups():
-    stations = [PlanningWeatherStation(planning_area_id=1,
-                                       station_code=4,
-                                       order_of_appearance_in_planning_area_list=1),
-                PlanningWeatherStation(planning_area_id=1,
-                                       station_code=5,
-                                       order_of_appearance_in_planning_area_list=2)]
+    stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=4, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=5, order_of_appearance_in_planning_area_list=2
+        ),
+    ]
     res = get_unique_planning_area_ids(stations)
     assert res == [1]
 
 
 def test_get_unique_planning_areas_uniques():
-    stations = [PlanningWeatherStation(planning_area_id=1,
-                                       station_code=4,
-                                       order_of_appearance_in_planning_area_list=1),
-                PlanningWeatherStation(planning_area_id=2,
-                                       station_code=5,
-                                       order_of_appearance_in_planning_area_list=2)]
+    stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=4, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=2, station_code=5, order_of_appearance_in_planning_area_list=2
+        ),
+    ]
     res = get_unique_planning_area_ids(stations)
     assert res == [1, 2]
 
 
 def test_get_next_order_by_planning_area_no_stations():
-    """ No updated stations or existing stations means no ordering"""
+    """No updated stations or existing stations means no ordering"""
     res = get_next_order_by_planning_area([], [])
     assert res == {}
 
 
 def test_get_next_order_by_planning_area_with_updates():
-    """ Updated station list is the current list so its ordering takes precedence over existing stations
-        In this case the last existing station was removed so the next added station has order 2
+    """Updated station list is the current list so its ordering takes precedence over existing stations
+    In this case the last existing station was removed so the next added station has order 2
     """
-    updated_stations = [PlanningWeatherStation(planning_area_id=1,
-                                               station_code=4,
-                                               order_of_appearance_in_planning_area_list=1)]
-    existing_stations = [PlanningWeatherStation(planning_area_id=1,
-                                                station_code=4,
-                                                order_of_appearance_in_planning_area_list=1),
-                         PlanningWeatherStation(planning_area_id=1,
-                                                station_code=5,
-                                                order_of_appearance_in_planning_area_list=2)]
+    updated_stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=4, order_of_appearance_in_planning_area_list=1
+        )
+    ]
+    existing_stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=4, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=5, order_of_appearance_in_planning_area_list=2
+        ),
+    ]
     res = get_next_order_by_planning_area(updated_stations, existing_stations)
     assert res == {1: 2}
 
 
 def test_get_next_order_by_planning_area_no_updates():
-    """ No updated stations mean next order is max(existing_orders) + 1"""
+    """No updated stations mean next order is max(existing_orders) + 1"""
     updated_stations = []
-    existing_stations = [PlanningWeatherStation(planning_area_id=1,
-                                                station_code=4,
-                                                order_of_appearance_in_planning_area_list=1),
-                         PlanningWeatherStation(planning_area_id=1,
-                                                station_code=5,
-                                                order_of_appearance_in_planning_area_list=2)]
+    existing_stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=4, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=5, order_of_appearance_in_planning_area_list=2
+        ),
+    ]
     res = get_next_order_by_planning_area(updated_stations, existing_stations)
     assert res == {1: 3}
 
 
 def test_get_next_order_by_planning_area():
-    """ Next order is computed based on stations in each planning area """
+    """Next order is computed based on stations in each planning area"""
     planning_area_1 = 1
-    pa1_station1 = PlanningWeatherStation(planning_area_id=planning_area_1,
-                                          station_code=1,
-                                          order_of_appearance_in_planning_area_list=1)
-    pa1_station2 = PlanningWeatherStation(planning_area_id=planning_area_1,
-                                          station_code=2,
-                                          order_of_appearance_in_planning_area_list=2)
+    pa1_station1 = PlanningWeatherStation(
+        planning_area_id=planning_area_1,
+        station_code=1,
+        order_of_appearance_in_planning_area_list=1,
+    )
+    pa1_station2 = PlanningWeatherStation(
+        planning_area_id=planning_area_1,
+        station_code=2,
+        order_of_appearance_in_planning_area_list=2,
+    )
     planning_area_2 = 2
-    pa2_station1 = PlanningWeatherStation(planning_area_id=planning_area_2,
-                                          station_code=3,
-                                          order_of_appearance_in_planning_area_list=1)
+    pa2_station1 = PlanningWeatherStation(
+        planning_area_id=planning_area_2,
+        station_code=3,
+        order_of_appearance_in_planning_area_list=1,
+    )
 
     res = get_next_order_by_planning_area([], [pa1_station1, pa1_station2, pa2_station1])
     assert res[planning_area_1] == 3  # order 1 and 2 for pa1 are taken
@@ -84,7 +107,7 @@ def test_get_next_order_by_planning_area():
 
 
 def test_add_station():
-    """ Adding a station to a planning area with correct order """
+    """Adding a station to a planning area with correct order"""
     pa_order_dict = {1: 1}
     station_to_add = HFIAdminAddedStation(planning_area_id=1, station_code=1, fuel_type_id=1)
     username = "test_user"
@@ -94,7 +117,7 @@ def test_add_station():
 
 
 def test_add_stations():
-    """ Adding stations to a planning area with correct orders """
+    """Adding stations to a planning area with correct orders"""
     pa_order_dict = {1: 1}
     station_to_add_1 = HFIAdminAddedStation(planning_area_id=1, station_code=1, fuel_type_id=1)
     station_to_add_2 = HFIAdminAddedStation(planning_area_id=1, station_code=2, fuel_type_id=1)
@@ -111,7 +134,7 @@ def test_add_stations():
 
 
 def test_add_stations_different_planning_areas():
-    """ Adding stations to a planning area with correct orders """
+    """Adding stations to a planning area with correct orders"""
     pa_order_dict = {1: 2, 2: 3}
     station_to_add_1 = HFIAdminAddedStation(planning_area_id=1, station_code=1, fuel_type_id=1)
     station_to_add_2 = HFIAdminAddedStation(planning_area_id=2, station_code=2, fuel_type_id=1)
@@ -128,72 +151,84 @@ def test_add_stations_different_planning_areas():
 
 
 def test_update_order_all_stations_removed():
-    """ Correct station order for planning area when all stations are removed """
+    """Correct station order for planning area when all stations are removed"""
 
     # [planning_area_id] -> {(station_code, order)...}
     # planning area 1 has stations 1 and 2 removed
     planning_area_removed_stations = {1: {(1, 1), (2, 2)}}
-    all_planning_area_stations = [PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=1,
-                                                         order_of_appearance_in_planning_area_list=1),
-                                  PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=2,
-                                                         order_of_appearance_in_planning_area_list=2)]
+    all_planning_area_stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=1, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=2, order_of_appearance_in_planning_area_list=2
+        ),
+    ]
     res = update_station_ordering(planning_area_removed_stations, all_planning_area_stations)
     assert len(res) == 0  # no order updates since all stations are removed
 
 
 def test_update_order_last_station_removed():
-    """ Correct station order for planning area when all stations are removed """
+    """Correct station order for planning area when all stations are removed"""
 
     # [planning_area_id] -> {(station_code, order)...}
     # planning area 1 has stations 1 and 2 removed
     planning_area_removed_stations = {1: {(2, 2)}}
-    all_planning_area_stations = [PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=1,
-                                                         order_of_appearance_in_planning_area_list=1),
-                                  PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=2,
-                                                         order_of_appearance_in_planning_area_list=2)]
+    all_planning_area_stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=1, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=2, order_of_appearance_in_planning_area_list=2
+        ),
+    ]
     res = update_station_ordering(planning_area_removed_stations, all_planning_area_stations)
     assert res[0].planning_area_id == 1
     assert res[0].station_code == 1
-    assert res[0].order_of_appearance_in_planning_area_list == 1  # first station still has same order
+    assert (
+        res[0].order_of_appearance_in_planning_area_list == 1
+    )  # first station still has same order
 
 
 def test_update_order_first_station_removed():
-    """ Correct station order for planning area when all stations are removed """
+    """Correct station order for planning area when all stations are removed"""
 
     # [planning_area_id] -> {(station_code, order)...}
     # planning area 1 has stations 1 and 2 removed
     planning_area_removed_stations = {1: {(1, 1)}}
-    all_planning_area_stations = [PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=1,
-                                                         order_of_appearance_in_planning_area_list=1),
-                                  PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=2,
-                                                         order_of_appearance_in_planning_area_list=2)]
+    all_planning_area_stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=1, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=2, order_of_appearance_in_planning_area_list=2
+        ),
+    ]
     res = update_station_ordering(planning_area_removed_stations, all_planning_area_stations)
     assert res[0].planning_area_id == 1
     assert res[0].station_code == 2
-    assert res[0].order_of_appearance_in_planning_area_list == 1  # remaining station now has order 1
+    assert (
+        res[0].order_of_appearance_in_planning_area_list == 1
+    )  # remaining station now has order 1
 
 
 def test_update_order_middle_station_removed():
-    """ Correct station order for planning area when all stations are removed """
+    """Correct station order for planning area when all stations are removed"""
 
     # [planning_area_id] -> {(station_code, order)...}
     # planning area 1 has stations 1 and 2 removed
     planning_area_removed_stations = {1: {(2, 2)}}
-    all_planning_area_stations = [PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=1,
-                                                         order_of_appearance_in_planning_area_list=1),
-                                  PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=2,
-                                                         order_of_appearance_in_planning_area_list=2),
-                                  PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=3,
-                                                         order_of_appearance_in_planning_area_list=3)]
+    all_planning_area_stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=1, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=2, order_of_appearance_in_planning_area_list=2
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=3, order_of_appearance_in_planning_area_list=3
+        ),
+    ]
     res = update_station_ordering(planning_area_removed_stations, all_planning_area_stations)
 
     assert len(res) == 2
@@ -208,53 +243,105 @@ def test_update_order_middle_station_removed():
 
 
 def test_remove_station():
-    """ Removing a station marks it as deleted an updates remaining orders """
-    removals = [PlanningWeatherStation(planning_area_id=1,
-                                       station_code=1,
-                                       order_of_appearance_in_planning_area_list=1)]
-    all_planning_area_stations = [removals[0],
-                                  PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=2,
-                                                         order_of_appearance_in_planning_area_list=2),
-                                  PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=3,
-                                                         order_of_appearance_in_planning_area_list=3)]
-    timestamp = datetime.fromisoformat('2019-06-10T18:42:49')
-    username = 'test'
+    """Removing a station marks it as deleted an updates remaining orders"""
+    removals = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=1, order_of_appearance_in_planning_area_list=1
+        )
+    ]
+    all_planning_area_stations = [
+        removals[0],
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=2, order_of_appearance_in_planning_area_list=2
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=3, order_of_appearance_in_planning_area_list=3
+        ),
+    ]
+    timestamp = datetime.fromisoformat("2019-06-10T18:42:49")
+    username = "test"
     stations_to_remove, stations_with_order_updates = remove_stations(
-        removals, all_planning_area_stations, timestamp, username)
+        removals, all_planning_area_stations, timestamp, username
+    )
 
     assert stations_to_remove[0].planning_area_id == removals[0].planning_area_id
     assert stations_to_remove[0].station_code == removals[0].station_code
     assert stations_to_remove[0].order_of_appearance_in_planning_area_list is None
 
     assert len(stations_with_order_updates) == 2
-    assert stations_with_order_updates[0].planning_area_id == all_planning_area_stations[1].planning_area_id
+    assert (
+        stations_with_order_updates[0].planning_area_id
+        == all_planning_area_stations[1].planning_area_id
+    )
     assert stations_with_order_updates[0].station_code == all_planning_area_stations[1].station_code
-    assert stations_with_order_updates[0].order_of_appearance_in_planning_area_list == 1  # 2nd is 1st now
+    assert (
+        stations_with_order_updates[0].order_of_appearance_in_planning_area_list == 1
+    )  # 2nd is 1st now
 
-    assert stations_with_order_updates[1].planning_area_id == all_planning_area_stations[2].planning_area_id
+    assert (
+        stations_with_order_updates[1].planning_area_id
+        == all_planning_area_stations[2].planning_area_id
+    )
     assert stations_with_order_updates[1].station_code == all_planning_area_stations[2].station_code
-    assert stations_with_order_updates[1].order_of_appearance_in_planning_area_list == 2  # 3rd is 2nd now
+    assert (
+        stations_with_order_updates[1].order_of_appearance_in_planning_area_list == 2
+    )  # 3rd is 2nd now
+
+
+def test_remove_station_with_non_consecutive_order():
+    """Removing a station does not depend on the row id matching stored order"""
+    removals = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=2, order_of_appearance_in_planning_area_list=4
+        )
+    ]
+    all_planning_area_stations = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=1, order_of_appearance_in_planning_area_list=2
+        ),
+        removals[0],
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=3, order_of_appearance_in_planning_area_list=6
+        ),
+    ]
+    timestamp = datetime.fromisoformat("2019-06-10T18:42:49")
+    username = "test"
+    stations_to_remove, stations_with_order_updates = remove_stations(
+        removals, all_planning_area_stations, timestamp, username
+    )
+
+    assert stations_to_remove[0].station_code == removals[0].station_code
+    assert stations_to_remove[0].order_of_appearance_in_planning_area_list is None
+
+    assert len(stations_with_order_updates) == 2
+    assert stations_with_order_updates[0].station_code == 1
+    assert stations_with_order_updates[0].order_of_appearance_in_planning_area_list == 1
+    assert stations_with_order_updates[1].station_code == 3
+    assert stations_with_order_updates[1].order_of_appearance_in_planning_area_list == 2
 
 
 def test_remove_stations():
-    """ Removing stations marks them as deleted and updates remaining orders"""
-    removals = [PlanningWeatherStation(planning_area_id=1,
-                                       station_code=1,
-                                       order_of_appearance_in_planning_area_list=1),
-                PlanningWeatherStation(planning_area_id=1,
-                                       station_code=2,
-                                       order_of_appearance_in_planning_area_list=2)]
-    all_planning_area_stations = [removals[0],
-                                  removals[1],
-                                  PlanningWeatherStation(planning_area_id=1,
-                                                         station_code=3,
-                                                         order_of_appearance_in_planning_area_list=3)]
-    timestamp = datetime.fromisoformat('2019-06-10T18:42:49')
-    username = 'test'
+    """Removing stations marks them as deleted and updates remaining orders"""
+    removals = [
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=1, order_of_appearance_in_planning_area_list=1
+        ),
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=2, order_of_appearance_in_planning_area_list=2
+        ),
+    ]
+    all_planning_area_stations = [
+        removals[0],
+        removals[1],
+        PlanningWeatherStation(
+            planning_area_id=1, station_code=3, order_of_appearance_in_planning_area_list=3
+        ),
+    ]
+    timestamp = datetime.fromisoformat("2019-06-10T18:42:49")
+    username = "test"
     stations_to_remove, stations_with_order_updates = remove_stations(
-        removals, all_planning_area_stations, timestamp, username)
+        removals, all_planning_area_stations, timestamp, username
+    )
 
     assert len(stations_to_remove) == 2
     assert stations_to_remove[0].planning_area_id == removals[0].planning_area_id
@@ -266,25 +353,46 @@ def test_remove_stations():
     assert stations_to_remove[1].order_of_appearance_in_planning_area_list is None
 
     assert len(stations_with_order_updates) == 1
-    assert stations_with_order_updates[0].planning_area_id == all_planning_area_stations[2].planning_area_id
+    assert (
+        stations_with_order_updates[0].planning_area_id
+        == all_planning_area_stations[2].planning_area_id
+    )
     assert stations_with_order_updates[0].station_code == all_planning_area_stations[2].station_code
-    assert stations_with_order_updates[0].order_of_appearance_in_planning_area_list == 1  # last one left
+    assert (
+        stations_with_order_updates[0].order_of_appearance_in_planning_area_list == 1
+    )  # last one left
 
 
 def test_get_next_order_no_updated_or_existing():
-    """ If there are no updated or existing stations, the next order should be 1 """
+    """If there are no updated or existing stations, the next order should be 1"""
     assert get_next_order([], []) == 1
 
 
 def test_get_next_order_no_updated():
-    """ If there are no updated or existing stations, the next order should be 1 """
-    assert get_next_order([], [PlanningWeatherStation(planning_area_id=1,
-                                                      station_code=3,
-                                                      order_of_appearance_in_planning_area_list=1)]) == 2
+    """If there are no updated or existing stations, the next order should be 1"""
+    assert (
+        get_next_order(
+            [],
+            [
+                PlanningWeatherStation(
+                    planning_area_id=1, station_code=3, order_of_appearance_in_planning_area_list=1
+                )
+            ],
+        )
+        == 2
+    )
 
 
 def test_get_next_order_no_existing():
-    """ If there are no updated or existing stations, the next order should be 1 """
-    assert get_next_order([], [PlanningWeatherStation(planning_area_id=1,
-                                                      station_code=3,
-                                                      order_of_appearance_in_planning_area_list=1)]) == 2
+    """If there are no updated or existing stations, the next order should be 1"""
+    assert (
+        get_next_order(
+            [],
+            [
+                PlanningWeatherStation(
+                    planning_area_id=1, station_code=3, order_of_appearance_in_planning_area_list=1
+                )
+            ],
+        )
+        == 2
+    )

--- a/backend/packages/wps-shared/src/wps_shared/db/crud/hfi_calc.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/hfi_calc.py
@@ -2,7 +2,7 @@
 
 from typing import List, Tuple
 
-from sqlalchemy import desc, insert, update
+from sqlalchemy import desc, insert, tuple_, update
 from sqlalchemy.engine import Row
 from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.orm import Session
@@ -198,21 +198,22 @@ def get_planning_areas(session: Session, fire_centre_id: int):
 def get_stations_for_removal(session: Session, station_requests: List[HFIAdminRemovedStation]):
     """Returns the station model requested to remove, along with all
     stations in in planning area, in ascending order."""
-    remove_request_planning_area_ids = [request.planning_area_id for request in station_requests]
-    remove_request_station_codes = [request.station_code for request in station_requests]
+    remove_request_keys = [
+        (request.planning_area_id, request.station_code) for request in station_requests
+    ]
 
-    # ordering is 1-based, row_id is 0-based
-    remove_request_orders = [request.row_id + 1 for request in station_requests]
+    if not remove_request_keys:
+        return []
 
     stations_to_remove = (
         session.query(PlanningWeatherStation)
-        .filter(PlanningWeatherStation.planning_area_id.in_(remove_request_planning_area_ids))
-        .filter(PlanningWeatherStation.station_code.in_(remove_request_station_codes))
         .filter(
-            PlanningWeatherStation.order_of_appearance_in_planning_area_list.in_(
-                remove_request_orders
-            )
+            tuple_(
+                PlanningWeatherStation.planning_area_id,
+                PlanningWeatherStation.station_code,
+            ).in_(remove_request_keys)
         )
+        .filter(PlanningWeatherStation.is_deleted == False)
         .all()
     )
     return stations_to_remove

--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/ManageStationsModal.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/ManageStationsModal.tsx
@@ -114,6 +114,7 @@ export const ManageStationsModal = ({
               planningAreas={planningAreas}
               fuelTypes={fuelTypes}
               existingPlanningAreaStations={existingStations}
+              stationUpdateError={stationsUpdatedError}
               addStationOptions={{
                 planningAreaOptions: planning_areas,
                 stationOptions: stations,

--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/SaveStationUpdatesButton.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/SaveStationUpdatesButton.tsx
@@ -23,7 +23,7 @@ export interface SaveStationUpdatesButtonProps {
   testId?: string
   addedStations: StationAdminRow[]
   removedStations: StationAdminRow[]
-  handleSave: () => void
+  handleSave: () => void | Promise<void>
 }
 
 const SaveStationUpdatesButton = ({ addedStations, removedStations, handleSave }: SaveStationUpdatesButtonProps) => {

--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/StationListAdmin.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/StationListAdmin.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material'
+import { Alert, Box } from '@mui/material'
 import type { FuelType, PlanningArea } from '@wps/api/hfiCalculatorAPI'
 import type { AppDispatch } from 'app/store'
 import AdminCancelButton from 'features/hfiCalculator/components/stationAdmin/AdminCancelButton'
@@ -28,6 +28,7 @@ export interface StationListAdminProps {
   fuelTypes: Pick<FuelType, 'id' | 'abbrev'>[]
   addStationOptions?: AddStationOptions
   existingPlanningAreaStations: { [key: string]: StationAdminRow[] }
+  stationUpdateError?: string | null
   handleClose: () => void
 }
 
@@ -36,6 +37,7 @@ const StationListAdmin = ({
   planningAreas,
   addStationOptions,
   existingPlanningAreaStations,
+  stationUpdateError,
   handleClose
 }: StationListAdminProps) => {
   const dispatch: AppDispatch = useDispatch()
@@ -84,23 +86,30 @@ const StationListAdmin = ({
     })
   }
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const allAdded = Object.values(addedStations).flat()
     const allRemoved = Object.values(removedStations).flat()
     if (every(allAdded, addedStation => !isUndefined(addedStation.station) && !isUndefined(addedStation.fuelType))) {
-      dispatch(
+      const saved = await dispatch(
         fetchAddOrUpdateStations(
           fireCentreId,
           allAdded as Required<StationAdminRow>[],
-          allRemoved as Required<StationAdminRow>[]
+          allRemoved as Required<Pick<StationAdminRow, 'planningAreaId' | 'rowId' | 'station'>>[]
         )
       )
-      handleClose()
+      if (saved) {
+        handleClose()
+      }
     }
   }
 
   return (
     <Box sx={{ width: '100%', pl: 4 }} aria-labelledby="planning-areas-admin">
+      {stationUpdateError && (
+        <Alert severity="error" sx={{ mb: 2, mr: 4 }} data-testid="station-update-error">
+          {stationUpdateError}
+        </Alert>
+      )}
       {sortBy(planningAreas, planningArea => planningArea.order_of_appearance_in_list).map(area => (
         <PlanningAreaAdmin
           key={`planning-area-admin-${area.id}`}

--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/StationListAdmin.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/StationListAdmin.tsx
@@ -10,7 +10,7 @@ import type {
 import PlanningAreaAdmin from 'features/hfiCalculator/components/stationAdmin/PlanningAreaAdmin'
 import SaveStationUpdatesButton from 'features/hfiCalculator/components/stationAdmin/SaveStationUpdatesButton'
 import { fetchAddOrUpdateStations } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
-import { every, findIndex, isUndefined, maxBy, sortBy } from 'lodash'
+import { every, isUndefined, maxBy, sortBy } from 'lodash'
 import React, { useState } from 'react'
 import { useDispatch } from 'react-redux'
 
@@ -40,52 +40,47 @@ const StationListAdmin = ({
 }: StationListAdminProps) => {
   const dispatch: AppDispatch = useDispatch()
 
-  const [addedStations, setAddedStations] = useState<{ [key: string]: StationAdminRow[] }>(
-    Object.fromEntries(Object.keys(existingPlanningAreaStations).map(key => [key, []]))
-  )
+  const emptyRowsByPlanningArea = Object.fromEntries(planningAreas.map(planningArea => [planningArea.id, []]))
+  const [addedStations, setAddedStations] = useState<{ [key: string]: StationAdminRow[] }>(emptyRowsByPlanningArea)
   const [removedStations, setRemovedStations] = useState<{
     [key: string]: { planningAreaId: number; rowId: number; station: BasicWFWXStation }[]
-  }>(Object.fromEntries(Object.keys(existingPlanningAreaStations).map(key => [key, []])))
+  }>(emptyRowsByPlanningArea)
 
   /** Adds net new stations */
   const handleAddStation = (planningAreaId: number) => {
-    const maxRowId = maxBy(addedStations[planningAreaId], 'rowId')?.rowId
+    const currentRows = addedStations[planningAreaId] ?? []
+    const maxRowId = maxBy(currentRows, 'rowId')?.rowId
     const lastRowId = maxRowId ? maxRowId : 0
-    const currentRow = addedStations[planningAreaId].concat([{ planningAreaId, rowId: lastRowId + 1 }])
     setAddedStations({
       ...addedStations,
-      [planningAreaId]: currentRow
+      [planningAreaId]: currentRows.concat([{ planningAreaId, rowId: lastRowId + 1 }])
     })
   }
 
   /** Removes net new stations */
   const handleRemoveStation = (planningAreaId: number, rowId: number) => {
-    const currentlyAdded = addedStations[planningAreaId]
-    const idx = findIndex(currentlyAdded, r => r.rowId === rowId)
-    currentlyAdded.splice(idx, 1)
     setAddedStations({
       ...addedStations,
-      [planningAreaId]: currentlyAdded
+      [planningAreaId]: (addedStations[planningAreaId] ?? []).filter(row => row.rowId !== rowId)
     })
   }
 
   /** Edits net new stations */
   const handleEditStation = (planningAreaId: number, rowId: number, row: StationAdminRow) => {
-    const currentlyAdded = addedStations[planningAreaId]
-    const idx = findIndex(currentlyAdded, r => r.rowId === rowId)
-    currentlyAdded.splice(idx, 1, row)
     setAddedStations({
       ...addedStations,
-      [planningAreaId]: currentlyAdded
+      [planningAreaId]: (addedStations[planningAreaId] ?? []).map(currentRow =>
+        currentRow.rowId === rowId ? row : currentRow
+      )
     })
   }
 
   /** Removes existing stations, not net new ones */
   const handleRemoveExistingStation = (planningAreaId: number, rowId: number, station: BasicWFWXStation) => {
-    const currentRow = removedStations[planningAreaId].concat({ planningAreaId, rowId, station })
+    const currentRows = removedStations[planningAreaId] ?? []
     setRemovedStations({
       ...removedStations,
-      [planningAreaId]: currentRow
+      [planningAreaId]: currentRows.concat({ planningAreaId, rowId, station })
     })
   }
 

--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/stationListAdmin.test.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/stationListAdmin.test.tsx
@@ -13,6 +13,7 @@ describe('StationListAdmin', () => {
       {
         id: 1,
         name: 'Empty Planning Area',
+        fire_centre_id: 1,
         order_of_appearance_in_list: 1,
         stations: []
       }

--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/stationListAdmin.test.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/stationListAdmin.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { PlanningArea } from '@wps/api/hfiCalculatorAPI'
+import StationListAdmin from 'features/hfiCalculator/components/stationAdmin/StationListAdmin'
+import { Provider } from 'react-redux'
+import { vi } from 'vitest'
+import { createTestStore } from '@/test/testUtils'
+
+describe('StationListAdmin', () => {
+  it('can add a station row to a planning area with no existing stations', async () => {
+    const user = userEvent.setup()
+    const planningAreas = [
+      {
+        id: 1,
+        name: 'Empty Planning Area',
+        order_of_appearance_in_list: 1,
+        stations: []
+      }
+    ] as PlanningArea[]
+
+    const { getByTestId } = render(
+      <Provider store={createTestStore()}>
+        <StationListAdmin
+          fireCentreId={1}
+          planningAreas={planningAreas}
+          fuelTypes={[]}
+          existingPlanningAreaStations={{}}
+          handleClose={vi.fn()}
+        />
+      </Provider>
+    )
+
+    await user.click(getByTestId('admin-add-station-button'))
+
+    expect(getByTestId('new-pa-admin-station-1-1')).toBeInTheDocument()
+  })
+})

--- a/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/stationListAdmin.test.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/stationAdmin/stationListAdmin.test.tsx
@@ -1,23 +1,38 @@
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { PlanningArea } from '@wps/api/hfiCalculatorAPI'
+import { type PlanningArea, updateStations } from '@wps/api/hfiCalculatorAPI'
 import StationListAdmin from 'features/hfiCalculator/components/stationAdmin/StationListAdmin'
 import { Provider } from 'react-redux'
 import { vi } from 'vitest'
 import { createTestStore } from '@/test/testUtils'
 
+vi.mock('@wps/api/hfiCalculatorAPI', async importOriginal => {
+  const actual = await importOriginal<typeof import('@wps/api/hfiCalculatorAPI')>()
+  return {
+    ...actual,
+    updateStations: vi.fn()
+  }
+})
+
+const updateStationsMock = vi.mocked(updateStations)
+
 describe('StationListAdmin', () => {
+  beforeEach(() => {
+    updateStationsMock.mockReset()
+  })
+
+  const planningAreas = [
+    {
+      id: 1,
+      name: 'Empty Planning Area',
+      fire_centre_id: 1,
+      order_of_appearance_in_list: 1,
+      stations: []
+    }
+  ] as PlanningArea[]
+
   it('can add a station row to a planning area with no existing stations', async () => {
     const user = userEvent.setup()
-    const planningAreas = [
-      {
-        id: 1,
-        name: 'Empty Planning Area',
-        fire_centre_id: 1,
-        order_of_appearance_in_list: 1,
-        stations: []
-      }
-    ] as PlanningArea[]
 
     const { getByTestId } = render(
       <Provider store={createTestStore()}>
@@ -34,5 +49,73 @@ describe('StationListAdmin', () => {
     await user.click(getByTestId('admin-add-station-button'))
 
     expect(getByTestId('new-pa-admin-station-1-1')).toBeInTheDocument()
+  })
+
+  it('renders station update errors locally', () => {
+    const { getByTestId } = render(
+      <Provider store={createTestStore()}>
+        <StationListAdmin
+          fireCentreId={1}
+          planningAreas={planningAreas}
+          fuelTypes={[]}
+          existingPlanningAreaStations={{}}
+          stationUpdateError="station update failed"
+          handleClose={vi.fn()}
+        />
+      </Provider>
+    )
+
+    expect(getByTestId('station-update-error')).toHaveTextContent('station update failed')
+  })
+
+  it('keeps the modal open when station updates fail', async () => {
+    const user = userEvent.setup()
+    const handleClose = vi.fn()
+    updateStationsMock.mockRejectedValue(new Error('station update failed'))
+
+    const { getByTestId } = render(
+      <Provider store={createTestStore()}>
+        <StationListAdmin
+          fireCentreId={1}
+          planningAreas={planningAreas}
+          fuelTypes={[]}
+          existingPlanningAreaStations={{
+            1: [{ planningAreaId: 1, rowId: 1, station: { code: 1, name: 'Station 1' } }]
+          }}
+          handleClose={handleClose}
+        />
+      </Provider>
+    )
+
+    await user.click(getByTestId('admin-remove-button'))
+    await user.click(getByTestId('save-new-station-button'))
+
+    await waitFor(() => expect(updateStationsMock).toHaveBeenCalledTimes(1))
+    expect(handleClose).not.toHaveBeenCalled()
+  })
+
+  it('closes the modal when station updates succeed', async () => {
+    const user = userEvent.setup()
+    const handleClose = vi.fn()
+    updateStationsMock.mockResolvedValue(200)
+
+    const { getByTestId } = render(
+      <Provider store={createTestStore()}>
+        <StationListAdmin
+          fireCentreId={1}
+          planningAreas={planningAreas}
+          fuelTypes={[]}
+          existingPlanningAreaStations={{
+            1: [{ planningAreaId: 1, rowId: 1, station: { code: 1, name: 'Station 1' } }]
+          }}
+          handleClose={handleClose}
+        />
+      </Provider>
+    )
+
+    await user.click(getByTestId('admin-remove-button'))
+    await user.click(getByTestId('save-new-station-button'))
+
+    await waitFor(() => expect(handleClose).toHaveBeenCalledTimes(1))
   })
 })

--- a/web/apps/wps-web/src/features/hfiCalculator/slices/hfiCalculatorSlice.test.ts
+++ b/web/apps/wps-web/src/features/hfiCalculator/slices/hfiCalculatorSlice.test.ts
@@ -3,6 +3,8 @@ import hfiCalculatorDailiesReducer, {
   fetchFuelTypesStart,
   getHFIResultFailed,
   initialState,
+  loadStationUpdateEnd,
+  loadStationUpdateStart,
   pdfDownloadEnd,
   pdfDownloadStart
 } from 'features/hfiCalculator/slices/hfiCalculatorSlice'
@@ -29,6 +31,23 @@ describe('hfiCalculatorSlice', () => {
       expect(hfiCalculatorDailiesReducer(initialState, pdfDownloadEnd())).toEqual({
         ...initialState,
         pdfLoading: false
+      })
+    })
+    it('should set stationsUpdateLoading = true and clear station update errors when loadStationUpdateStart is called', () => {
+      expect(
+        hfiCalculatorDailiesReducer({ ...initialState, stationsUpdatedError: dummyError }, loadStationUpdateStart())
+      ).toEqual({
+        ...initialState,
+        stationsUpdateLoading: true,
+        stationsUpdatedError: null
+      })
+    })
+    it('should set stationsUpdateLoading = false when loadStationUpdateEnd is called', () => {
+      expect(
+        hfiCalculatorDailiesReducer({ ...initialState, stationsUpdateLoading: true }, loadStationUpdateEnd())
+      ).toEqual({
+        ...initialState,
+        stationsUpdateLoading: false
       })
     })
     it('should set a value for error state when fetchFuelTypesFailed is called', () => {

--- a/web/apps/wps-web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/apps/wps-web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -277,19 +277,20 @@ export const fetchAddOrUpdateStations =
     fireCentreId: number,
     addedStations: Required<StationAdminRow>[],
     removedStations: Required<Pick<StationAdminRow, 'planningAreaId' | 'rowId' | 'station'>>[]
-  ): AppThunk =>
+  ): AppThunk<Promise<boolean>> =>
   async dispatch => {
     try {
       dispatch(loadStationUpdateStart())
       await updateStations(fireCentreId, addedStations, removedStations)
       dispatch(loadStationUpdateEnd())
       dispatch(setChangeSaved(true))
+      return true
     } catch (err) {
       dispatch(loadStationUpdateEnd())
       const errorMessage = getErrorMessage(err)
       dispatch(setStationsUpdatedFailed(errorMessage))
-      dispatch(getHFIResultFailed(errorMessage))
       logError(err)
+      return false
     }
   }
 

--- a/web/apps/wps-web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/apps/wps-web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -17,8 +17,8 @@ import {
   updateStations
 } from '@wps/api/hfiCalculatorAPI'
 import { logError } from '@wps/utils/error'
+import { getErrorMessage } from '@wps/utils/getError'
 import type { AppThunk } from 'app/store'
-import axios from 'axios'
 import type {
   AddStationOptions,
   StationAdminRow
@@ -286,8 +286,7 @@ export const fetchAddOrUpdateStations =
       dispatch(setChangeSaved(true))
     } catch (err) {
       dispatch(loadStationUpdateEnd())
-      const errorMessage =
-        (axios.isAxiosError(err) ? err.response?.data.detail : (err as Error).toString()) ?? 'Failed to update stations'
+      const errorMessage = getErrorMessage(err)
       dispatch(setStationsUpdatedFailed(errorMessage))
       dispatch(getHFIResultFailed(errorMessage))
       logError(err)

--- a/web/apps/wps-web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
+++ b/web/apps/wps-web/src/features/hfiCalculator/slices/hfiCalculatorSlice.ts
@@ -83,6 +83,7 @@ const dailiesSlice = createSlice({
     },
     loadStationUpdateStart(state: HFICalculatorState) {
       state.stationsUpdateLoading = true
+      state.stationsUpdatedError = null
     },
     loadStationUpdateEnd(state: HFICalculatorState) {
       state.stationsUpdateLoading = false
@@ -284,11 +285,11 @@ export const fetchAddOrUpdateStations =
       dispatch(loadStationUpdateEnd())
       dispatch(setChangeSaved(true))
     } catch (err) {
-      if (axios.isAxiosError(err)) {
-        dispatch(getHFIResultFailed(err.response?.data.detail))
-      } else {
-        dispatch(getHFIResultFailed((err as Error).toString()))
-      }
+      dispatch(loadStationUpdateEnd())
+      const errorMessage =
+        (axios.isAxiosError(err) ? err.response?.data.detail : (err as Error).toString()) ?? 'Failed to update stations'
+      dispatch(setStationsUpdatedFailed(errorMessage))
+      dispatch(getHFIResultFailed(errorMessage))
       logError(err)
     }
   }

--- a/web/packages/api/src/hfiCalculatorAPI.ts
+++ b/web/packages/api/src/hfiCalculatorAPI.ts
@@ -204,6 +204,7 @@ export interface HFIAdminAddedStation {
 }
 export interface HFIAdminRemovedStation {
   planning_area_id: number
+  station_code: number
   row_id: number
 }
 

--- a/web/packages/utils/src/getError.test.ts
+++ b/web/packages/utils/src/getError.test.ts
@@ -17,5 +17,20 @@ describe('hfiReadySlice', () => {
       const error3 = 'some garbage'
       expect(getErrorMessage(error3)).toBe('some garbage')
     })
+
+    it('should return messages from FastAPI validation detail arrays', () => {
+      const error = {
+        response: {
+          data: {
+            detail: [
+              { loc: ['body', 'field_one'], msg: 'field one is required', type: 'missing' },
+              { loc: ['body', 'field_two'], msg: 'field two must be an integer', type: 'int_parsing' }
+            ]
+          }
+        }
+      }
+
+      expect(getErrorMessage(error)).toBe('field one is required, field two must be an integer')
+    })
   })
 })

--- a/web/packages/utils/src/getError.ts
+++ b/web/packages/utils/src/getError.ts
@@ -1,4 +1,10 @@
-export type ErrorWithDetails = { response: { data: { detail: unknown } } }
+export type ErrorWithDetails = { response?: { data?: { detail?: unknown } } }
+
+type FastApiValidationError = { msg: unknown }
+
+function hasMessage(value: unknown): value is FastApiValidationError {
+  return typeof value === 'object' && value !== null && 'msg' in value
+}
 
 function getDetail(error: ErrorWithDetails): string {
   const detail = error?.response?.data?.detail
@@ -10,7 +16,7 @@ function getDetail(error: ErrorWithDetails): string {
   if (Array.isArray(detail)) {
     return detail
       .map(item => {
-        if (typeof item === 'object' && item !== null && 'msg' in item) {
+        if (hasMessage(item)) {
           return String(item.msg)
         }
         return JSON.stringify(item)

--- a/web/packages/utils/src/getError.ts
+++ b/web/packages/utils/src/getError.ts
@@ -1,7 +1,32 @@
-export type ErrorWithDetails = { response: { data: { detail: string } } }
+export type ErrorWithDetails = { response: { data: { detail: unknown } } }
 
 function getDetail(error: ErrorWithDetails): string {
-  return error?.response?.data?.detail || ''
+  const detail = error?.response?.data?.detail
+
+  if (typeof detail === 'string') {
+    return detail
+  }
+
+  if (Array.isArray(detail)) {
+    return detail
+      .map(item => {
+        if (typeof item === 'object' && item !== null && 'msg' in item) {
+          return String(item.msg)
+        }
+        return JSON.stringify(item)
+      })
+      .join(', ')
+  }
+
+  if (detail === null || detail === undefined) {
+    return ''
+  }
+
+  if (typeof detail === 'object') {
+    return JSON.stringify(detail)
+  }
+
+  return String(detail)
 }
 
 export function getErrorMessage(error: unknown): string {


### PR DESCRIPTION
  - Use planning area + station code as the stable identity for station removals
  - Include station code in removed-station API payloads
  - Keep the station admin modal open until save succeeds
  - Show station update failures inside the modal
  - Clear station update errors on retry
  - Format FastAPI validation error arrays into readable messages


# Test Links:
[Landing Page](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5576-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
