### PR TITLE
SFMS: Single daily-FWI endpoint for all parameters at a point

### DIFF
--- a/backend/packages/wps-api/src/app/routers/sfms_fwi.py
+++ b/backend/packages/wps-api/src/app/routers/sfms_fwi.py
@@ -1,12 +1,14 @@
 """Daily FWI Raster Endpoints
 
 Provides endpoints to download and query SFMS daily FWI actuals rasters
-(FFMC, DMC, DC, ISI, FWI, BUI) and hourly FFMC rasters.
+(FFMC, DMC, DC, ISI, FWI, BUI) and hourly FFMC rasters. Values can be sampled
+one parameter at a time, or all daily FWI parameters at once for a lat/lon.
 
 Access is controlled by the APS Kong gateway (key-auth). Consumers register
 for an API key at https://api.gov.bc.ca.
 """
 
+import asyncio
 import logging
 from datetime import date, datetime, timezone
 from typing import Annotated
@@ -89,6 +91,20 @@ class FWIValueResponse(BaseModel):
     )
 
 
+class DailyFWIValuesResponse(BaseModel):
+    date: str = Field(description="Date of the rasters the values were sampled from (YYYY-MM-DD)")
+    latitude: float = Field(description="Latitude of the sampled point, as provided in the request")
+    longitude: float = Field(
+        description="Longitude of the sampled point, as provided in the request"
+    )
+    ffmc: float | None = Field(description="Fine Fuel Moisture Code")
+    dmc: float | None = Field(description="Duff Moisture Code")
+    dc: float | None = Field(description="Drought Code")
+    isi: float | None = Field(description="Initial Spread Index")
+    bui: float | None = Field(description="Buildup Index")
+    fwi: float | None = Field(description="Fire Weather Index")
+
+
 async def _load_raster(key: str) -> bytes:
     try:
         async with S3Client() as s3_client:
@@ -119,8 +135,60 @@ async def _find_uploaded_hffmc_key(for_date: date, hour: int) -> str | None:
     )
 
 
