### PR TITLE
Insights: Fire Centre Layer

### DIFF
--- a/web/apps/wps-web/src/features/fba/components/map/FBAMap.tsx
+++ b/web/apps/wps-web/src/features/fba/components/map/FBAMap.tsx
@@ -6,8 +6,6 @@ import { createHillshadeVectorTileLayer, createVectorTileLayer, getStyleJson } f
 import { selectProvincialSummaryZones, selectRunDates } from 'app/rootReducer'
 import {
   fireCentreLabelStyler,
-  fireCentreLineStyler,
-  fireCentreStyler,
   fireShapeLabelStyler,
   fireShapeLineStyler,
   fireShapeStyler,
@@ -18,6 +16,7 @@ import ScalebarContainer from 'features/fba/components/map/ScaleBarContainer'
 import { extentsMap } from 'features/fba/fireCentreExtents'
 import { fireZoneExtentsMap } from 'features/fba/fireZoneUnitExtents'
 import { buildPMTilesURL } from 'features/fba/pmtilesBuilder'
+import { fireCentreLineStyler, fireCentreStyler } from 'features/map/fireCentreStylers'
 import { cloneDeep, isNull, isUndefined } from 'lodash'
 import { DateTime } from 'luxon'
 import { Map as OlMap, View } from 'ol'
@@ -27,16 +26,11 @@ import { boundingExtent } from 'ol/extent'
 import VectorTileLayer from 'ol/layer/VectorTile'
 import type MapBrowserEvent from 'ol/MapBrowserEvent'
 import { PMTilesVectorSource } from 'ol-pmtiles'
+import { createPMTilesVectorSource, getFireCentrePMTilesLayers } from '@/features/map/fireCentreLayer'
 import { BASEMAP_LAYER_NAME } from '@/features/sfmsInsights/components/map/layerDefinitions'
 import 'ol/ol.css'
 import { BC_EXTENT, CENTER_OF_BC } from '@wps/utils/constants'
-import {
-  BASEMAP_STYLE_URL,
-  BASEMAP_TILE_URL,
-  HILLSHADE_STYLE_URL,
-  HILLSHADE_TILE_URL,
-  PMTILES_BUCKET
-} from '@wps/utils/env'
+import { BASEMAP_STYLE_URL, BASEMAP_TILE_URL, HILLSHADE_STYLE_URL, HILLSHADE_TILE_URL } from '@wps/utils/env'
 import { fromLonLat } from 'ol/proj'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -68,11 +62,6 @@ const removeLayerByName = (map: OlMap, layerName: string) => {
   }
 }
 
