### PR TITLE
SFMSng: No data values

### DIFF
--- a/backend/packages/wps-sfms/src/wps_sfms/processors/fwi.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/processors/fwi.py
@@ -30,6 +30,7 @@ from wps_shared.sfms.raster_addresser import FWIParameter, SFMSInterpolatedWeath
 from wps_shared.utils.s3 import set_s3_gdal_config
 from wps_shared.utils.s3_client import S3Client
 
+from wps_sfms.interpolation.common import SFMS_NO_DATA
 from wps_sfms.publish import publish_dataset
 from wps_sfms.sfmsng_raster_addresser import FWIInputs
 
@@ -49,6 +50,10 @@ class FWIDatasets:
 class FWIResult(NamedTuple):
     values: np.ndarray
     nodata_value: float
+
+
+def create_sfms_nodata_output_array(reference: np.ndarray) -> np.ndarray:
+    return np.full(reference.shape, SFMS_NO_DATA, dtype=reference.dtype)
 
 
 class FWICalculator(ABC):
@@ -92,7 +97,7 @@ class FFMCCalculator(FWICalculator):
         wind_ds = datasets.weather[SFMSInterpolatedWeatherParameter.WIND_SPEED]
         ffmc_prev_ds = datasets.index[FWIParameter.FFMC]
 
-        ffmc_prev, nodata_value = ffmc_prev_ds.replace_nodata_with(np.nan)
+        ffmc_prev, _ = ffmc_prev_ds.replace_nodata_with(np.nan)
         temp, _ = temp_ds.replace_nodata_with(np.nan)
         rh, _ = rh_ds.replace_nodata_with(np.nan)
         prec, _ = precip_ds.replace_nodata_with(np.nan)
@@ -100,7 +105,7 @@ class FFMCCalculator(FWICalculator):
 
         mask = np.isnan(ffmc_prev) | np.isnan(temp) | np.isnan(rh) | np.isnan(prec) | np.isnan(ws)
         valid = ~mask
-        values = np.full(ffmc_prev.shape, nodata_value, dtype=ffmc_prev.dtype)
+        values = create_sfms_nodata_output_array(ffmc_prev)
 
         start = perf_counter()
         values[valid] = vectorized_ffmc(
@@ -108,7 +113,7 @@ class FFMCCalculator(FWICalculator):
         )
         logger.info("%f seconds to calculate vectorized ffmc", perf_counter() - start)
 
-        return FWIResult(values, nodata_value)
+        return FWIResult(values, SFMS_NO_DATA)
 
 
 class DMCCalculator(MonthlyFWICalculator):
@@ -128,14 +133,14 @@ class DMCCalculator(MonthlyFWICalculator):
         dmc_prev_ds = datasets.index[FWIParameter.DMC]
 
         lat, mon = self._lat_month_arrays(dmc_prev_ds)
-        dmc_prev, nodata_value = dmc_prev_ds.replace_nodata_with(np.nan)
+        dmc_prev, _ = dmc_prev_ds.replace_nodata_with(np.nan)
         temp, _ = temp_ds.replace_nodata_with(np.nan)
         rh, _ = rh_ds.replace_nodata_with(np.nan)
         prec, _ = precip_ds.replace_nodata_with(np.nan)
 
         mask = np.isnan(dmc_prev) | np.isnan(temp) | np.isnan(rh) | np.isnan(prec)
         valid = ~mask
-        values = np.full(dmc_prev.shape, nodata_value, dtype=dmc_prev.dtype)
+        values = create_sfms_nodata_output_array(dmc_prev)
 
         start = perf_counter()
         values[valid] = vectorized_dmc(
@@ -143,7 +148,7 @@ class DMCCalculator(MonthlyFWICalculator):
         )
         logger.info("%f seconds to calculate vectorized dmc", perf_counter() - start)
 
-        return FWIResult(values, nodata_value)
+        return FWIResult(values, SFMS_NO_DATA)
 
 
 class DCCalculator(MonthlyFWICalculator):
