### PR TITLE
Insights: Tooltip fix

### DIFF
--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterTooltipHandler.test.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterTooltipHandler.test.ts
@@ -27,6 +27,7 @@ describe('getRasterTooltipData', () => {
       ['large positive nodata', new Float32Array([NODATA_THRESHOLD + 1000]), 'fwi' as const],
       ['GeoTIFF nodata', new Float32Array([-3.4028235e38]), 'dmc' as const],
       ['large negative nodata', new Float32Array([-NODATA_THRESHOLD - 1000]), 'dc' as const],
+      ['transparent alpha band', new Float32Array([0, 0]), 'fwi' as const],
       ['positive infinity', new Float32Array([Infinity]), 'ffmc' as const],
       ['negative infinity', new Float32Array([-Infinity]), 'bui' as const]
     ])('%s', (_description, data, rasterType) => {
@@ -39,6 +40,7 @@ describe('getRasterTooltipData', () => {
   describe('should return rounded value for valid data', () => {
     it.each([
       ['zero', new Float32Array([0]), undefined, 0, 'FWI'],
+      ['zero with visible alpha band', new Float32Array([0, 255]), 'fwi' as const, 0, 'FWI'],
       ['small integer', new Float32Array([5]), 'fwi' as const, 5, 'FWI'],
       ['decimal value rounds down', new Float32Array([42.3]), 'dmc' as const, 42, 'DMC'],
       ['decimal value rounds up', new Float32Array([42.7]), 'dc' as const, 43, 'DC'],

--- a/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterTooltipHandler.ts
+++ b/web/apps/wps-web/src/features/sfmsInsights/components/map/rasterTooltipHandler.ts
@@ -12,6 +12,8 @@ export interface RasterTooltipResult {
   pixelCoords: [number, number]
 }
 
+const ALPHA_BAND_INDEX = 1
+
 /**
  * Extracts raster value from layer data and determines if it should be displayed
  * This function is pure and can be tested in isolation
@@ -25,6 +27,13 @@ export const getRasterTooltipData = (data: RasterData, rasterType: RasterType | 
   }
 
   const rawValue = data[0]
+  const alphaValue = data[ALPHA_BAND_INDEX]
+
+  // openlayers appends an alpha band when GeoTIFF nodata exists; alpha 0 means
+  // the pixel is transparent even when the raster band itself reads back as 0.
+  if (data.length > ALPHA_BAND_INDEX && alphaValue === 0) {
+    return { value: null, label: defaultLabel }
+  }
 
   // Check for NaN (can occur when undefined is coerced to number)
   if (Number.isNaN(rawValue)) {


### PR DESCRIPTION
Anywhere the alpha band == 0 (transparent), don't show the value from band 1 of the raster on the hover tooltip
# Test Links:
[Landing Page](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5594-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