-const createPMTilesVectorSource = (filename: string) =>
-  new PMTilesVectorSource({
-    url: `${PMTILES_BUCKET}${filename}`
-  })
-
 const FBAMap = (props: FBAMapProps) => {
   const { forDate, selectedFireCentre, selectedFireShape, setSelectedFireShape, runType, zoomSource, setZoomSource } =
     props
@@ -94,29 +83,13 @@ const FBAMap = (props: FBAMapProps) => {
   const scaleRef = useRef<HTMLDivElement | null>(null) as React.MutableRefObject<HTMLElement>
 
   // stable OpenLayers sources and layers
-  const fireCentreVectorSource = useMemo(() => createPMTilesVectorSource('fireCentres.pmtiles'), [])
   const fireShapeVectorSource = useMemo(() => createPMTilesVectorSource('fireZoneUnits.pmtiles'), [])
   const fireCentreLabelVectorSource = useMemo(() => createPMTilesVectorSource('fireCentreLabels.pmtiles'), [])
   const fireShapeLabelVectorSource = useMemo(() => createPMTilesVectorSource('fireZoneUnitLabels.pmtiles'), [])
 
-  const fireCentreVTL = useMemo(
-    () =>
-      new VectorTileLayer({
-        source: fireCentreVectorSource,
-        style: fireCentreStyler(undefined),
-        zIndex: 51
-      }),
-    [fireCentreVectorSource]
-  )
-
-  const fireCentreLineVTL = useMemo(
-    () =>
-      new VectorTileLayer({
-        source: fireCentreVectorSource,
-        style: fireCentreLineStyler(undefined),
-        zIndex: 52
-      }),
-    [fireCentreVectorSource]
+  const { fireCentreLayer: fireCentreVTL, fireCentreLineLayer: fireCentreLineVTL } = useMemo(
+    () => getFireCentrePMTilesLayers(),
+    []
   )
 
   const fireShapeVTL = useMemo(
@@ -283,7 +256,7 @@ const FBAMap = (props: FBAMapProps) => {
       const latestHFILayer = new VectorTileLayer({
         source: hfiSource,
         style: hfiStyler,
-        zIndex: 100,
+        zIndex: 54,
         minZoom: 4,
         properties: { name: hfiLayerName },
         visible: showHFI

--- a/web/apps/wps-web/src/features/fba/components/map/fbaMap.test.tsx
+++ b/web/apps/wps-web/src/features/fba/components/map/fbaMap.test.tsx
@@ -16,6 +16,30 @@ vi.mock('@wps/utils/vectorLayerUtils', async () => {
   }
 })
 
+vi.mock('ol-pmtiles', () => ({
+  PMTilesVectorSource: class MockPMTilesVectorSource {
+    addEventListener() {}
+
+    removeEventListener() {}
+
+    on() {
+      return this
+    }
+
+    once() {
+      return this
+    }
+
+    un() {
+      return this
+    }
+
+    getState() {
+      return 'ready'
+    }
+  }
+}))
+
 describe('FBAMap', () => {
   class ResizeObserver {
     observe() {

--- a/web/apps/wps-web/src/features/fba/components/map/featureStylers.ts
+++ b/web/apps/wps-web/src/features/fba/components/map/featureStylers.ts
@@ -1,5 +1,4 @@
 import type { FireShape, FireShapeStatusDetail } from '@wps/api/fbaAPI'
-import type { FireCentre } from '@wps/types/fireCentre'
 import { AdvisoryStatus } from '@wps/utils/constants'
 import { isUndefined, lowerCase, range, startCase } from 'lodash'
 import type * as ol from 'ol'
@@ -9,7 +8,6 @@ import { Fill, Stroke, Text } from 'ol/style'
 import CircleStyle from 'ol/style/Circle'
 import Style from 'ol/style/Style'
 
-const GREY_FILL = 'rgba(128, 128, 128, 0.8)'
 const EMPTY_FILL = 'rgba(0, 0, 0, 0.0)'
 export const ADVISORY_ORANGE_FILL = 'rgba(255, 147, 38, 0.4)'
 export const ADVISORY_RED_FILL = 'rgba(128, 0, 0, 0.4)'
@@ -36,33 +34,6 @@ export const fireCentreLabelStyler = (feature: RenderFeature | ol.Feature<Geomet
   return new Style({
     text: fireCentreTextStyler(feature)
   })
-}
-
-export const fireCentreStyler = (selectedFireCentre: FireCentre | undefined) => {
-  return (feature: RenderFeature | ol.Feature<Geometry>): Style => {
-    const fireCentreId = feature.getProperties().MOF_FIRE_CENTRE_NAME
-    const isSelected = selectedFireCentre && fireCentreId === selectedFireCentre.name
-
-    const fillColour = isSelected ? new Fill({ color: EMPTY_FILL }) : new Fill({ color: GREY_FILL })
-
-    return new Style({
-      fill: selectedFireCentre ? fillColour : undefined
-    })
-  }
-}
-
-export const fireCentreLineStyler = (selectedFireCentre: FireCentre | undefined) => {
-  return (feature: RenderFeature | ol.Feature<Geometry>): Style => {
-    const fireCentreId = feature.getProperties().MOF_FIRE_CENTRE_NAME
-    const isSelected = selectedFireCentre && fireCentreId === selectedFireCentre.name
-
-    return new Style({
-      stroke: new Stroke({
-        color: 'black',
-        width: isSelected ? 8 : 3
-      })
-    })
-  }
 }
 
 export const fireShapeStyler = (fireZoneStatuses: FireShapeStatusDetail[], showZoneStatus: boolean) => {

--- a/web/apps/wps-web/src/features/map/fireCentreLayer.test.ts
+++ b/web/apps/wps-web/src/features/map/fireCentreLayer.test.ts
@@ -1,0 +1,74 @@
+import {
+  FIRE_CENTRE_LAYER_NAME,
+  FIRE_CENTRE_LINE_LAYER_NAME,
+  getFireCentreLinePMTilesLayer,
+  getFireCentrePMTilesLayers
+} from '@/features/map/fireCentreLayer'
+
+// mock ol-pmtiles to prevent it from using real PMTiles
+vi.mock('ol-pmtiles', () => ({
+  PMTilesVectorSource: class MockPMTilesVectorSource {
+    constructor(public options: { url: string }) {}
+
+    addEventListener() {}
+
+    removeEventListener() {}
+
+    on() {
+      return this
+    }
+
+    once() {
+      return this
+    }
+
+    un() {
+      return this
+    }
+
+    getState() {
+      return 'ready'
+    }
+  }
+}))
+
+describe('fireCentreLayerDefinitions', () => {
+  describe('getFireCentreLinePMTilesLayer', () => {
+    it('should create only a fire centre line layer', () => {
+      const layer = getFireCentreLinePMTilesLayer({ zIndex: 54 })
+
+      expect(layer.getProperties().name).toBe(FIRE_CENTRE_LINE_LAYER_NAME)
+      expect(layer.getZIndex()).toBe(54)
+    })
+  })
+
+  describe('getFireCentrePMTilesLayers', () => {
+    it('should create only fire centre fill and line layers', () => {
+      const layers = getFireCentrePMTilesLayers()
+
+      expect(Object.keys(layers)).toEqual(['fireCentreLayer', 'fireCentreLineLayer'])
+      expect(layers.fireCentreLayer.getProperties().name).toBe(FIRE_CENTRE_LAYER_NAME)
+      expect(layers.fireCentreLineLayer.getProperties().name).toBe(FIRE_CENTRE_LINE_LAYER_NAME)
+    })
+
+    it('should share a single PMTiles source between fire centre layers', () => {
+      const { fireCentreLayer, fireCentreLineLayer } = getFireCentrePMTilesLayers()
+
+      expect(fireCentreLayer.getSource()).toBe(fireCentreLineLayer.getSource())
+    })
+
+    it('should use the default FBA z-indexes', () => {
+      const { fireCentreLayer, fireCentreLineLayer } = getFireCentrePMTilesLayers()
+
+      expect(fireCentreLayer.getZIndex()).toBe(51)
+      expect(fireCentreLineLayer.getZIndex()).toBe(52)
+    })
+
+    it('should allow SFMS to place fire centre boundaries above raster layers', () => {
+      const { fireCentreLayer, fireCentreLineLayer } = getFireCentrePMTilesLayers({ zIndex: 54 })
+
+      expect(fireCentreLayer.getZIndex()).toBe(54)
+      expect(fireCentreLineLayer.getZIndex()).toBe(55)
+    })
+  })
+})

--- a/web/apps/wps-web/src/features/map/fireCentreLayer.ts
+++ b/web/apps/wps-web/src/features/map/fireCentreLayer.ts
@@ -1,0 +1,59 @@
+import type { FireCentre } from '@wps/types/fireCentre'
+import { PMTILES_BUCKET } from '@wps/utils/env'
+import VectorTileLayer from 'ol/layer/VectorTile'
+import { PMTilesVectorSource } from 'ol-pmtiles'
+import { fireCentreLineStyler, fireCentreStyler } from '@/features/map/fireCentreStylers'
+
+export const FIRE_CENTRE_LAYER_NAME = 'fireCentreVector'
+export const FIRE_CENTRE_LINE_LAYER_NAME = 'fireCentreLineVector'
+const FIRE_CENTRES_PMTILES_FILENAME = 'fireCentres.pmtiles'
+const DEFAULT_FIRE_CENTRE_Z_INDEX = 51
+const DEFAULT_FIRE_CENTRE_LINE_Z_INDEX = 52
+
+export interface FireCentrePMTilesLayerOptions {
+  selectedFireCentre?: FireCentre
+  source?: PMTilesVectorSource
+  zIndex?: number
+}
+
+export const createPMTilesVectorSource = (filename: string) =>
+  new PMTilesVectorSource({
+    url: `${PMTILES_BUCKET}${filename}`
+  })
+
+export const createFireCentrePMTilesSource = () => createPMTilesVectorSource(FIRE_CENTRES_PMTILES_FILENAME)
+
+export const getFireCentrePMTilesLayer = ({
+  selectedFireCentre,
+  source = createFireCentrePMTilesSource(),
+  zIndex = DEFAULT_FIRE_CENTRE_Z_INDEX
+}: FireCentrePMTilesLayerOptions = {}) =>
+  new VectorTileLayer({
+    source,
+    style: fireCentreStyler(selectedFireCentre),
+    zIndex,
+    properties: { name: FIRE_CENTRE_LAYER_NAME }
+  })
+
+export const getFireCentreLinePMTilesLayer = ({
+  selectedFireCentre,
+  source = createFireCentrePMTilesSource(),
+  zIndex = DEFAULT_FIRE_CENTRE_LINE_Z_INDEX
+}: FireCentrePMTilesLayerOptions = {}) =>
+  new VectorTileLayer({
+    source,
+    style: fireCentreLineStyler(selectedFireCentre),
+    zIndex,
+    properties: { name: FIRE_CENTRE_LINE_LAYER_NAME }
+  })
+
+export const getFireCentrePMTilesLayers = ({
+  selectedFireCentre,
+  zIndex = DEFAULT_FIRE_CENTRE_Z_INDEX
+}: FireCentrePMTilesLayerOptions = {}) => {
+  const source = createFireCentrePMTilesSource()
+  const fireCentreLayer = getFireCentrePMTilesLayer({ selectedFireCentre, source, zIndex })
+  const fireCentreLineLayer = getFireCentreLinePMTilesLayer({ selectedFireCentre, source, zIndex: zIndex + 1 })
+
+  return { fireCentreLayer, fireCentreLineLayer }
+}

--- a/web/apps/wps-web/src/features/map/fireCentreLayer.ts
+++ b/web/apps/wps-web/src/features/map/fireCentreLayer.ts
@@ -23,7 +23,7 @@ export const createPMTilesVectorSource = (filename: string) =>
 
 export const createFireCentrePMTilesSource = () => createPMTilesVectorSource(FIRE_CENTRES_PMTILES_FILENAME)
 
-export const getFireCentrePMTilesLayer = ({
+export const getFireCentreHighlightPMTilesLayer = ({
   selectedFireCentre,
   source = createFireCentrePMTilesSource(),
   zIndex = DEFAULT_FIRE_CENTRE_Z_INDEX
@@ -52,7 +52,7 @@ export const getFireCentrePMTilesLayers = ({
   zIndex = DEFAULT_FIRE_CENTRE_Z_INDEX
 }: FireCentrePMTilesLayerOptions = {}) => {
   const source = createFireCentrePMTilesSource()
-  const fireCentreLayer = getFireCentrePMTilesLayer({ selectedFireCentre, source, zIndex })
+  const fireCentreLayer = getFireCentreHighlightPMTilesLayer({ selectedFireCentre, source, zIndex })
   const fireCentreLineLayer = getFireCentreLinePMTilesLayer({ selectedFireCentre, source, zIndex: zIndex + 1 })
 
   return { fireCentreLayer, fireCentreLineLayer }

--- a/web/apps/wps-web/src/features/map/fireCentreStylers.ts
+++ b/web/apps/wps-web/src/features/map/fireCentreStylers.ts
@@ -1,0 +1,36 @@
+import type { FireCentre } from '@wps/types/fireCentre'
+import type * as ol from 'ol'
+import type Geometry from 'ol/geom/Geometry'
+import type RenderFeature from 'ol/render/Feature'
+import { Fill, Stroke } from 'ol/style'
+import Style from 'ol/style/Style'
+
+const GREY_FILL = 'rgba(128, 128, 128, 0.8)'
+const EMPTY_FILL = 'rgba(0, 0, 0, 0.0)'
+
+export const fireCentreStyler = (selectedFireCentre: FireCentre | undefined) => {
+  return (feature: RenderFeature | ol.Feature<Geometry>): Style => {
+    const fireCentreId = feature.getProperties().MOF_FIRE_CENTRE_NAME
+    const isSelected = selectedFireCentre && fireCentreId === selectedFireCentre.name
+
+    const fillColour = isSelected ? new Fill({ color: EMPTY_FILL }) : new Fill({ color: GREY_FILL })
+
+    return new Style({
+      fill: selectedFireCentre ? fillColour : undefined
+    })
+  }
+}
+
+export const fireCentreLineStyler = (selectedFireCentre: FireCentre | undefined) => {
+  return (feature: RenderFeature | ol.Feature<Geometry>): Style => {
+    const fireCentreId = feature.getProperties().MOF_FIRE_CENTRE_NAME
+    const isSelected = selectedFireCentre && fireCentreId === selectedFireCentre.name
+
+    return new Style({
+      stroke: new Stroke({
+        color: 'black',
+        width: isSelected ? 8 : 3
+      })
+    })
+  }
+}

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/SFMSMap.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/SFMSMap.tsx
@@ -16,6 +16,7 @@ import type { DateTime } from 'luxon'
 import { Map as OlMap, View } from 'ol'
 import { defaults as defaultControls } from 'ol/control'
 import { boundingExtent } from 'ol/extent'
+import { getFireCentreLinePMTilesLayer } from '@/features/map/fireCentreLayer'
 import { LayerManager, type RasterError } from '@/features/sfmsInsights/components/map/layerManager'
 import RasterErrorNotification from '@/features/sfmsInsights/components/map/RasterErrorNotification'
 import {
@@ -25,7 +26,7 @@ import {
 import 'ol/ol.css'
 import { selectToken } from 'app/rootReducer'
 import { fromLonLat } from 'ol/proj'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 const MapContext = React.createContext<OlMap | null>(null)
@@ -67,11 +68,12 @@ const SFMSMap = ({ snowDate, rasterDate, rasterType = 'fwi', showSnow = true }: 
 
   const rasterLayerManagerRef = useRef(new LayerManager({ onLoadingChange: handleLoadingChange, trackLoading: true }))
   const snowLayerManagerRef = useRef(new LayerManager({ trackLoading: false }))
+  const fireCentreLineLayer = useMemo(() => getFireCentreLinePMTilesLayer({ zIndex: 54 }), [])
 
   useEffect(() => {
     const mapObject = new OlMap({
       target: mapRef.current,
-      layers: [],
+      layers: [fireCentreLineLayer],
       controls: defaultControls(),
       view: new View({
         zoom: 5,
@@ -100,7 +102,7 @@ const SFMSMap = ({ snowDate, rasterDate, rasterType = 'fwi', showSnow = true }: 
     return () => {
       mapObject.setTarget('')
     }
-  }, [])
+  }, [fireCentreLineLayer])
 
   useEffect(() => {
     snowLayerManagerRef.current.updateLayer(!isNull(snowDate) && showSnow ? getSnowPMTilesLayer(snowDate, token) : null)

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsMap.test.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsMap.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@wps/utils/vectorLayerUtils', async () => {
   }
 })
 
-vi.mock('features/map/fireCentreLayerDefinitions', () => ({
+vi.mock('@/features/map/fireCentreLayer', () => ({
   getFireCentreLinePMTilesLayer: vi.fn()
 }))
 

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsMap.test.tsx
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsMap.test.tsx
@@ -3,6 +3,7 @@ import { createVectorTileLayer, getStyleJson } from '@wps/utils/vectorLayerUtils
 import { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
 import type { Mock } from 'vitest'
+import { getFireCentreLinePMTilesLayer } from '@/features/map/fireCentreLayer'
 import * as layerDefinitions from '@/features/sfmsInsights/components/map/layerDefinitions'
 import type { RasterError } from '@/features/sfmsInsights/components/map/layerManager'
 import SFMSMap from '@/features/sfmsInsights/components/map/SFMSMap'
@@ -14,6 +15,10 @@ vi.mock('@wps/utils/vectorLayerUtils', async () => {
     createVectorTileLayer: vi.fn()
   }
 })
+
+vi.mock('features/map/fireCentreLayerDefinitions', () => ({
+  getFireCentreLinePMTilesLayer: vi.fn()
+}))
 
 type LoadingChangeFn = (isLoading: boolean, error?: RasterError) => void
 const mockLayerManagerInstances: Array<{ onLoadingChange?: LoadingChangeFn; setMap: Mock; updateLayer: Mock }> = []
@@ -61,6 +66,7 @@ describe('SFMSMap', () => {
     getMinZoom: vi.fn(() => 4)
   }
   const mockFireWeatherLayer = createLayerMock('fwiRaster')
+  const mockFireCentreLineLayer = createLayerMock('fireCentreLineVector')
 
   const makeStore = (token = 'test-token') =>
     createTestStore({
@@ -87,12 +93,19 @@ describe('SFMSMap', () => {
     ;(createVectorTileLayer as Mock).mockResolvedValue(createLayerMock('base'))
     ;(layerDefinitions.getSnowPMTilesLayer as Mock).mockReturnValue(mockSnowLayer)
     ;(layerDefinitions.getRasterLayer as Mock).mockReturnValue(mockFireWeatherLayer)
+    ;(getFireCentreLinePMTilesLayer as Mock).mockReturnValue(mockFireCentreLineLayer)
   })
 
   it('should render the map', () => {
     const { getByTestId } = renderWithStore(<SFMSMap snowDate={null} rasterDate={DateTime.fromISO('2025-11-02')} />)
     const map = getByTestId('sfms-map')
     expect(map).toBeVisible()
+  })
+
+  it('should create only the persistent fire centre boundary layer above raster layers', () => {
+    renderWithStore(<SFMSMap snowDate={null} rasterDate={DateTime.fromISO('2025-11-02')} />)
+
+    expect(getFireCentreLinePMTilesLayer).toHaveBeenCalledWith({ zIndex: 54 })
   })
 
   it('should not add snow layer when snowDate is null', () => {


### PR DESCRIPTION
- Centralizes the fire centre layers to `features/map` for use in both apps that currently use them (ASA & SFMS Insights)
- Adds Fire Centres to SFMS Insights without labels
- Adjusts ASA layering index to bring labels above the HFI pixels
- closes #5579 
# Test Links:
[Landing Page](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5591-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