@@ -163,14 +168,14 @@ class DCCalculator(MonthlyFWICalculator):
         dc_prev_ds = datasets.index[FWIParameter.DC]
 
         lat, mon = self._lat_month_arrays(dc_prev_ds)
-        dc_prev, nodata_value = dc_prev_ds.replace_nodata_with(np.nan)
+        dc_prev, _ = dc_prev_ds.replace_nodata_with(np.nan)
         temp, _ = temp_ds.replace_nodata_with(np.nan)
         rh, _ = rh_ds.replace_nodata_with(np.nan)
         prec, _ = precip_ds.replace_nodata_with(np.nan)
 
         mask = np.isnan(dc_prev) | np.isnan(temp) | np.isnan(rh) | np.isnan(prec)
         valid = ~mask
-        values = np.full(dc_prev.shape, nodata_value, dtype=dc_prev.dtype)
+        values = create_sfms_nodata_output_array(dc_prev)
 
         start = perf_counter()
         values[valid] = vectorized_dc(
@@ -178,7 +183,7 @@ class DCCalculator(MonthlyFWICalculator):
         )
         logger.info("%f seconds to calculate vectorized dc", perf_counter() - start)
 
-        return FWIResult(values, nodata_value)
+        return FWIResult(values, SFMS_NO_DATA)
 
 
 class ISICalculator(FWICalculator):
@@ -191,18 +196,18 @@ class ISICalculator(FWICalculator):
         ffmc_ds = datasets.index[FWIParameter.FFMC]
         wind_ds = datasets.weather[SFMSInterpolatedWeatherParameter.WIND_SPEED]
 
-        ffmc, nodata_value = ffmc_ds.replace_nodata_with(np.nan)
+        ffmc, _ = ffmc_ds.replace_nodata_with(np.nan)
         ws, _ = wind_ds.replace_nodata_with(np.nan)
 
         mask = np.isnan(ffmc) | np.isnan(ws)
         valid = ~mask
-        values = np.full(ffmc.shape, nodata_value, dtype=ffmc.dtype)
+        values = create_sfms_nodata_output_array(ffmc)
 
         start = perf_counter()
         values[valid] = vectorized_isi(ffmc[valid], ws[valid], False)
         logger.info("%f seconds to calculate vectorized isi", perf_counter() - start)
 
-        return FWIResult(values, nodata_value)
+        return FWIResult(values, SFMS_NO_DATA)
 
 
 class BUICalculator(FWICalculator):
@@ -214,18 +219,18 @@ class BUICalculator(FWICalculator):
         dmc_ds = datasets.index[FWIParameter.DMC]
         dc_ds = datasets.index[FWIParameter.DC]
 
-        dmc, nodata_value = dmc_ds.replace_nodata_with(np.nan)
+        dmc, _ = dmc_ds.replace_nodata_with(np.nan)
         dc, _ = dc_ds.replace_nodata_with(np.nan)
 
         mask = np.isnan(dmc) | np.isnan(dc)
         valid = ~mask
-        values = np.full(dmc.shape, nodata_value, dtype=dmc.dtype)
+        values = create_sfms_nodata_output_array(dmc)
 
         start = perf_counter()
         values[valid] = vectorized_bui(dmc[valid], dc[valid])
         logger.info("%f seconds to calculate vectorized bui", perf_counter() - start)
 
-        return FWIResult(values, nodata_value)
+        return FWIResult(values, SFMS_NO_DATA)
 
 
 class FWIFinalCalculator(FWICalculator):
@@ -237,18 +242,18 @@ class FWIFinalCalculator(FWICalculator):
         isi_ds = datasets.index[FWIParameter.ISI]
         bui_ds = datasets.index[FWIParameter.BUI]
 
-        isi, nodata_value = isi_ds.replace_nodata_with(np.nan)
+        isi, _ = isi_ds.replace_nodata_with(np.nan)
         bui, _ = bui_ds.replace_nodata_with(np.nan)
 
         mask = np.isnan(isi) | np.isnan(bui)
         valid = ~mask