-# /value routes must be defined before the bare download routes to avoid
-# the variable {parameter} segment swallowing the literal "value" segment.
+async def _sample_daily_fwi_value(
+    for_date: date, parameter: FWIParameter, lat: float, lon: float
+) -> float | None:
+    """Load the uploaded daily FWI actuals raster for the given date/parameter and
+    return its value at the WGS84 lat/lon point (None if outside the extent or on a
+    nodata pixel). Raises 404 via _load_raster if the raster itself doesn't exist."""
+    key = _addresser.get_uploaded_index_key(_for_date_to_utc(for_date), parameter)
+    logger.info("Sampling %s raster at (%s, %s) from %s", parameter.value, lat, lon, key)
+
+    raster_bytes = await _load_raster(key)
+    ds = WPSDataset.from_bytes(raster_bytes)
+    with ds:
+        return ds.extract_value_at_point(lat, lon)
+
+
+# The /value and /values routes must be defined before the bare download routes so
+# the literal path segments aren't swallowed by the variable {parameter} segment.
+
+
+@router.get(
+    "/{for_date}/values",
+    response_model=DailyFWIValuesResponse,
+    responses=_VALUE_RESPONSES,
+    summary="Get all daily FWI values at a point",
+)
+async def get_daily_fwi_values_at_point(
+    for_date: Annotated[date, Path(description=_FOR_DATE_DESC, examples=[_FOR_DATE_EXAMPLE])],
+    lat: Annotated[float, Query(ge=-90, le=90, description=_LAT_DESC, examples=[_LAT_EXAMPLE])],
+    lon: Annotated[float, Query(ge=-180, le=180, description=_LON_DESC, examples=[_LON_EXAMPLE])],
+):
+    """
+    Sample every daily FWI actuals raster (ffmc, dmc, dc, isi, bui, fwi) at a single
+    WGS84 lat/lon coordinate for the given date, returning all values in one response.
+
+    This is a convenience over the per-parameter `/{parameter}/value` route: it saves
+    callers from issuing six separate requests for the same point and date.
+
+    The raster values returned are from the actual rasters uploaded
+    by the existing/legacy SFMS system run by geospatial.
+
+    Each value is `null` if the coordinate falls outside the raster's extent or on a
+    nodata pixel. A 404 means any of the daily FWI rasters themselves don't exist for that date.
+    """
+    values = await asyncio.gather(
+        *(_sample_daily_fwi_value(for_date, parameter, lat, lon) for parameter in FWIParameter)
+    )
+    by_parameter = {parameter.value: value for parameter, value in zip(FWIParameter, values)}
+
+    return DailyFWIValuesResponse(
+        date=for_date.isoformat(),
+        latitude=lat,
+        longitude=lon,
+        **by_parameter,
+    )
 
 
 @router.get(
@@ -140,8 +208,8 @@ async def get_hourly_ffmc_value_at_point(
     WGS84 lat/lon coordinate, for the given date and hour (PDT, matching the
     SFMS upload filename convention).
 
-    The raster returned is the actual raster uploaded by the existing/legacy SFMS system run by
-    geospatial, not a WPS-calculated ones.
+    The raster value returned is from the actual raster uploaded
+    by the existing/legacy SFMS system run by geospatial.
 
     Returns `value: null` if the coordinate falls outside the raster's extent or on
     a nodata pixel, rather than a 404 -- a 404 means the raster itself doesn't exist
@@ -184,17 +252,14 @@ async def get_daily_fwi_value_at_point(
     Sample the daily FWI actuals raster at a single WGS84 lat/lon coordinate, for
     the given date and parameter (dc, dmc, bui, ffmc, isi, or fwi).
 
+    The raster value returned is from the actual raster uploaded
+    by the existing/legacy SFMS system run by geospatial.
+
     Returns `value: null` if the coordinate falls outside the raster's extent or on
     a nodata pixel, rather than a 404 -- a 404 means the raster itself doesn't exist
     for that date/parameter.
     """
-    key = _addresser.get_uploaded_index_key(_for_date_to_utc(for_date), parameter)
-    logger.info("Sampling %s raster at (%s, %s) from %s", parameter.value, lat, lon, key)
-
-    raster_bytes = await _load_raster(key)
-    ds = WPSDataset.from_bytes(raster_bytes)
-    with ds:
-        value = ds.extract_value_at_point(lat, lon)
+    value = await _sample_daily_fwi_value(for_date, parameter, lat, lon)
 
     return FWIValueResponse(
         date=for_date.isoformat(),
@@ -220,8 +285,8 @@ async def get_hourly_ffmc_raster(
     GeoTIFF, for the given date and hour (PDT, matching the SFMS upload
     filename convention).
 
-    The raster returned is the actual raster uploaded by the existing/legacy SFMS system run by
-    geospatial, not a WPS-calculated ones.
+    The raster returned is the actual raster uploaded
+    by the existing/legacy SFMS system run by geospatial.
 
     Supports HTTP range requests (a `Range` header returns a 206 partial response).
     """
@@ -248,8 +313,8 @@ async def get_daily_fwi_raster(
     Download the daily FWI actuals raster for the given date and
     parameter (dc, dmc, bui, ffmc, isi, or fwi).
 
-    The raster returned is the actual raster uploaded by the existing/legacy SFMS system run by
-    geospatial.
+    The raster returned is the actual raster uploaded
+    by the existing/legacy SFMS system run by geospatial.
 
     Supports HTTP range requests (a `Range` header returns a 206 partial response).
     """

--- a/backend/packages/wps-api/src/app/tests/sfms/test_sfms_fwi_endpoints.py
+++ b/backend/packages/wps-api/src/app/tests/sfms/test_sfms_fwi_endpoints.py
@@ -238,6 +238,16 @@ class TestDailyFWIValueAtPoint:
         response = client.get(f"{BASE_URL}/2025-11-02/fwi/value?lat=49.0&lon=-123.0")
         assert response.status_code == 404
 
+    def test_returns_502_on_s3_error(self, monkeypatch):
+        async def _raise_s3_error(self, key):
+            raise ClientError({"Error": {"Code": "InternalError"}}, "GetObject")
+
+        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", _raise_s3_error)
+        client = TestClient(app.sfms_fwi_main.app)
+        response = client.get(f"{BASE_URL}/2025-11-02/fwi/value?lat=49.0&lon=-123.0")
+        assert response.status_code == 502
+        assert "InternalError" in response.json()["detail"]
+
     def test_missing_lat_lon_returns_422(self):
         client = TestClient(app.sfms_fwi_main.app)
         response = client.get(f"{BASE_URL}/2025-11-02/fwi/value")
@@ -264,6 +274,66 @@ class TestDailyFWIValueAtPoint:
         assert "sfms/uploads" in captured_keys[0]
         assert "actual" in captured_keys[0]
         assert "ffmc20251102.tif" in captured_keys[0]
+
+
+class TestDailyFWIValuesAtPoint:
+    """Tests for GET /sfms/daily-fwi/{for_date}/values (all parameters at once)."""
+
+    def test_returns_all_parameters(self, monkeypatch):
+        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes"))
+        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(42.5))
+
+        client = TestClient(app.sfms_fwi_main.app)
+        response = client.get(f"{BASE_URL}/2025-11-02/values?lat=49.0&lon=-123.0")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["date"] == "2025-11-02"
+        assert data["latitude"] == pytest.approx(49.0)
+        assert data["longitude"] == pytest.approx(-123.0)
+        for param in ("ffmc", "dmc", "dc", "isi", "bui", "fwi"):
+            assert data[param] == pytest.approx(42.5)
+
+    def test_returns_null_values_when_outside_raster(self, monkeypatch):
+        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes"))
+        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(None))
+
+        client = TestClient(app.sfms_fwi_main.app)
+        response = client.get(f"{BASE_URL}/2025-11-02/values?lat=0.0&lon=0.0")
+        assert response.status_code == 200
+        data = response.json()
+        for param in ("ffmc", "dmc", "dc", "isi", "bui", "fwi"):
+            assert data[param] is None
+
+    def test_returns_404_when_raster_missing(self, monkeypatch):
+        async def _raise_not_found(self, key):
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+
+        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", _raise_not_found)
+        client = TestClient(app.sfms_fwi_main.app)
+        response = client.get(f"{BASE_URL}/2025-11-02/values?lat=49.0&lon=-123.0")
+        assert response.status_code == 404
+
+    def test_missing_lat_lon_returns_422(self):
+        client = TestClient(app.sfms_fwi_main.app)
+        response = client.get(f"{BASE_URL}/2025-11-02/values")
+        assert response.status_code == 422
+
+    def test_samples_all_six_uploaded_actual_keys(self, monkeypatch):
+        captured_keys = []
+
+        async def _capture_key(self, key):
+            captured_keys.append(key)
+            return b"fake-bytes"
+
+        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", _capture_key)
+        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(1.0))
+
+        client = TestClient(app.sfms_fwi_main.app)
+        client.get(f"{BASE_URL}/2025-11-02/values?lat=49.0&lon=-123.0")
+        assert len(captured_keys) == 6
+        assert all("sfms/uploads" in key and "actual" in key for key in captured_keys)
+        for param in ("dc", "dmc", "bui", "ffmc", "isi", "fwi"):
+            assert any(f"{param}20251102.tif" in key for key in captured_keys)
 
 
 class TestHourlyFFMCValueAtPoint:

--- a/backend/packages/wps-api/src/app/tests/sfms/test_sfms_fwi_endpoints.py
+++ b/backend/packages/wps-api/src/app/tests/sfms/test_sfms_fwi_endpoints.py
@@ -162,7 +162,9 @@ class TestHourlyFFMCRasterDownload:
 
     @pytest.mark.usefixtures("mock_stream_object")
     def test_downloads_hourly_ffmc_raster(self, mock_list_hffmc_uploads):
-        mock_list_hffmc_uploads(["sfms/uploads/hourlies/2025-11-02/fine_fuel_moisture_code2025110212.tif"])
+        mock_list_hffmc_uploads(
+            ["sfms/uploads/hourlies/2025-11-02/fine_fuel_moisture_code2025110212.tif"]
+        )
         client = TestClient(app.sfms_fwi_main.app)
         response = client.get(f"{BASE_URL}/2025-11-02/hffmc?hour=12")
         assert response.status_code == 200
@@ -185,7 +187,9 @@ class TestHourlyFFMCRasterDownload:
         assert response.status_code == 422
 
     def test_uses_hffmc_key_path(self, monkeypatch, mock_list_hffmc_uploads):
-        mock_list_hffmc_uploads(["sfms/uploads/hourlies/2025-11-02/fine_fuel_moisture_code2025110212.tif"])
+        mock_list_hffmc_uploads(
+            ["sfms/uploads/hourlies/2025-11-02/fine_fuel_moisture_code2025110212.tif"]
+        )
         captured_keys = []
 
         async def _capture_key(key, byte_range=None, chunk_size=65536):
@@ -208,8 +212,12 @@ class TestDailyFWIValueAtPoint:
     """Tests for GET /sfms/daily-fwi/{for_date}/{parameter}/value."""
 
     def test_returns_value_at_point(self, monkeypatch):
-        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes"))
-        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(42.5))
+        monkeypatch.setattr(
+            "wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes")
+        )
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(42.5)
+        )
 
         client = TestClient(app.sfms_fwi_main.app)
         response = client.get(f"{BASE_URL}/2025-11-02/fwi/value?lat=49.0&lon=-123.0")
@@ -221,8 +229,12 @@ class TestDailyFWIValueAtPoint:
         assert data["longitude"] == pytest.approx(-123.0)
 
     def test_returns_null_value_when_outside_raster(self, monkeypatch):
-        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes"))
-        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(None))
+        monkeypatch.setattr(
+            "wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes")
+        )
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(None)
+        )
 
         client = TestClient(app.sfms_fwi_main.app)
         response = client.get(f"{BASE_URL}/2025-11-02/fwi/value?lat=0.0&lon=0.0")
@@ -266,7 +278,9 @@ class TestDailyFWIValueAtPoint:
             return b"fake-bytes"
 
         monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", _capture_key)
-        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(42.5))
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(42.5)
+        )
 
         client = TestClient(app.sfms_fwi_main.app)
         client.get(f"{BASE_URL}/2025-11-02/ffmc/value?lat=49.0&lon=-123.0")
@@ -280,8 +294,12 @@ class TestDailyFWIValuesAtPoint:
     """Tests for GET /sfms/daily-fwi/{for_date}/values (all parameters at once)."""
 
     def test_returns_all_parameters(self, monkeypatch):
-        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes"))
-        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(42.5))
+        monkeypatch.setattr(
+            "wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes")
+        )
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(42.5)
+        )
 
         client = TestClient(app.sfms_fwi_main.app)
         response = client.get(f"{BASE_URL}/2025-11-02/values?lat=49.0&lon=-123.0")
@@ -294,8 +312,12 @@ class TestDailyFWIValuesAtPoint:
             assert data[param] == pytest.approx(42.5)
 
     def test_returns_null_values_when_outside_raster(self, monkeypatch):
-        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes"))
-        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(None))
+        monkeypatch.setattr(
+            "wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes")
+        )
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(None)
+        )
 
         client = TestClient(app.sfms_fwi_main.app)
         response = client.get(f"{BASE_URL}/2025-11-02/values?lat=0.0&lon=0.0")
@@ -313,6 +335,25 @@ class TestDailyFWIValuesAtPoint:
         response = client.get(f"{BASE_URL}/2025-11-02/values?lat=49.0&lon=-123.0")
         assert response.status_code == 404
 
+    @pytest.mark.parametrize("missing_param", ("dc", "dmc", "bui", "ffmc", "isi", "fwi"))
+    def test_returns_404_when_single_raster_missing(self, monkeypatch, missing_param):
+        """All-or-nothing: any one missing parameter raster 404s the whole request
+        rather than returning the other five values with one null."""
+
+        async def _raise_for_missing(self, key):
+            if f"{missing_param}20251102.tif" in key:
+                raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+            return b"fake-bytes"
+
+        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", _raise_for_missing)
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(42.5)
+        )
+
+        client = TestClient(app.sfms_fwi_main.app)
+        response = client.get(f"{BASE_URL}/2025-11-02/values?lat=49.0&lon=-123.0")
+        assert response.status_code == 404
+
     def test_missing_lat_lon_returns_422(self):
         client = TestClient(app.sfms_fwi_main.app)
         response = client.get(f"{BASE_URL}/2025-11-02/values")
@@ -326,7 +367,9 @@ class TestDailyFWIValuesAtPoint:
             return b"fake-bytes"
 
         monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", _capture_key)
-        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(1.0))
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(1.0)
+        )
 
         client = TestClient(app.sfms_fwi_main.app)
         client.get(f"{BASE_URL}/2025-11-02/values?lat=49.0&lon=-123.0")
@@ -340,9 +383,15 @@ class TestHourlyFFMCValueAtPoint:
     """Tests for GET /sfms/daily-fwi/{for_date}/hffmc/value."""
 
     def test_returns_value_at_point(self, monkeypatch, mock_list_hffmc_uploads):
-        mock_list_hffmc_uploads(["sfms/uploads/hourlies/2025-11-02/fine_fuel_moisture_code2025110212.tif"])
-        monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes"))
-        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(85.3))
+        mock_list_hffmc_uploads(
+            ["sfms/uploads/hourlies/2025-11-02/fine_fuel_moisture_code2025110212.tif"]
+        )
+        monkeypatch.setattr(
+            "wps_shared.utils.s3_client.S3Client.read_object", AsyncMock(return_value=b"fake-bytes")
+        )
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(85.3)
+        )
 
         client = TestClient(app.sfms_fwi_main.app)
         response = client.get(f"{BASE_URL}/2025-11-02/hffmc/value?hour=12&lat=49.0&lon=-123.0")
@@ -365,7 +414,9 @@ class TestHourlyFFMCValueAtPoint:
         assert response.status_code == 404
 
     def test_uses_uploaded_hffmc_key(self, monkeypatch, mock_list_hffmc_uploads):
-        mock_list_hffmc_uploads(["sfms/uploads/hourlies/2025-11-02/fine_fuel_moisture_code2025110212.tif"])
+        mock_list_hffmc_uploads(
+            ["sfms/uploads/hourlies/2025-11-02/fine_fuel_moisture_code2025110212.tif"]
+        )
         captured_keys = []
 
         async def _capture_key(self, key):
@@ -373,7 +424,9 @@ class TestHourlyFFMCValueAtPoint:
             return b"fake-bytes"
 
         monkeypatch.setattr("wps_shared.utils.s3_client.S3Client.read_object", _capture_key)
-        monkeypatch.setattr("app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(85.3))
+        monkeypatch.setattr(
+            "app.routers.sfms_fwi.WPSDataset.from_bytes", lambda b: _make_mock_dataset(85.3)
+        )
 
         client = TestClient(app.sfms_fwi_main.app)
         client.get(f"{BASE_URL}/2025-11-02/hffmc/value?hour=12&lat=49.0&lon=-123.0")


### PR DESCRIPTION
Adds `GET /api/sfms/daily-fwi/{date}/values` — samples **all six daily FWI actuals rasters** (ffmc, dmc, dc, isi, bui, fwi) at a single WGS84 lat/lon and returns them in one response.

This is a convenience over the existing per-parameter `/{parameter}/value` route, saving callers from issuing six separate requests for the same point and date.

### Endpoint

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/sfms/daily-fwi/{date}/values?lat=&lon=` | All daily FWI values (ffmc, dmc, dc, isi, bui, fwi) at a WGS84 lat/lon point |

### Example response

```json
{
  "date": "2025-11-02",
  "latitude": 49.0,
  "longitude": -123.0,
  "ffmc": 88.1, "dmc": 24.3, "dc": 210.5,
  "isi": 6.2, "bui": 35.0, "fwi": 12.4
}
```
Notes

- Extracted the shared load-and-sample logic into a `_sample_daily_fwi_value` helper and refactored the existing single-parameter value route onto it, so both routes build the S3 key and sample identically.
- The new route `asyncio.gather`s the six raster reads so the S3 I/O overlaps rather than running strictly serially.
- **Route ordering:** `/{for_date}/values` is declared before the bare `/{for_date}/{parameter}` download route so the literal `values` segment isn't captured as `{parameter}` — same pattern the existing `/value` routes use.
- **Error semantics** match the existing endpoints: each value is `null` if the point is outside the raster's extent or on a nodata pixel; a `404` means the any of the date's rasters don't exist; a `502` surfaces object-store errors.

Closes #5597 
# Test Links:
[Landing Page](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[C-Haines](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/c-haines)
[FireCalc](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5599-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
