### PR TITLE
TSConfig test fix

### DIFF
--- a/web/packages/api/package.json
+++ b/web/packages/api/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "coverage:ci": "vitest run --coverage",
     "clean": "rm -rf dist .turbo tsconfig.tsbuildinfo"

--- a/web/packages/api/tsconfig.build.json
+++ b/web/packages/api/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/web/packages/api/tsconfig.json
+++ b/web/packages/api/tsconfig.json
@@ -12,6 +12,5 @@
     "declarationMap": true,
     "customConditions": ["development"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/web/packages/ui/package.json
+++ b/web/packages/ui/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "coverage:ci": "vitest run --coverage",
     "clean": "rm -rf dist .turbo tsconfig.tsbuildinfo"

--- a/web/packages/ui/tsconfig.build.json
+++ b/web/packages/ui/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/setupTests.ts"]
+}

--- a/web/packages/ui/tsconfig.json
+++ b/web/packages/ui/tsconfig.json
@@ -8,6 +8,5 @@
     "customConditions": ["development"],
     "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom", "@wps/types"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/setupTests.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/web/packages/utils/package.json
+++ b/web/packages/utils/package.json
@@ -23,7 +23,7 @@
     "@wps/types": "workspace:*"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "coverage:ci": "vitest run --coverage",
     "clean": "rm -rf dist .turbo tsconfig.tsbuildinfo"

--- a/web/packages/utils/tsconfig.build.json
+++ b/web/packages/utils/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/web/packages/utils/tsconfig.json
+++ b/web/packages/utils/tsconfig.json
@@ -13,6 +13,5 @@
     "declarationMap": true,
     "customConditions": ["development"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
Fixes tsconfig setup. Typescript was ignoring test files in dev, so during local development if you open a test file in the packages touched by this PR, you would see issues with test definitions like `describe`, `it`, and `expect` saying something like:
>Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.

This was incorrect advice for the fix, the real reason was that typescript was ignoring test files in dev. This specifically adds a `tsconfig.build.json` for each package that ignores test files during builds.

# Test Links:
[Landing Page](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5580-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