-        values = np.full(isi.shape, nodata_value, dtype=isi.dtype)
+        values = create_sfms_nodata_output_array(isi)
 
         start = perf_counter()
         values[valid] = vectorized_fwi(isi[valid], bui[valid])
         logger.info("%f seconds to calculate vectorized fwi", perf_counter() - start)
 
-        return FWIResult(values, nodata_value)
+        return FWIResult(values, SFMS_NO_DATA)
 
 
 class FWIProcessor:

--- a/backend/packages/wps-sfms/src/wps_sfms/tests/test_fwi_processor.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/tests/test_fwi_processor.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import numpy as np
@@ -14,6 +15,7 @@ from wps_shared.tests.geospatial.dataset_common import (
     create_test_dataset,
 )
 from wps_shared.utils.s3_client import S3Client
+from wps_sfms.interpolation.common import SFMS_NO_DATA
 from wps_sfms.processors.fwi import (
     BUICalculator,
     DCCalculator,
@@ -115,6 +117,31 @@ async def test_fwi_processor_ffmc(mocker: MockerFixture):
 
         assert publish_spy.call_count == 1
         assert publish_spy.await_args.kwargs["output_key"] == fwi_inputs.output_key
+
+
+@pytest.mark.anyio
+async def test_fwi_processor_publishes_sfms_nodata_metadata(mocker: MockerFixture):
+    processor = FWIProcessor(TEST_DATETIME)
+    fwi_inputs = make_fwi_inputs(FWIParameter.FFMC)
+    _, mock_input_dataset_context = create_mock_input_dataset_context(5)
+    captured_nodata = None
+
+    async def capture_publish_dataset(*, dataset, output_key, **_kwargs):
+        nonlocal captured_nodata
+        captured_nodata = dataset.as_gdal_ds().GetRasterBand(1).GetNoDataValue()
+        return SimpleNamespace(output_key=output_key, cog_key=None)
+
+    mocker.patch("wps_sfms.processors.fwi.rasters_match", return_value=True)
+    mocker.patch("wps_sfms.processors.fwi.publish_dataset", side_effect=capture_publish_dataset)
+
+    async with S3Client() as mock_s3_client:
+        mocker.patch.object(mock_s3_client, "all_objects_exist", new=AsyncMock(return_value=True))
+
+        await processor.calculate_index(
+            mock_s3_client, mock_input_dataset_context, FFMCCalculator(), fwi_inputs
+        )
+
+    assert captured_nodata == pytest.approx(SFMS_NO_DATA)
 
 
 @pytest.mark.anyio
@@ -411,12 +438,15 @@ class TestFWINodeataPropagation:
     # 2x2 WGS84 grid over southern BC (lat ~48–50, lon ~-121–-119)
     EXTENT = (-121.0, -119.0, 48.0, 50.0)
 
-    def make_ds(self, fill: float, nodata_at: tuple | None = None) -> WPSDataset:
+    def make_ds(
+        self, fill: float, nodata_at: tuple | None = None, nodata_value: float | None = None
+    ) -> WPSDataset:
         """2x2 dataset filled with *fill*; optionally set one pixel to NODATA."""
-        gdal_ds = create_test_dataset("test.tif", 2, 2, self.EXTENT, 4326, no_data_value=self.NODATA)
+        nodata = self.NODATA if nodata_value is None else nodata_value
+        gdal_ds = create_test_dataset("test.tif", 2, 2, self.EXTENT, 4326, no_data_value=nodata)
         arr = np.full((2, 2), fill, dtype=np.float32)
         if nodata_at is not None:
-            arr[nodata_at] = self.NODATA
+            arr[nodata_at] = nodata
         gdal_ds.GetRasterBand(1).WriteArray(arr)
         return WPSDataset(ds_path=None, ds=gdal_ds)
 
@@ -435,7 +465,9 @@ class TestFWINodeataPropagation:
     )
     def test_nodata_propagates(self, calculator: FWICalculator, prev_value, nodata_input):
         nodata_pixel = (0, 0)
-        prev_ds = self.make_ds(prev_value, nodata_at=nodata_pixel if nodata_input == "prev_fwi" else None)
+        prev_ds = self.make_ds(
+            prev_value, nodata_at=nodata_pixel if nodata_input == "prev_fwi" else None
+        )
         temp_ds = self.make_ds(20.0, nodata_at=nodata_pixel if nodata_input == "temp" else None)
         rh_ds = self.make_ds(50.0, nodata_at=nodata_pixel if nodata_input == "rh" else None)
         precip_ds = self.make_ds(0.0, nodata_at=nodata_pixel if nodata_input == "precip" else None)
@@ -449,13 +481,35 @@ class TestFWINodeataPropagation:
         }
         index_datasets = {calculator.reference_index_param: prev_ds}
 
-        result = calculator.calculate(
-            FWIDatasets(index=index_datasets, weather=weather_datasets)
-        )
+        result = calculator.calculate(FWIDatasets(index=index_datasets, weather=weather_datasets))
 
-        assert np.isnan(result.nodata_value)
-        assert np.isnan(result.values[0, 0]), "nodata pixel must propagate as NaN"
+        assert result.nodata_value == pytest.approx(SFMS_NO_DATA)
+        assert result.values[0, 0] == pytest.approx(SFMS_NO_DATA)
         # All other pixels must have been computed (not NaN)
         assert not np.isnan(result.values[0, 1])
         assert not np.isnan(result.values[1, 0])
         assert not np.isnan(result.values[1, 1])
+
+    def test_nan_nodata_input_is_normalized_to_sfms_nodata_output(self):
+        nodata_pixel = (0, 0)
+        prev_ds = self.make_ds(85.0, nodata_at=nodata_pixel, nodata_value=np.nan)
+        temp_ds = self.make_ds(20.0)
+        rh_ds = self.make_ds(50.0)
+        precip_ds = self.make_ds(0.0)
+        wind_ds = self.make_ds(10.0)
+
+        result = FFMCCalculator().calculate(
+            FWIDatasets(
+                index={FWIParameter.FFMC: prev_ds},
+                weather={
+                    SFMSInterpolatedWeatherParameter.TEMP: temp_ds,
+                    SFMSInterpolatedWeatherParameter.RH: rh_ds,
+                    SFMSInterpolatedWeatherParameter.PRECIP: precip_ds,
+                    SFMSInterpolatedWeatherParameter.WIND_SPEED: wind_ds,
+                },
+            )
+        )
+
+        assert result.nodata_value == pytest.approx(SFMS_NO_DATA)
+        assert result.values[0, 0] == pytest.approx(SFMS_NO_DATA)
+        assert not np.isnan(result.values[0, 1])

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.test.ts
@@ -25,12 +25,6 @@ vi.mock('pmtiles', () => ({
 // Mock ol/source/GeoTIFF to prevent background network fetches that cause unhandled rejections
 vi.mock('ol/source/GeoTIFF', () => ({
   default: class MockGeoTIFF {
-    options: unknown
-
-    constructor(options: unknown) {
-      this.options = options
-    }
-
     getState() {
       return 'ready'
     }
@@ -135,16 +129,6 @@ describe('layerDefinitions', () => {
       const layer = getFireWeatherRasterLayer(rasterDate, 'fwi', 'test-token')
 
       expect(layer.getZIndex()).toBe(52)
-    })
-
-    it('should use GeoTIFF nodata metadata for fire weather rasters', () => {
-      const rasterDate = DateTime.fromISO('2025-11-02')
-      const layer = getFireWeatherRasterLayer(rasterDate, 'fwi', 'test-token')
-      const source = layer.getSource() as unknown as {
-        options: { sources: Array<{ url: string; nodata?: number }> }
-      }
-
-      expect(source.options.sources[0]).not.toHaveProperty('nodata')
     })
 
     it('should have lower zIndex than snow layer', () => {

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.test.ts
@@ -25,6 +25,12 @@ vi.mock('pmtiles', () => ({
 // Mock ol/source/GeoTIFF to prevent background network fetches that cause unhandled rejections
 vi.mock('ol/source/GeoTIFF', () => ({
   default: class MockGeoTIFF {
+    options: unknown
+
+    constructor(options: unknown) {
+      this.options = options
+    }
+
     getState() {
       return 'ready'
     }
@@ -129,6 +135,16 @@ describe('layerDefinitions', () => {
       const layer = getFireWeatherRasterLayer(rasterDate, 'fwi', 'test-token')
 
       expect(layer.getZIndex()).toBe(52)
+    })
+
+    it('should use GeoTIFF nodata metadata for fire weather rasters', () => {
+      const rasterDate = DateTime.fromISO('2025-11-02')
+      const layer = getFireWeatherRasterLayer(rasterDate, 'fwi', 'test-token')
+      const source = layer.getSource() as unknown as {
+        options: { sources: Array<{ url: string; nodata?: number }> }
+      }
+
+      expect(source.options.sources[0]).not.toHaveProperty('nodata')
     })
 
     it('should have lower zIndex than snow layer', () => {

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.ts
@@ -71,7 +71,7 @@ export const getFireWeatherRasterLayer = (
   }
 
   const source = new GeoTIFF({
-    sources: [{ url, nodata: -3.4028235e38 }],
+    sources: [{ url }],
     sourceOptions: {
       headers
     },

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/layerDefinitions.ts
@@ -71,7 +71,7 @@ export const getFireWeatherRasterLayer = (
   }
 
   const source = new GeoTIFF({
-    sources: [{ url }],
+    sources: [{ url, nodata: -3.4028235e38 }],
     sourceOptions: {
       headers
     },

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.test.ts
@@ -63,7 +63,7 @@ describe('fuelCOGColourExpression', () => {
     expect(expr[0]).toBe('case')
   })
 
-  it('should make pixels with empty source alpha transparent', () => {
+  it('should make pixels with a zero alpha band transparent', () => {
     const expr = fuelCOGColourExpression()
 
     expect(expr[1]).toEqual(['==', ['band', 2], 0])
@@ -117,7 +117,7 @@ describe('fuelCOGColourExpression', () => {
 })
 
 describe('getFireWeatherColourExpression', () => {
-  it('should make pixels with empty source alpha transparent before applying color breaks', () => {
+  it('should make pixels with a zero alpha band transparent before applying color breaks', () => {
     const expr = getFireWeatherColourExpression('fwi')
 
     expect(expr[0]).toBe('case')

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.test.ts
@@ -6,6 +6,7 @@ import {
   EMPTY_FILL,
   fuelCOGColourExpression,
   getColorForRasterValue,
+  getFireWeatherColourExpression,
   isNodataValue,
   NODATA_THRESHOLD,
   SNOW_FILL,
@@ -62,10 +63,17 @@ describe('fuelCOGColourExpression', () => {
     expect(expr[0]).toBe('case')
   })
 
+  it('should make pixels with empty source alpha transparent', () => {
+    const expr = fuelCOGColourExpression()
+
+    expect(expr[1]).toEqual(['<=', ['band', 2], 0])
+    expect(expr[2]).toEqual([0, 0, 0, 0])
+  })
+
   it('should include all raster values and their corresponding colors', () => {
     const expr = fuelCOGColourExpression()
-    // Expected: 'case' + (3 nodata cases * 2) + (14 fuel types * 2) + fallback = 1 + 6 + 28 + 1 = 36
-    const expectedLength = 1 + 3 * 2 + FUEL_TYPE_COLORS.length * 2 + 1
+    // expected: 'case' + alpha guard + (3 nodata cases * 2) + (14 fuel types * 2) + fallback.
+    const expectedLength = 1 + 2 + 3 * 2 + FUEL_TYPE_COLORS.length * 2 + 1
     expect(expr.length).toBe(expectedLength)
 
     // Check nodata values are transparent (99, 102, -10000)
@@ -105,6 +113,23 @@ describe('fuelCOGColourExpression', () => {
     const expr = fuelCOGColourExpression()
     const fallback = expr[expr.length - 1]
     expect(fallback).toEqual([0, 0, 0, 0])
+  })
+})
+
+describe('getFireWeatherColourExpression', () => {
+  it('should make pixels with empty source alpha transparent before applying color breaks', () => {
+    const expr = getFireWeatherColourExpression('fwi')
+
+    expect(expr[0]).toBe('case')
+    expect(expr[1]).toEqual(['<=', ['band', 2], 0])
+    expect(expr[2]).toEqual([0, 0, 0, 0])
+  })
+
+  it('should still handle large nodata sentinels explicitly', () => {
+    const expr = getFireWeatherColourExpression('fwi')
+
+    expect(expr).toContainEqual(['>', ['band', 1], NODATA_THRESHOLD])
+    expect(expr).toContainEqual(['<', ['band', 1], -NODATA_THRESHOLD])
   })
 })
 

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.test.ts
@@ -66,7 +66,7 @@ describe('fuelCOGColourExpression', () => {
   it('should make pixels with empty source alpha transparent', () => {
     const expr = fuelCOGColourExpression()
 
-    expect(expr[1]).toEqual(['<=', ['band', 2], 0])
+    expect(expr[1]).toEqual(['==', ['band', 2], 0])
     expect(expr[2]).toEqual([0, 0, 0, 0])
   })
 
@@ -121,7 +121,7 @@ describe('getFireWeatherColourExpression', () => {
     const expr = getFireWeatherColourExpression('fwi')
 
     expect(expr[0]).toBe('case')
-    expect(expr[1]).toEqual(['<=', ['band', 2], 0])
+    expect(expr[1]).toEqual(['==', ['band', 2], 0])
     expect(expr[2]).toEqual([0, 0, 0, 0])
   })
 

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.ts
@@ -76,9 +76,10 @@ type ColourCaseCondition =
 type ColourCaseColour = [number, number, number, number]
 type ColourCases = Array<ColourCaseCondition | ColourCaseColour>
 
-// use alpha as a validity flag because normalize:false may expose valid alpha as 255, not 1
+// alpha is transparency: 0 is fully transparent, and any nonzero value is visible.
+// use it as a validity flag because normalize:false may expose valid alpha as 255, not 1
 const transparentWhenSourceAlphaIsEmpty = (): ColourCases => [
-  ['<=', ['band', ALPHA_BAND], 0],
+  ['==', ['band', ALPHA_BAND], 0],
   [0, 0, 0, 0]
 ]
 

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.ts
@@ -13,6 +13,8 @@ export const EMPTY_FILL = 'rgba(0, 0, 0, 0)'
 // GeoTIFF nodata is -3.4028235e+38, use threshold for floating-point reliability
 // Note: JavaScript treats number literals like 1, 1.0, and 1 as identical values.
 export const NODATA_THRESHOLD = 10000000000
+const RASTER_BAND = 1
+const ALPHA_BAND = 2
 
 // Helper function to check if a raster value is nodata
 export const isNodataValue = (value: number): boolean => {
@@ -65,28 +67,39 @@ export const snowStyler = (feature: RenderFeature | ol.Feature<Geometry>): Style
   return snowStyle
 }
 
-type ColourCaseCondition = ['==', ['band', number], number]
+type ColourCaseCondition =
+  | ['==', ['band', number], number]
+  | ['<=', ['band', number], number]
+  | ['>', ['band', number], number]
+  | ['<', ['band', number], number]
+  | ['>=', ['band', number], number]
 type ColourCaseColour = [number, number, number, number]
 type ColourCases = Array<ColourCaseCondition | ColourCaseColour>
 
+// use alpha as a validity flag because normalize:false may expose valid alpha as 255, not 1
+const transparentWhenSourceAlphaIsEmpty = (): ColourCases => [
+  ['<=', ['band', ALPHA_BAND], 0],
+  [0, 0, 0, 0]
+]
+
 export const fuelCOGColourExpression = () => {
-  const colourCases: ColourCases = []
+  const colourCases: ColourCases = transparentWhenSourceAlphaIsEmpty()
 
   // Handle nodata values - make them transparent
   // 99 = non-fuel areas, 102 = water/non-vegetated, -10000 = primary nodata
   colourCases.push(
-    ['==', ['band', 1], 99],
+    ['==', ['band', RASTER_BAND], 99],
     [0, 0, 0, 0],
-    ['==', ['band', 1], 102],
+    ['==', ['band', RASTER_BAND], 102],
     [0, 0, 0, 0],
-    ['==', ['band', 1], -10000],
+    ['==', ['band', RASTER_BAND], -10000],
     [0, 0, 0, 0]
   )
 
   // Add color cases for valid fuel types (1-14)
   FUEL_TYPE_COLORS.forEach(({ value, rgb }) => {
     const [r, g, b] = rgb
-    colourCases.push(['==', ['band', 1], value], [r, g, b, 1])
+    colourCases.push(['==', ['band', RASTER_BAND], value], [r, g, b, 1])
   })
 
   // Fallback for any other values - transparent
@@ -98,14 +111,17 @@ export const fuelCOGColourExpression = () => {
 // Generate color expression dynamically from color breaks
 export const getFireWeatherColourExpression = (rasterType: string) => {
   const colorBreaks = RASTER_COLOR_BREAKS[rasterType as RasterType]
-  const expression: any[] = ['case']
+  const expression: Array<string | ColourCaseCondition | ColourCaseColour> = [
+    'case',
+    ...transparentWhenSourceAlphaIsEmpty()
+  ]
 
   // Handle nodata values - GeoTIFF nodata is -3.4028235e+38
   // Use threshold checks for floating-point reliability
   expression.push(
-    ['>', ['band', 1], NODATA_THRESHOLD],
+    ['>', ['band', RASTER_BAND], NODATA_THRESHOLD],
     [0, 0, 0, 0], // Very large positive values (nodata): transparent
-    ['<', ['band', 1], -NODATA_THRESHOLD],
+    ['<', ['band', RASTER_BAND], -NODATA_THRESHOLD],
     [0, 0, 0, 0] // Very large negative values (nodata): transparent
   )
 
@@ -115,9 +131,9 @@ export const getFireWeatherColourExpression = (rasterType: string) => {
 
     if (colorBreak.max === null) {
       // Last break (no max) - use >= min
-      expression.push(['>=', ['band', 1], colorBreak.min], [r, g, b, 1])
+      expression.push(['>=', ['band', RASTER_BAND], colorBreak.min], [r, g, b, 1])
     } else {
-      expression.push(['<', ['band', 1], colorBreak.max], [r, g, b, 1])
+      expression.push(['<', ['band', RASTER_BAND], colorBreak.max], [r, g, b, 1])
     }
   })
 

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/sfmsFeatureStylers.ts
@@ -78,13 +78,13 @@ type ColourCases = Array<ColourCaseCondition | ColourCaseColour>
 
 // alpha is transparency: 0 is fully transparent, and any nonzero value is visible.
 // use it as a validity flag because normalize:false may expose valid alpha as 255, not 1
-const transparentWhenSourceAlphaIsEmpty = (): ColourCases => [
+const transparentWhenAlphaBandIsZero = (): ColourCases => [
   ['==', ['band', ALPHA_BAND], 0],
   [0, 0, 0, 0]
 ]
 
 export const fuelCOGColourExpression = () => {
-  const colourCases: ColourCases = transparentWhenSourceAlphaIsEmpty()
+  const colourCases: ColourCases = transparentWhenAlphaBandIsZero()
 
   // Handle nodata values - make them transparent
   // 99 = non-fuel areas, 102 = water/non-vegetated, -10000 = primary nodata
@@ -114,7 +114,7 @@ export const getFireWeatherColourExpression = (rasterType: string) => {
   const colorBreaks = RASTER_COLOR_BREAKS[rasterType as RasterType]
   const expression: Array<string | ColourCaseCondition | ColourCaseColour> = [
     'case',
-    ...transparentWhenSourceAlphaIsEmpty()
+    ...transparentWhenAlphaBandIsZero()
   ]
 
   // Handle nodata values - GeoTIFF nodata is -3.4028235e+38

--- a/web/apps/wps-web/src/features/weatherToolkit/hooks/useWxChartCache.test.ts
+++ b/web/apps/wps-web/src/features/weatherToolkit/hooks/useWxChartCache.test.ts
@@ -130,12 +130,15 @@ describe('useWxChartCache', () => {
   })
 
   it('removes a key from the fetching set after a successful fetch so it can be re-fetched if needed', async () => {
+    const key = buildChartKey(MODEL, MODEL_RUN_DATE, MODEL_RUN_HOUR, 0)
     const { result, rerender } = renderHook(
       ({ modelRunDate }: { modelRunDate: DateTime }) => useWxChartCache(MODEL, modelRunDate, MODEL_RUN_HOUR, 0),
       { initialProps: { modelRunDate: MODEL_RUN_DATE } }
     )
-    await waitFor(() => expect(result.current.cache.size).toBeGreaterThan(0))
-    const callCountAfterFirst = vi.mocked(weatherToolkitAPI.getWxChart).mock.calls.length
+    await waitFor(() => expect(result.current.cache.get(key)).toBe(fakeObjectUrl))
+    const keyCallsAfterFirstFetch = vi
+      .mocked(weatherToolkitAPI.getWxChart)
+      .mock.calls.filter(([calledKey]) => calledKey === key).length
 
     // Change params to clear the cache, then restore original params — the key
     // should be re-fetched rather than silently skipped due to a stale fetching entry.
@@ -143,10 +146,11 @@ describe('useWxChartCache', () => {
     act(() => rerender({ modelRunDate: MODEL_RUN_DATE }))
 
     await waitFor(() =>
-      expect(vi.mocked(weatherToolkitAPI.getWxChart).mock.calls.length).toBeGreaterThan(callCountAfterFirst)
+      expect(vi.mocked(weatherToolkitAPI.getWxChart).mock.calls.filter(([calledKey]) => calledKey === key).length).toBe(
+        keyCallsAfterFirstFetch + 1
+      )
     )
-    const key = buildChartKey(MODEL, MODEL_RUN_DATE, MODEL_RUN_HOUR, 0)
-    expect(result.current.cache.get(key)).toBe(fakeObjectUrl)
+    await waitFor(() => expect(result.current.cache.get(key)).toBe(fakeObjectUrl))
   })
 
   it('does not fetch the same key twice', async () => {

--- a/web/apps/wps-web/src/features/weatherToolkit/hooks/useWxChartCache.test.ts
+++ b/web/apps/wps-web/src/features/weatherToolkit/hooks/useWxChartCache.test.ts
@@ -146,9 +146,9 @@ describe('useWxChartCache', () => {
     act(() => rerender({ modelRunDate: MODEL_RUN_DATE }))
 
     await waitFor(() =>
-      expect(vi.mocked(weatherToolkitAPI.getWxChart).mock.calls.filter(([calledKey]) => calledKey === key).length).toBe(
-        keyCallsAfterFirstFetch + 1
-      )
+      expect(
+        vi.mocked(weatherToolkitAPI.getWxChart).mock.calls.filter(([calledKey]) => calledKey === key)
+      ).toHaveLength(keyCallsAfterFirstFetch + 1)
     )
     await waitFor(() => expect(result.current.cache.get(key)).toBe(fakeObjectUrl))
   })


### PR DESCRIPTION
FWI rasters were being generated with nodata values of `nan` while weather rasters were using `-3.4028235e+38`. In Openlayers, we were explicity setting nodata as `-3.4028235e+38` and users were seeing nodata values in FWI rasters (but not all users, which I don't quite understand).

This PR changes a couple things:
- Makes all weather and FWI rasters use the same nodata value of `-3.4028235e+38`
- Removes the explicit setting of a `nodata` value in openlayers.
   - Openlayers will read geotiff metadata to get the `nodata` value on it's own, then it will create an alpha band (band 2 in a single band dataset). We can set transparency on this alpha band so it should work well for all rasters that have any `nodata` value set 
   - There should be no need to regenerate any data
   - https://openlayers.org/en/latest/apidoc/module-ol_source_GeoTIFF.html#~SourceInfo
- Also fixes one unrelated flaky test that I noticed failed a few times for me in  `useWeatherChartCache.test.ts`

# Test Links:
[Landing Page](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5592-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
