### PR TITLE
Dev: Distinguish upstream outages from real failures in the weather model jobs

### DIFF
--- a/backend/packages/wps-api/src/app/tests/jobs/test_grass_curing.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_grass_curing.py
@@ -70,12 +70,12 @@ def test_grass_curing_job_fail(mocker: MockerFixture, monkeypatch):
         raise OSError("Error")
 
     monkeypatch.setattr(GrassCuringJob, '_run_grass_curing', mock__run_grass_curing)
-    rocket_chat_spy = mocker.spy(grass_curing, 'send_chatops_notification')
+    chatops_spy = mocker.spy(grass_curing, 'send_chatops_notification')
 
     with pytest.raises(SystemExit) as excinfo:
         grass_curing.main()
     assert excinfo.value.code == os.EX_SOFTWARE
-    assert rocket_chat_spy.call_count == 1
+    assert chatops_spy.call_count == 1
 
 
 def test_grass_curing_job_exits_without_error_when_no_work_required(monkeypatch):
@@ -154,13 +154,13 @@ def test_main_exits_cleanly_when_file_not_found(mocker: MockerFixture, monkeypat
         raise GrassCuringFileNotFoundException("not found")
 
     monkeypatch.setattr(GrassCuringJob, "_run_grass_curing", mock__run_grass_curing)
-    rocket_chat_spy = mocker.spy(grass_curing, "send_chatops_notification")
+    chatops_spy = mocker.spy(grass_curing, "send_chatops_notification")
 
     with pytest.raises(SystemExit) as excinfo:
         grass_curing.main()
 
     assert excinfo.value.code == os.EX_OK
-    assert rocket_chat_spy.call_count == 0
+    assert chatops_spy.call_count == 0
 
 
 def test_yield_value_for_stations_returns_correct_pixel_values():

--- a/backend/packages/wps-api/src/app/tests/jobs/test_hourly_actuals.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_hourly_actuals.py
@@ -40,11 +40,11 @@ def test_hourly_actuals_job_fail(mocker: MockerFixture, mock_wfwx_api):
 
     mock_wfwx_api.get_hourly_actuals_all_stations = mocker.AsyncMock(side_effect=Exception())
     mocker.patch("app.jobs.hourly_actuals.WfwxApi", return_value=mock_wfwx_api)
-    rocket_chat_spy = mocker.spy(hourly_actuals, "send_chatops_notification")
+    chatops_spy = mocker.spy(hourly_actuals, "send_chatops_notification")
 
     with pytest.raises(SystemExit) as excinfo:
         hourly_actuals.main()
     # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_SOFTWARE
     # Assert that rocket chat was called.
-    assert rocket_chat_spy.call_count == 1
+    assert chatops_spy.call_count == 1

--- a/backend/packages/wps-api/src/app/tests/jobs/test_noon_forecasts.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_noon_forecasts.py
@@ -38,11 +38,11 @@ def test_noon_forecasts_bot_fail(mocker: MockerFixture, monkeypatch, mock_wfwx_a
     """
 
     mock_wfwx_api.get_noon_forecasts_all_stations = mocker.AsyncMock(side_effect=Exception())
-    rocket_chat_spy = mocker.spy(noon_forecasts, "send_chatops_notification")
+    chatops_spy = mocker.spy(noon_forecasts, "send_chatops_notification")
 
     with pytest.raises(SystemExit) as excinfo:
         noon_forecasts.main()
     # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_SOFTWARE
     # Assert that rocket chat was called.
-    assert rocket_chat_spy.call_count == 1
+    assert chatops_spy.call_count == 1

--- a/backend/packages/wps-api/src/app/tests/jobs/test_viirs_snow.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_viirs_snow.py
@@ -255,7 +255,7 @@ def test_viirs_snow_job_fail(mocker: MockerFixture, monkeypatch: pytest.MonkeyPa
         raise OSError("Error")
 
     monkeypatch.setattr(ViirsSnowJob, "_get_last_processed_date", mock__get_last_processed_date)
-    rocket_chat_spy = mocker.spy(viirs_snow, "send_chatops_notification")
+    chatops_spy = mocker.spy(viirs_snow, "send_chatops_notification")
     # mock sys.argv with a random path, otherwise argparser will pickup the sys.argv args from pytest
     mocker.patch("sys.argv", ["/test"])
 
@@ -264,7 +264,7 @@ def test_viirs_snow_job_fail(mocker: MockerFixture, monkeypatch: pytest.MonkeyPa
     # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_SOFTWARE
     # Assert that rocket chat was called.
-    assert rocket_chat_spy.call_count == 1
+    assert chatops_spy.call_count == 1
 
 
 def test_viirs_snow_job_exits_without_error_when_no_work_required(
@@ -333,11 +333,11 @@ def test_viirs_snow_job_fails_on_earthdata_access_auth_failure(
     # mock sys.argv with a random path, otherwise argparser will pickup the sys.argv args from pytest
     mocker.patch("sys.argv", ["/test"])
 
-    rocket_chat_spy = mocker.spy(viirs_snow, "send_chatops_notification")
+    chatops_spy = mocker.spy(viirs_snow, "send_chatops_notification")
 
     with pytest.raises(SystemExit) as excinfo:
         viirs_snow.main()
     # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_SOFTWARE
     # Assert that rocket chat was called.
-    assert rocket_chat_spy.call_count == 1
+    assert chatops_spy.call_count == 1

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_ecmwf.py
@@ -283,7 +283,7 @@ def test_main_success(mocker: MockerFixture, monkeypatch):
     monkeypatch.setattr(ClientSession, "get", default_mock_client_get)
     monkeypatch.setattr(weather_model_jobs.ecmwf, "process_models", mock_process_models)
     mocker.patch.object(weather_model_jobs.ecmwf, "exit_process", side_effect=raise_system_exit)
-    rocket_chat_spy = mocker.spy(weather_model_jobs.ecmwf, "send_chatops_notification")
+    chatops_spy = mocker.spy(weather_model_jobs.ecmwf, "send_chatops_notification")
 
     with pytest.raises(SystemExit) as excinfo:
         weather_model_jobs.ecmwf.main()
@@ -291,7 +291,7 @@ def test_main_success(mocker: MockerFixture, monkeypatch):
     # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_OK
     # Assert that rocket chat was called.
-    assert rocket_chat_spy.call_count == 0
+    assert chatops_spy.call_count == 0
 
 
 def test_main_fail(mocker: MockerFixture, monkeypatch):
@@ -300,7 +300,7 @@ def test_main_fail(mocker: MockerFixture, monkeypatch):
     def mock_process_models():
         raise Exception()
 
-    rocket_chat_spy = mocker.spy(weather_model_jobs.ecmwf, "send_chatops_notification")
+    chatops_spy = mocker.spy(weather_model_jobs.ecmwf, "send_chatops_notification")
     monkeypatch.setattr(weather_model_jobs.ecmwf, "process_models", mock_process_models)
     mocker.patch.object(weather_model_jobs.ecmwf, "exit_process", side_effect=raise_system_exit)
 
@@ -310,7 +310,7 @@ def test_main_fail(mocker: MockerFixture, monkeypatch):
     # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_SOFTWARE
     # Assert that rocket chat was called.
-    assert rocket_chat_spy.call_count == 1
+    assert chatops_spy.call_count == 1
 
 
 @pytest.mark.anyio

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_gdps.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_gdps.py
@@ -254,6 +254,48 @@ EXIT_DECISION_CASES = [
 ]
 
 
+# What main() does about each verdict process_models() can reach.
+#
+# raised_by_process_models, exit_code, chatops_severity (None = no notification at all)
+MAIN_OUTCOME_CASES = [
+    # A clean run: succeed quietly.
+    (None, os.EX_OK, None),
+    # An outage on HPFX and DD: tell us, but don't fail the job - hourly retries recover it.
+    (NoFilesProcessed("no files processed"), os.EX_OK, "warning"),
+    # Real exceptions on some URLs: fail the job. Deliberately no chatops (pre-existing).
+    (CompletedWithSomeExceptions(), os.EX_SOFTWARE, None),
+    # Anything we didn't see coming: fail loudly.
+    (ValueError("boom"), os.EX_SOFTWARE, "critical"),
+]
+
+
+@pytest.mark.parametrize("raised,exit_code,severity", MAIN_OUTCOME_CASES)
+def test_main_outcomes(raised, exit_code, severity, mocker, monkeypatch: pytest.MonkeyPatch):
+    """Pin the exit code and chatops severity main() produces for every verdict."""
+    monkeypatch.setattr(sys, "argv", ["argv", "GDPS"])
+    monkeypatch.setattr(env_canada, "apply_data_retention_policy", MagicMock())
+
+    def process_models():
+        if raised is not None:
+            raise raised
+
+    monkeypatch.setattr(env_canada, "process_models", process_models)
+    chatops_spy = mocker.patch.object(env_canada, "send_chatops_notification")
+
+    with pytest.raises(SystemExit) as excinfo:
+        env_canada.main()
+
+    assert excinfo.value.code == exit_code
+
+    if severity is None:
+        chatops_spy.assert_not_called()
+    else:
+        chatops_spy.assert_called_once()
+        # severity is only passed explicitly for the outage path; otherwise it defaults.
+        assert chatops_spy.call_args.kwargs.get("severity", "critical") == severity
+        assert "GDPS" in chatops_spy.call_args.args[0]
+
+
 @pytest.mark.parametrize(
     "files_processed,connection_errors,exceptions,expected", EXIT_DECISION_CASES
 )

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_gdps.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_gdps.py
@@ -233,94 +233,41 @@ def test_process_models_raises_no_files_processed_when_all_downloads_fail(
         env_canada.process_models()
 
 
-# How a finished run is judged, over every combination of the three counters it is judged on.
-#
-# NoFilesProcessed            -> warning to chatops, exits EX_OK (an upstream outage).
-# CompletedWithSomeExceptions -> exits EX_SOFTWARE (something we can act on).
-# None                        -> no raise, exits EX_OK (success, or nothing new to do).
-#
-# The rule the corner cases turn on: a real exception always beats an outage, because
-# NoFilesProcessed is excused as "the retries will get it" and a genuine bug must not be.
-EXIT_DECISION_CASES = [
-    # files_processed, connection_errors, exceptions, expected
-    (10, 0, 0, None),  # clean run
-    (0, 0, 0, None),  # nothing new to do: everything already processed, or not published yet
-    (10, 5, 0, None),  # partial outage, but we still got files: retries pick up the rest
-    (0, 5, 0, NoFilesProcessed),  # total outage, nothing else wrong
-    (0, 5, 3, CompletedWithSomeExceptions),  # outage AND a real bug: the bug wins
-    (0, 0, 3, CompletedWithSomeExceptions),  # nothing processed, purely our own fault
-    (10, 0, 3, CompletedWithSomeExceptions),  # partial success with real exceptions
-    (10, 5, 3, CompletedWithSomeExceptions),  # everything at once: still a real failure
-]
+# The verdict rules themselves live on the shared runner and are tested in
+# test_model_job_runner.py. All this job has to get right is the wiring.
 
 
-# What main() does about each verdict process_models() can reach.
-#
-# raised_by_process_models, exit_code, chatops_severity (None = no notification at all)
-MAIN_OUTCOME_CASES = [
-    # A clean run: succeed quietly.
-    (None, os.EX_OK, None),
-    # An outage on HPFX and DD: tell us, but don't fail the job - hourly retries recover it.
-    (NoFilesProcessed("no files processed"), os.EX_OK, "warning"),
-    # Real exceptions on some URLs: fail the job. Deliberately no chatops (pre-existing).
-    (CompletedWithSomeExceptions(), os.EX_SOFTWARE, None),
-    # Anything we didn't see coming: fail loudly.
-    (ValueError("boom"), os.EX_SOFTWARE, "critical"),
-]
-
-
-@pytest.mark.parametrize("raised,exit_code,severity", MAIN_OUTCOME_CASES)
-def test_main_outcomes(raised, exit_code, severity, mocker, monkeypatch: pytest.MonkeyPatch):
-    """Pin the exit code and chatops severity main() produces for every verdict."""
-    monkeypatch.setattr(sys, "argv", ["argv", "GDPS"])
-    monkeypatch.setattr(env_canada, "apply_data_retention_policy", MagicMock())
-
-    def process_models():
-        if raised is not None:
-            raise raised
-
-    monkeypatch.setattr(env_canada, "process_models", process_models)
-    chatops_spy = mocker.patch.object(env_canada, "send_chatops_notification")
-
-    with pytest.raises(SystemExit) as excinfo:
-        env_canada.main()
-
-    assert excinfo.value.code == exit_code
-
-    if severity is None:
-        chatops_spy.assert_not_called()
-    else:
-        chatops_spy.assert_called_once()
-        # severity is only passed explicitly for the outage path; otherwise it defaults.
-        assert chatops_spy.call_args.kwargs.get("severity", "critical") == severity
-        assert "GDPS" in chatops_spy.call_args.args[0]
-
-
-@pytest.mark.parametrize(
-    "files_processed,connection_errors,exceptions,expected", EXIT_DECISION_CASES
-)
-def test_process_models_exit_decision(
-    files_processed,
-    connection_errors,
-    exceptions,
-    expected,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """Pin how process_models() judges a finished run, for every counter combination."""
+def test_process_models_delegates_the_verdict_to_judge_run(monkeypatch: pytest.MonkeyPatch):
+    """process_models() must hand its counters to judge_run and return the result."""
     monkeypatch.setattr("wps_shared.db.database.get_write_session_scope", MagicMock())
     monkeypatch.setattr(env_canada, "ModelValueProcessor", MagicMock())
     monkeypatch.setattr(env_canada, "GribFileProcessor", MagicMock())
 
     def finished_run(self):
-        self.files_processed = files_processed
-        self.connection_error_count = connection_errors
-        self.exception_count = exceptions
+        self.files_processed = 7
+        self.connection_error_count = 2
+        self.exception_count = 0
 
     monkeypatch.setattr(env_canada.EnvCanada, "process", finished_run)
+    judge_run = MagicMock(return_value=7)
+    monkeypatch.setattr(env_canada, "judge_run", judge_run)
     monkeypatch.setattr(sys, "argv", ["argv", "GDPS"])
 
-    if expected is None:
-        assert env_canada.process_models() == files_processed
-    else:
-        with pytest.raises(expected):
-            env_canada.process_models()
+    assert env_canada.process_models() == 7
+
+    job = judge_run.call_args.args[0]
+    assert (job.files_processed, job.connection_error_count, job.exception_count) == (7, 2, 0)
+    assert judge_run.call_args.kwargs == {"source": "Env Canada", "model": "GDPS"}
+
+
+def test_main_delegates_to_the_shared_runner(monkeypatch: pytest.MonkeyPatch):
+    """main() must hand process_models to the runner, tagged with this job's source."""
+    run_model_job = MagicMock()
+    monkeypatch.setattr(env_canada, "run_model_job", run_model_job)
+    monkeypatch.setattr(sys, "argv", ["argv", "GDPS"])
+
+    env_canada.main()
+
+    run_model_job.assert_called_once_with(
+        env_canada.process_models, source="Env Canada", model="GDPS"
+    )

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_gdps.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_gdps.py
@@ -24,7 +24,11 @@ from wps_shared.db.models.weather_models import (
     ProcessedModelRunUrl,
 )
 from wps_shared.tests.common import default_mock_client_get
-from wps_shared.weather_models import ModelEnum, NoFilesProcessed
+from wps_shared.weather_models import (
+    CompletedWithSomeExceptions,
+    ModelEnum,
+    NoFilesProcessed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -227,3 +231,54 @@ def test_process_models_raises_no_files_processed_when_all_downloads_fail(
     sys.argv = ["argv", "GDPS"]
     with pytest.raises(NoFilesProcessed):
         env_canada.process_models()
+
+
+# How a finished run is judged, over every combination of the three counters it is judged on.
+#
+# NoFilesProcessed            -> warning to chatops, exits EX_OK (an upstream outage).
+# CompletedWithSomeExceptions -> exits EX_SOFTWARE (something we can act on).
+# None                        -> no raise, exits EX_OK (success, or nothing new to do).
+#
+# The rule the corner cases turn on: a real exception always beats an outage, because
+# NoFilesProcessed is excused as "the retries will get it" and a genuine bug must not be.
+EXIT_DECISION_CASES = [
+    # files_processed, connection_errors, exceptions, expected
+    (10, 0, 0, None),  # clean run
+    (0, 0, 0, None),  # nothing new to do: everything already processed, or not published yet
+    (10, 5, 0, None),  # partial outage, but we still got files: retries pick up the rest
+    (0, 5, 0, NoFilesProcessed),  # total outage, nothing else wrong
+    (0, 5, 3, CompletedWithSomeExceptions),  # outage AND a real bug: the bug wins
+    (0, 0, 3, CompletedWithSomeExceptions),  # nothing processed, purely our own fault
+    (10, 0, 3, CompletedWithSomeExceptions),  # partial success with real exceptions
+    (10, 5, 3, CompletedWithSomeExceptions),  # everything at once: still a real failure
+]
+
+
+@pytest.mark.parametrize(
+    "files_processed,connection_errors,exceptions,expected", EXIT_DECISION_CASES
+)
+def test_process_models_exit_decision(
+    files_processed,
+    connection_errors,
+    exceptions,
+    expected,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Pin how process_models() judges a finished run, for every counter combination."""
+    monkeypatch.setattr("wps_shared.db.database.get_write_session_scope", MagicMock())
+    monkeypatch.setattr(env_canada, "ModelValueProcessor", MagicMock())
+    monkeypatch.setattr(env_canada, "GribFileProcessor", MagicMock())
+
+    def finished_run(self):
+        self.files_processed = files_processed
+        self.connection_error_count = connection_errors
+        self.exception_count = exceptions
+
+    monkeypatch.setattr(env_canada.EnvCanada, "process", finished_run)
+    monkeypatch.setattr(sys, "argv", ["argv", "GDPS"])
+
+    if expected is None:
+        assert env_canada.process_models() == files_processed
+    else:
+        with pytest.raises(expected):
+            env_canada.process_models()

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_hrdps.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_hrdps.py
@@ -18,6 +18,7 @@ import wps_shared.utils.time as time_utils
 import wps_shared.db.database
 import wps_shared.db.crud.weather_models
 import weather_model_jobs.env_canada
+from weather_model_jobs import model_job_runner
 import weather_model_jobs.common_model_fetchers
 import weather_model_jobs.utils.process_grib
 from wps_shared.weather_models import ProjectionEnum
@@ -153,7 +154,8 @@ def test_main_fail(mocker: MockerFixture, monkeypatch):
     def mock_process_models():
         raise Exception()
 
-    rocket_chat_spy = mocker.spy(weather_model_jobs.env_canada, "send_chatops_notification")
+    # chatops now lives on the shared runner, which is what env_canada.main() delegates to.
+    rocket_chat_spy = mocker.patch.object(model_job_runner, "send_chatops_notification")
     monkeypatch.setattr(weather_model_jobs.env_canada, "process_models", mock_process_models)
 
     with pytest.raises(SystemExit) as excinfo:

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_hrdps.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_env_canada_hrdps.py
@@ -155,7 +155,7 @@ def test_main_fail(mocker: MockerFixture, monkeypatch):
         raise Exception()
 
     # chatops now lives on the shared runner, which is what env_canada.main() delegates to.
-    rocket_chat_spy = mocker.patch.object(model_job_runner, "send_chatops_notification")
+    chatops_spy = mocker.patch.object(model_job_runner, "send_chatops_notification")
     monkeypatch.setattr(weather_model_jobs.env_canada, "process_models", mock_process_models)
 
     with pytest.raises(SystemExit) as excinfo:
@@ -164,7 +164,7 @@ def test_main_fail(mocker: MockerFixture, monkeypatch):
     # Assert that we exited with an error code.
     assert excinfo.value.code == os.EX_SOFTWARE
     # Assert that rocket chat was called.
-    assert rocket_chat_spy.call_count == 1
+    assert chatops_spy.call_count == 1
 
 
 def test_parse_high_res_model_url_correct_format():

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_model_job_runner.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_model_job_runner.py
@@ -1,0 +1,151 @@
+"""Unit tests for weather_model_jobs/model_job_runner.py
+
+This is where the weather model jobs decide success from failure. Both Env Canada and NOAA
+delegate to judge_run() and run_model_job(), so the rules are pinned here once.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from weather_model_jobs import model_job_runner
+from weather_model_jobs.model_job_runner import judge_run, run_model_job
+from wps_shared.weather_models import CompletedWithSomeExceptions, NoFilesProcessed
+
+SOURCE = "Env Canada"
+MODEL = "GDPS"
+
+
+class FakeJob:
+    """A finished job, as judge_run() sees it."""
+
+    def __init__(self, files_processed, connection_error_count, exception_count):
+        self.files_processed = files_processed
+        self.connection_error_count = connection_error_count
+        self.exception_count = exception_count
+
+
+# How a finished run is judged, over every combination of the three counters it is judged on.
+#
+# NoFilesProcessed            -> warning to chatops, exits EX_OK (an upstream outage).
+# CompletedWithSomeExceptions -> exits EX_SOFTWARE (something we can act on).
+# None                        -> no raise, exits EX_OK (success, or nothing new to do).
+#
+# The rule the corner cases turn on: a real exception always beats an outage, because
+# NoFilesProcessed is excused as "the retries will get it" and a genuine bug must not be.
+EXIT_DECISION_CASES = [
+    # files_processed, connection_errors, exceptions, expected
+    (10, 0, 0, None),  # clean run
+    (0, 0, 0, None),  # nothing new to do: everything already processed, or not published yet
+    (10, 5, 0, None),  # partial outage, but we still got files: retries pick up the rest
+    (0, 5, 0, NoFilesProcessed),  # total outage, nothing else wrong
+    (0, 5, 3, CompletedWithSomeExceptions),  # outage AND a real bug: the bug wins
+    (0, 0, 3, CompletedWithSomeExceptions),  # nothing processed, purely our own fault
+    (10, 0, 3, CompletedWithSomeExceptions),  # partial success with real exceptions
+    (10, 5, 3, CompletedWithSomeExceptions),  # everything at once: still a real failure
+]
+
+
+def exit_decision_id(case) -> str:
+    files_processed, connection_errors, exceptions, expected = case
+    outcome = expected.__name__ if expected else "ok"
+    return f"{files_processed}processed-{connection_errors}conn-{exceptions}exc-{outcome}"
+
+
+@pytest.mark.parametrize("case", EXIT_DECISION_CASES, ids=exit_decision_id)
+def test_judge_run(case):
+    """Pin how a finished run is judged, for every counter combination."""
+    files_processed, connection_errors, exceptions, expected = case
+    job = FakeJob(files_processed, connection_errors, exceptions)
+
+    if expected is None:
+        assert judge_run(job, source=SOURCE, model=MODEL) == files_processed
+    else:
+        with pytest.raises(expected):
+            judge_run(job, source=SOURCE, model=MODEL)
+
+
+# What run_model_job() does about each verdict judge_run() can reach.
+#
+# raised_by_process_models, exit_code, chatops_severity (None = no notification at all)
+MAIN_OUTCOME_CASES = [
+    # A clean run: succeed quietly.
+    (None, os.EX_OK, None),
+    # An upstream outage: tell us, but don't fail the job - the hourly retries recover it.
+    (NoFilesProcessed("no files processed"), os.EX_OK, "warning"),
+    # Real exceptions on some URLs: fail the job. Deliberately no chatops (pre-existing).
+    (CompletedWithSomeExceptions(), os.EX_SOFTWARE, None),
+    # Anything we didn't see coming: fail loudly.
+    (ValueError("boom"), os.EX_SOFTWARE, "critical"),
+]
+
+
+def main_outcome_id(case) -> str:
+    raised, _, severity = case
+    return f"{type(raised).__name__ if raised else 'success'}-{severity or 'no_chatops'}"
+
+
+@pytest.mark.parametrize("case", MAIN_OUTCOME_CASES, ids=main_outcome_id)
+def test_run_model_job(case, mocker, monkeypatch):
+    """Pin the exit code and chatops severity produced for every verdict."""
+    raised, exit_code, severity = case
+
+    monkeypatch.setattr(model_job_runner, "apply_data_retention_policy", MagicMock())
+    chatops_spy = mocker.patch.object(model_job_runner, "send_chatops_notification")
+
+    def process_models():
+        if raised is not None:
+            raise raised
+
+    with pytest.raises(SystemExit) as excinfo:
+        run_model_job(process_models, source=SOURCE, model=MODEL)
+
+    assert excinfo.value.code == exit_code
+
+    if severity is None:
+        chatops_spy.assert_not_called()
+    else:
+        chatops_spy.assert_called_once()
+        # severity is only passed explicitly for the outage path; otherwise it defaults.
+        assert chatops_spy.call_args.kwargs.get("severity", "critical") == severity
+        # The message must name the model and the source - NOAA's used to be a broken
+        # f-string that posted the literal text "{sys.argv[1]}" to chatops.
+        message = chatops_spy.call_args.args[0]
+        assert MODEL in message
+        assert SOURCE in message
+
+
+def test_run_model_job_applies_data_retention_policy_on_success(mocker, monkeypatch):
+    """The retention policy only runs when the job got that far."""
+    retention = MagicMock()
+    monkeypatch.setattr(model_job_runner, "apply_data_retention_policy", retention)
+    mocker.patch.object(model_job_runner, "send_chatops_notification")
+
+    with pytest.raises(SystemExit):
+        run_model_job(lambda: None, source=SOURCE, model=MODEL)
+
+    retention.assert_called_once()
+
+
+def test_judge_run_warns_about_connection_errors(caplog):
+    """A partial outage still gets a line in the log, even though the run succeeds."""
+    job = FakeJob(files_processed=10, connection_error_count=5, exception_count=0)
+
+    with caplog.at_level("WARNING"):
+        judge_run(job, source=SOURCE, model=MODEL)
+
+    assert "5 connection error(s)" in caplog.text
+
+
+def test_sys_argv_is_not_read_by_the_runner():
+    """The runner takes the model as an argument - it must not reach back into sys.argv."""
+    original = sys.argv
+    sys.argv = ["argv"]  # no model argument at all
+    try:
+        job = FakeJob(files_processed=0, connection_error_count=1, exception_count=0)
+        with pytest.raises(NoFilesProcessed) as excinfo:
+            judge_run(job, source=SOURCE, model=MODEL)
+        assert MODEL in str(excinfo.value)
+    finally:
+        sys.argv = original

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
@@ -344,6 +344,50 @@ EXIT_DECISION_CASES = [
 ]
 
 
+# What main() does about each verdict process_models() can reach.
+#
+# raised_by_process_models, exit_code, chatops_severity (None = no notification at all)
+MAIN_OUTCOME_CASES = [
+    # A clean run: succeed quietly.
+    (None, os.EX_OK, None),
+    # An outage at NOAA: tell us, but don't fail the job - the hourly retries recover it.
+    (NoFilesProcessed("no files processed"), os.EX_OK, "warning"),
+    # Real exceptions on some URLs: fail the job. Deliberately no chatops (pre-existing).
+    (CompletedWithSomeExceptions(), os.EX_SOFTWARE, None),
+    # Anything we didn't see coming: fail loudly.
+    (ValueError("boom"), os.EX_SOFTWARE, "critical"),
+]
+
+
+@pytest.mark.parametrize("raised,exit_code,severity", MAIN_OUTCOME_CASES)
+def test_main_outcomes(raised, exit_code, severity, mocker, monkeypatch):
+    """Pin the exit code and chatops severity main() produces for every verdict."""
+    monkeypatch.setattr(sys, "argv", ["argv", "GFS"])
+    monkeypatch.setattr(noaa, "apply_data_retention_policy", MagicMock())
+
+    def process_models():
+        if raised is not None:
+            raise raised
+
+    monkeypatch.setattr(noaa, "process_models", process_models)
+    chatops_spy = mocker.patch.object(noaa, "send_chatops_notification")
+
+    with pytest.raises(SystemExit) as excinfo:
+        noaa.main()
+
+    assert excinfo.value.code == exit_code
+
+    if severity is None:
+        chatops_spy.assert_not_called()
+    else:
+        chatops_spy.assert_called_once()
+        # severity is only passed explicitly for the outage path; otherwise it defaults.
+        assert chatops_spy.call_args.kwargs.get("severity", "critical") == severity
+        # The message must name the model - it used to be a broken f-string that
+        # posted the literal text "{sys.argv[1]}" to chatops.
+        assert "GFS" in chatops_spy.call_args.args[0]
+
+
 @pytest.mark.parametrize(
     "files_processed,connection_errors,exceptions,expected", EXIT_DECISION_CASES
 )

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import sys
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
@@ -23,7 +24,11 @@ from wps_shared.db.models.weather_models import (
     PredictionModelRunTimestamp,
     ProcessedModelRunUrl,
 )
-from wps_shared.weather_models import ModelEnum
+from wps_shared.weather_models import (
+    CompletedWithSomeExceptions,
+    ModelEnum,
+    NoFilesProcessed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -307,6 +312,53 @@ def test_process_model_run_urls_generic_exception_increments_count(monkeypatch):
     noaa_instance.process_model_run_urls(["https://example.com/grib1", "https://example.com/grib2"])
 
     assert noaa_instance.exception_count == 2
+
+
+# How a finished run is judged, over every combination of the three counters it is judged on.
+#
+# NoFilesProcessed            -> warning to chatops, exits EX_OK (an outage at NOAA).
+# CompletedWithSomeExceptions -> exits EX_SOFTWARE (something we can act on).
+# None                        -> no raise, exits EX_OK (success, or nothing new to do).
+#
+# The rule the corner cases turn on: a real exception always beats an outage, because
+# NoFilesProcessed is excused as "the retries will get it" and a genuine bug must not be.
+EXIT_DECISION_CASES = [
+    # files_processed, connection_errors, exceptions, expected
+    (10, 0, 0, None),  # clean run
+    (0, 0, 0, None),  # nothing new to do: everything already processed, or not published yet
+    (10, 5, 0, None),  # partial outage, but we still got files: retries pick up the rest
+    (0, 5, 0, NoFilesProcessed),  # total outage, nothing else wrong
+    (0, 5, 3, CompletedWithSomeExceptions),  # outage AND a real bug: the bug wins
+    (0, 0, 3, CompletedWithSomeExceptions),  # nothing processed, purely our own fault
+    (10, 0, 3, CompletedWithSomeExceptions),  # partial success with real exceptions
+    (10, 5, 3, CompletedWithSomeExceptions),  # everything at once: still a real failure
+]
+
+
+@pytest.mark.parametrize(
+    "files_processed,connection_errors,exceptions,expected", EXIT_DECISION_CASES
+)
+def test_process_models_exit_decision(
+    files_processed, connection_errors, exceptions, expected, monkeypatch
+):
+    """Pin how process_models() judges a finished run, for every counter combination."""
+    monkeypatch.setattr("wps_shared.db.database.get_write_session_scope", MagicMock())
+    monkeypatch.setattr(noaa, "ModelValueProcessor", MagicMock())
+    monkeypatch.setattr(noaa, "GribFileProcessor", MagicMock())
+
+    def finished_run(self):
+        self.files_processed = files_processed
+        self.connection_error_count = connection_errors
+        self.exception_count = exceptions
+
+    monkeypatch.setattr(noaa.NOAA, "process", finished_run)
+    monkeypatch.setattr(sys, "argv", ["argv", "GFS"])
+
+    if expected is None:
+        assert noaa.process_models() == files_processed
+    else:
+        with pytest.raises(expected):
+            noaa.process_models()
 
 
 def test_process_model_run_urls_connection_error_increments_connection_count(monkeypatch):

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
@@ -251,6 +251,15 @@ def _make_noaa(monkeypatch, model_type=ModelEnum.GFS):
     return noaa.NOAA(MagicMock(), model_type)
 
 
+def _raise(exception):
+    """Return a process_url stand-in that always raises *exception*."""
+
+    def process_url(url):
+        raise exception
+
+    return process_url
+
+
 def test_process_model_run_urls_403_is_warned_not_raised(monkeypatch):
     """403 HTTPError should be logged as a warning and not increment exception_count."""
     noaa_instance = _make_noaa(monkeypatch)
@@ -258,7 +267,7 @@ def test_process_model_run_urls_403_is_warned_not_raised(monkeypatch):
     mock_response.status_code = 403
     http_error = HTTPError(response=mock_response)
 
-    monkeypatch.setattr(noaa_instance, "process_url", lambda url: (_ for _ in ()).throw(http_error))
+    monkeypatch.setattr(noaa_instance, "process_url", _raise(http_error))
 
     noaa_instance.process_model_run_urls(["https://example.com/grib1"])
 
@@ -272,7 +281,7 @@ def test_process_model_run_urls_404_is_warned_not_raised(monkeypatch):
     mock_response.status_code = 404
     http_error = HTTPError(response=mock_response)
 
-    monkeypatch.setattr(noaa_instance, "process_url", lambda url: (_ for _ in ()).throw(http_error))
+    monkeypatch.setattr(noaa_instance, "process_url", _raise(http_error))
 
     noaa_instance.process_model_run_urls(["https://example.com/grib1"])
 
@@ -286,7 +295,7 @@ def test_process_model_run_urls_500_http_error_is_reraised(monkeypatch):
     mock_response.status_code = 500
     http_error = HTTPError(response=mock_response)
 
-    monkeypatch.setattr(noaa_instance, "process_url", lambda url: (_ for _ in ()).throw(http_error))
+    monkeypatch.setattr(noaa_instance, "process_url", _raise(http_error))
 
     with pytest.raises(HTTPError):
         noaa_instance.process_model_run_urls(["https://example.com/grib1"])
@@ -297,7 +306,7 @@ def test_process_model_run_urls_http_error_without_response_is_reraised(monkeypa
     noaa_instance = _make_noaa(monkeypatch)
     http_error = HTTPError(response=None)
 
-    monkeypatch.setattr(noaa_instance, "process_url", lambda url: (_ for _ in ()).throw(http_error))
+    monkeypatch.setattr(noaa_instance, "process_url", _raise(http_error))
 
     with pytest.raises(HTTPError):
         noaa_instance.process_model_run_urls(["https://example.com/grib1"])
@@ -307,7 +316,7 @@ def test_process_model_run_urls_generic_exception_increments_count(monkeypatch):
     """Non-HTTP exceptions should increment exception_count for each URL and not raise."""
     noaa_instance = _make_noaa(monkeypatch)
 
-    monkeypatch.setattr(noaa_instance, "process_url", lambda url: (_ for _ in ()).throw(ValueError("boom")))
+    monkeypatch.setattr(noaa_instance, "process_url", _raise(ValueError("boom")))
 
     noaa_instance.process_model_run_urls(["https://example.com/grib1", "https://example.com/grib2"])
 
@@ -365,11 +374,7 @@ def test_process_model_run_urls_connection_error_increments_connection_count(mon
     """A NOMADS outage is not a bug on our side: it must not land in exception_count."""
     noaa_instance = _make_noaa(monkeypatch)
 
-    monkeypatch.setattr(
-        noaa_instance,
-        "process_url",
-        lambda url: (_ for _ in ()).throw(requests.ConnectionError()),
-    )
+    monkeypatch.setattr(noaa_instance, "process_url", _raise(requests.ConnectionError()))
 
     noaa_instance.process_model_run_urls(["https://example.com/grib1", "https://example.com/grib2"])
 
@@ -381,9 +386,7 @@ def test_process_model_run_urls_timeout_increments_connection_count(monkeypatch)
     """Timeouts are the other half of an outage and are counted the same way."""
     noaa_instance = _make_noaa(monkeypatch)
 
-    monkeypatch.setattr(
-        noaa_instance, "process_url", lambda url: (_ for _ in ()).throw(requests.Timeout())
-    )
+    monkeypatch.setattr(noaa_instance, "process_url", _raise(requests.Timeout()))
 
     noaa_instance.process_model_run_urls(["https://example.com/grib1"])
 

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
@@ -309,6 +309,36 @@ def test_process_model_run_urls_generic_exception_increments_count(monkeypatch):
     assert noaa_instance.exception_count == 2
 
 
+def test_process_model_run_urls_connection_error_increments_connection_count(monkeypatch):
+    """A NOMADS outage is not a bug on our side: it must not land in exception_count."""
+    noaa_instance = _make_noaa(monkeypatch)
+
+    monkeypatch.setattr(
+        noaa_instance,
+        "process_url",
+        lambda url: (_ for _ in ()).throw(requests.ConnectionError()),
+    )
+
+    noaa_instance.process_model_run_urls(["https://example.com/grib1", "https://example.com/grib2"])
+
+    assert noaa_instance.connection_error_count == 2
+    assert noaa_instance.exception_count == 0
+
+
+def test_process_model_run_urls_timeout_increments_connection_count(monkeypatch):
+    """Timeouts are the other half of an outage and are counted the same way."""
+    noaa_instance = _make_noaa(monkeypatch)
+
+    monkeypatch.setattr(
+        noaa_instance, "process_url", lambda url: (_ for _ in ()).throw(requests.Timeout())
+    )
+
+    noaa_instance.process_model_run_urls(["https://example.com/grib1"])
+
+    assert noaa_instance.connection_error_count == 1
+    assert noaa_instance.exception_count == 0
+
+
 def test_process_model_run_urls_403_does_not_stop_remaining_urls(monkeypatch):
     """A 403 on one URL should not prevent subsequent URLs from being processed."""
     noaa_instance = _make_noaa(monkeypatch)

--- a/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
+++ b/backend/packages/wps-jobs/src/tests/weather_models/test_noaa_gfs.py
@@ -323,95 +323,42 @@ def test_process_model_run_urls_generic_exception_increments_count(monkeypatch):
     assert noaa_instance.exception_count == 2
 
 
-# How a finished run is judged, over every combination of the three counters it is judged on.
-#
-# NoFilesProcessed            -> warning to chatops, exits EX_OK (an outage at NOAA).
-# CompletedWithSomeExceptions -> exits EX_SOFTWARE (something we can act on).
-# None                        -> no raise, exits EX_OK (success, or nothing new to do).
-#
-# The rule the corner cases turn on: a real exception always beats an outage, because
-# NoFilesProcessed is excused as "the retries will get it" and a genuine bug must not be.
-EXIT_DECISION_CASES = [
-    # files_processed, connection_errors, exceptions, expected
-    (10, 0, 0, None),  # clean run
-    (0, 0, 0, None),  # nothing new to do: everything already processed, or not published yet
-    (10, 5, 0, None),  # partial outage, but we still got files: retries pick up the rest
-    (0, 5, 0, NoFilesProcessed),  # total outage, nothing else wrong
-    (0, 5, 3, CompletedWithSomeExceptions),  # outage AND a real bug: the bug wins
-    (0, 0, 3, CompletedWithSomeExceptions),  # nothing processed, purely our own fault
-    (10, 0, 3, CompletedWithSomeExceptions),  # partial success with real exceptions
-    (10, 5, 3, CompletedWithSomeExceptions),  # everything at once: still a real failure
-]
+# The verdict rules themselves live on the shared runner and are tested in
+# test_model_job_runner.py. All this job has to get right is the wiring.
 
 
-# What main() does about each verdict process_models() can reach.
-#
-# raised_by_process_models, exit_code, chatops_severity (None = no notification at all)
-MAIN_OUTCOME_CASES = [
-    # A clean run: succeed quietly.
-    (None, os.EX_OK, None),
-    # An outage at NOAA: tell us, but don't fail the job - the hourly retries recover it.
-    (NoFilesProcessed("no files processed"), os.EX_OK, "warning"),
-    # Real exceptions on some URLs: fail the job. Deliberately no chatops (pre-existing).
-    (CompletedWithSomeExceptions(), os.EX_SOFTWARE, None),
-    # Anything we didn't see coming: fail loudly.
-    (ValueError("boom"), os.EX_SOFTWARE, "critical"),
-]
-
-
-@pytest.mark.parametrize("raised,exit_code,severity", MAIN_OUTCOME_CASES)
-def test_main_outcomes(raised, exit_code, severity, mocker, monkeypatch):
-    """Pin the exit code and chatops severity main() produces for every verdict."""
-    monkeypatch.setattr(sys, "argv", ["argv", "GFS"])
-    monkeypatch.setattr(noaa, "apply_data_retention_policy", MagicMock())
-
-    def process_models():
-        if raised is not None:
-            raise raised
-
-    monkeypatch.setattr(noaa, "process_models", process_models)
-    chatops_spy = mocker.patch.object(noaa, "send_chatops_notification")
-
-    with pytest.raises(SystemExit) as excinfo:
-        noaa.main()
-
-    assert excinfo.value.code == exit_code
-
-    if severity is None:
-        chatops_spy.assert_not_called()
-    else:
-        chatops_spy.assert_called_once()
-        # severity is only passed explicitly for the outage path; otherwise it defaults.
-        assert chatops_spy.call_args.kwargs.get("severity", "critical") == severity
-        # The message must name the model - it used to be a broken f-string that
-        # posted the literal text "{sys.argv[1]}" to chatops.
-        assert "GFS" in chatops_spy.call_args.args[0]
-
-
-@pytest.mark.parametrize(
-    "files_processed,connection_errors,exceptions,expected", EXIT_DECISION_CASES
-)
-def test_process_models_exit_decision(
-    files_processed, connection_errors, exceptions, expected, monkeypatch
-):
-    """Pin how process_models() judges a finished run, for every counter combination."""
+def test_process_models_delegates_the_verdict_to_judge_run(monkeypatch: pytest.MonkeyPatch):
+    """process_models() must hand its counters to judge_run and return the result."""
     monkeypatch.setattr("wps_shared.db.database.get_write_session_scope", MagicMock())
     monkeypatch.setattr(noaa, "ModelValueProcessor", MagicMock())
     monkeypatch.setattr(noaa, "GribFileProcessor", MagicMock())
 
     def finished_run(self):
-        self.files_processed = files_processed
-        self.connection_error_count = connection_errors
-        self.exception_count = exceptions
+        self.files_processed = 7
+        self.connection_error_count = 2
+        self.exception_count = 0
 
     monkeypatch.setattr(noaa.NOAA, "process", finished_run)
+    judge_run = MagicMock(return_value=7)
+    monkeypatch.setattr(noaa, "judge_run", judge_run)
     monkeypatch.setattr(sys, "argv", ["argv", "GFS"])
 
-    if expected is None:
-        assert noaa.process_models() == files_processed
-    else:
-        with pytest.raises(expected):
-            noaa.process_models()
+    assert noaa.process_models() == 7
+
+    job = judge_run.call_args.args[0]
+    assert (job.files_processed, job.connection_error_count, job.exception_count) == (7, 2, 0)
+    assert judge_run.call_args.kwargs == {"source": "NOAA", "model": "GFS"}
+
+
+def test_main_delegates_to_the_shared_runner(monkeypatch: pytest.MonkeyPatch):
+    """main() must hand process_models to the runner, tagged with this job's source."""
+    run_model_job = MagicMock()
+    monkeypatch.setattr(noaa, "run_model_job", run_model_job)
+    monkeypatch.setattr(sys, "argv", ["argv", "GFS"])
+
+    noaa.main()
+
+    run_model_job.assert_called_once_with(noaa.process_models, source="NOAA", model="GFS")
 
 
 def test_process_model_run_urls_connection_error_increments_connection_count(monkeypatch):

--- a/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
@@ -388,7 +388,13 @@ def process_models():
     )
     if env_canada.connection_error_count > 0:
         logger.warning("%d connection error(s) during run (hourly retries will catch missed files)", env_canada.connection_error_count)
-    if env_canada.files_processed == 0 and env_canada.connection_error_count > 0:
+    # Only an outage if nothing else went wrong. A real exception in the mix means the job
+    # failed for a reason we can act on, and must not be excused as an upstream outage.
+    if (
+        env_canada.files_processed == 0
+        and env_canada.connection_error_count > 0
+        and env_canada.exception_count == 0
+    ):
         raise NoFilesProcessed(f"no files processed for {sys.argv[1]} — possible outage on HPFX and DD")
     if env_canada.exception_count > 0:
         raise CompletedWithSomeExceptions()

--- a/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
@@ -399,10 +399,13 @@ def main():
         process_models()
         apply_data_retention_policy()
     except NoFilesProcessed as exc:
+        # An outage on both HPFX and DD isn't something we can act on, and the hourly
+        # retries pick up whatever we missed. Notify at warning severity and exit
+        # cleanly so it doesn't surface as a failed job.
         logger.warning("%s", exc)
         rc_message = f":warning: No files processed for {sys.argv[1]} model data from Env Canada — hourly retries will attempt recovery"
-        send_chatops_notification(rc_message, exc)
-        sys.exit(os.EX_SOFTWARE)
+        send_chatops_notification(rc_message, exc, severity="warning")
+        sys.exit(os.EX_OK)
     except CompletedWithSomeExceptions:
         logger.warning("completed processing with some exceptions")
         sys.exit(os.EX_SOFTWARE)

--- a/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
@@ -15,7 +15,6 @@ import wps_shared.utils.time as time_utils
 from sqlalchemy.orm import Session
 from weather_model_jobs.common_model_fetchers import (
     ModelValueProcessor,
-    apply_data_retention_policy,
     check_if_model_run_complete,
     flag_file_as_processed,
 )
@@ -23,7 +22,7 @@ from weather_model_jobs.utils.process_grib import (
     GribFileProcessor,
     ModelRunInfo,
 )
-from wps_shared.chatops_notification import send_chatops_notification
+from weather_model_jobs.model_job_runner import judge_run, run_model_job
 from wps_shared.db.crud.weather_models import (
     get_prediction_model,
     get_prediction_run,
@@ -31,9 +30,7 @@ from wps_shared.db.crud.weather_models import (
     update_prediction_run,
 )
 from wps_shared.weather_models import (
-    CompletedWithSomeExceptions,
     ModelEnum,
-    NoFilesProcessed,
     ProjectionEnum,
     UnhandledPredictionModelType,
     adjust_model_day,
@@ -51,6 +48,8 @@ if __name__ == "__main__":
     configure_logging()
 
 logger = logging.getLogger(__name__)
+
+SOURCE = "Env Canada"
 
 
 def parse_gdps_msc_filename(url: str):
@@ -386,46 +385,12 @@ def process_models():
         seconds,
         execution_time,
     )
-    if env_canada.connection_error_count > 0:
-        logger.warning("%d connection error(s) during run (hourly retries will catch missed files)", env_canada.connection_error_count)
-    # Only an outage if nothing else went wrong. A real exception in the mix means the job
-    # failed for a reason we can act on, and must not be excused as an upstream outage.
-    if (
-        env_canada.files_processed == 0
-        and env_canada.connection_error_count > 0
-        and env_canada.exception_count == 0
-    ):
-        raise NoFilesProcessed(f"no files processed for {sys.argv[1]} — possible outage on HPFX and DD")
-    if env_canada.exception_count > 0:
-        raise CompletedWithSomeExceptions()
-    return env_canada.files_processed
+    return judge_run(env_canada, source=SOURCE, model=sys.argv[1])
 
 
 def main():
     """main script - process and download models, then do exception handling"""
-    try:
-        process_models()
-        apply_data_retention_policy()
-    except NoFilesProcessed as exc:
-        # An outage on both HPFX and DD isn't something we can act on, and the hourly
-        # retries pick up whatever we missed. Notify at warning severity and exit
-        # cleanly so it doesn't surface as a failed job.
-        logger.warning("%s", exc)
-        rc_message = f":warning: No files processed for {sys.argv[1]} model data from Env Canada — hourly retries will attempt recovery"
-        send_chatops_notification(rc_message, exc, severity="warning")
-        sys.exit(os.EX_OK)
-    except CompletedWithSomeExceptions:
-        logger.warning("completed processing with some exceptions")
-        sys.exit(os.EX_SOFTWARE)
-    except Exception as exception:
-        # We catch and log any exceptions we may have missed.
-        logger.exception("unexpected exception processing")
-        rc_message = f":poop: Encountered error retrieving {sys.argv[1]} model data from Env Canada"
-        send_chatops_notification(rc_message, exception)
-        # Exit with a failure code.
-        sys.exit(os.EX_SOFTWARE)
-    # We assume success if we get to this point.
-    sys.exit(os.EX_OK)
+    run_model_job(process_models, source=SOURCE, model=sys.argv[1])
 
 
 if __name__ == "__main__":

--- a/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/env_canada.py
@@ -323,6 +323,8 @@ class EnvCanada:
         # Process all the urls.
         self.process_model_run_urls(urls, fetcher)
 
+        fetcher.log_connection_summary()
+
         # Having completed processing, check if we're all done.
         if check_if_model_run_complete(self.session, urls):
             logger.info(

--- a/backend/packages/wps-jobs/src/weather_model_jobs/model_job_runner.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/model_job_runner.py
@@ -1,0 +1,91 @@
+"""Shared success/failure handling for the weather model download jobs.
+
+Every model job (Env Canada, NOAA) does the same two things once its downloads are done:
+judge the run from its counters, then act on that verdict. Both halves live here so the
+jobs can't drift apart on what counts as a failure.
+
+The contract:
+
+    NoFilesProcessed            an upstream outage - warn to chatops, exit EX_OK. The next
+                                scheduled run picks up whatever we missed.
+    CompletedWithSomeExceptions something we can act on - exit EX_SOFTWARE.
+    (no exception)              success - exit EX_OK.
+
+A real exception always beats an outage: NoFilesProcessed is excused as "the retries will
+get it", so it must never be raised for a run that also hit genuine exceptions.
+"""
+
+import logging
+import os
+import sys
+from typing import Callable, Protocol
+
+from weather_model_jobs.common_model_fetchers import apply_data_retention_policy
+from wps_shared.chatops_notification import send_chatops_notification
+from wps_shared.weather_models import CompletedWithSomeExceptions, NoFilesProcessed
+
+logger = logging.getLogger(__name__)
+
+
+class ModelJob(Protocol):
+    """What judge_run needs to know about a finished job."""
+
+    files_processed: int
+    connection_error_count: int
+    exception_count: int
+
+
+def judge_run(job: ModelJob, source: str, model: str) -> int:
+    """Judge a finished run, raising if it didn't go well. Returns the files processed.
+
+    Raises
+    ------
+    NoFilesProcessed
+        Connection failures wiped out the run and nothing else went wrong: an outage.
+    CompletedWithSomeExceptions
+        At least one URL failed for a reason that isn't an outage.
+    """
+    if job.connection_error_count > 0:
+        logger.warning(
+            "%d connection error(s) during run (hourly retries will catch missed files)",
+            job.connection_error_count,
+        )
+
+    # Only an outage if nothing else went wrong. A real exception in the mix means the job
+    # failed for a reason we can act on, and must not be excused as an upstream outage.
+    if job.files_processed == 0 and job.connection_error_count > 0 and job.exception_count == 0:
+        raise NoFilesProcessed(f"no files processed for {model} — possible outage at {source}")
+
+    if job.exception_count > 0:
+        raise CompletedWithSomeExceptions()
+
+    return job.files_processed
+
+
+def run_model_job(process_models: Callable[[], int], source: str, model: str):
+    """Run a model job to completion and exit the process with the appropriate code."""
+    try:
+        process_models()
+        apply_data_retention_policy()
+    except NoFilesProcessed as exc:
+        # An outage upstream isn't something we can act on, and the hourly retries pick up
+        # whatever we missed. Notify at warning severity and exit cleanly so it doesn't
+        # surface as a failed job.
+        logger.warning("%s", exc)
+        rc_message = (
+            f":warning: No files processed for {model} model data from {source} "
+            "— hourly retries will attempt recovery"
+        )
+        send_chatops_notification(rc_message, exc, severity="warning")
+        sys.exit(os.EX_OK)
+    except CompletedWithSomeExceptions:
+        logger.warning("completed processing with some exceptions")
+        sys.exit(os.EX_SOFTWARE)
+    except Exception as exception:
+        # We catch and log any exceptions we may have missed.
+        logger.exception("unexpected exception processing")
+        rc_message = f":poop: Encountered error retrieving {model} model data from {source}"
+        send_chatops_notification(rc_message, exception)
+        sys.exit(os.EX_SOFTWARE)
+    # We assume success if we get to this point.
+    sys.exit(os.EX_OK)

--- a/backend/packages/wps-jobs/src/weather_model_jobs/model_job_runner.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/model_job_runner.py
@@ -72,11 +72,11 @@ def run_model_job(process_models: Callable[[], int], source: str, model: str):
         # whatever we missed. Notify at warning severity and exit cleanly so it doesn't
         # surface as a failed job.
         logger.warning("%s", exc)
-        rc_message = (
+        chatops_message = (
             f":warning: No files processed for {model} model data from {source} "
             "— hourly retries will attempt recovery"
         )
-        send_chatops_notification(rc_message, exc, severity="warning")
+        send_chatops_notification(chatops_message, exc, severity="warning")
         sys.exit(os.EX_OK)
     except CompletedWithSomeExceptions:
         logger.warning("completed processing with some exceptions")
@@ -84,8 +84,8 @@ def run_model_job(process_models: Callable[[], int], source: str, model: str):
     except Exception as exception:
         # We catch and log any exceptions we may have missed.
         logger.exception("unexpected exception processing")
-        rc_message = f":poop: Encountered error retrieving {model} model data from {source}"
-        send_chatops_notification(rc_message, exception)
+        chatops_message = f":poop: Encountered error retrieving {model} model data from {source}"
+        send_chatops_notification(chatops_message, exception)
         sys.exit(os.EX_SOFTWARE)
     # We assume success if we get to this point.
     sys.exit(os.EX_OK)

--- a/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
@@ -9,6 +9,7 @@ from typing import Generator
 from urllib.parse import parse_qs, urlsplit
 from zoneinfo import ZoneInfo
 
+import requests
 import wps_shared.db.database
 import wps_shared.utils.time as time_utils
 from requests import HTTPError
@@ -33,6 +34,7 @@ from wps_shared.db.crud.weather_models import (
 from wps_shared.weather_models import (
     CompletedWithSomeExceptions,
     ModelEnum,
+    NoFilesProcessed,
     ProjectionEnum,
     download,
 )
@@ -278,6 +280,7 @@ class NOAA:
         self.files_downloaded = 0
         self.files_processed = 0
         self.exception_count = 0
+        self.connection_error_count = 0
         # We always work in UTC:
         self.now = time_utils.get_utc_now()
         self.grib_processor = GribFileProcessor()
@@ -340,6 +343,11 @@ class NOAA:
                     )
                 else:
                     raise http_error
+            except (requests.ConnectionError, requests.Timeout) as exc:
+                # NOMADS being unreachable isn't a bug on our side - track it separately from
+                # real exceptions so a NOMADS outage doesn't look like broken code.
+                self.connection_error_count += 1
+                logger.warning("Connection error for %s: %s", url, exc)
             except Exception:
                 self.exception_count += 1
                 # We catch and log exceptions, but keep trying to download.
@@ -418,6 +426,13 @@ def process_models():
         seconds,
         execution_time,
     )
+    if noaa.connection_error_count > 0:
+        logger.warning(
+            "%d connection error(s) during run (hourly retries will catch missed files)",
+            noaa.connection_error_count,
+        )
+    if noaa.files_processed == 0 and noaa.connection_error_count > 0:
+        raise NoFilesProcessed(f"no files processed for {sys.argv[1]} — possible outage at NOAA")
     # check if we encountered any exceptions.
     if noaa.exception_count > 0:
         # if there were any exceptions, return a non-zero status.
@@ -430,13 +445,21 @@ def main():
     try:
         process_models()
         apply_data_retention_policy()
+    except NoFilesProcessed as exc:
+        # An outage at NOAA isn't something we can act on, and the hourly retries pick up
+        # whatever we missed. Notify at warning severity and exit cleanly so it doesn't
+        # surface as a failed job.
+        logger.warning("%s", exc)
+        rc_message = f":warning: No files processed for {sys.argv[1]} model data from NOAA — hourly retries will attempt recovery"
+        send_chatops_notification(rc_message, exc, severity="warning")
+        sys.exit(os.EX_OK)
     except CompletedWithSomeExceptions:
         logger.warning("completed processing with some exceptions")
         sys.exit(os.EX_SOFTWARE)
     except Exception as exception:
         # We catch and log any exceptions we may have missed.
         logger.exception("unexpected exception processing")
-        rc_message = ":poop: Encountered error retrieving {sys.argv[1]} model data from NOAA"
+        rc_message = f":poop: Encountered error retrieving {sys.argv[1]} model data from NOAA"
         send_chatops_notification(rc_message, exception)
         # Exit with a failure code.
         sys.exit(os.EX_SOFTWARE)

--- a/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
@@ -431,7 +431,13 @@ def process_models():
             "%d connection error(s) during run (hourly retries will catch missed files)",
             noaa.connection_error_count,
         )
-    if noaa.files_processed == 0 and noaa.connection_error_count > 0:
+    # Only an outage if nothing else went wrong. A real exception in the mix means the job
+    # failed for a reason we can act on, and must not be excused as an upstream outage.
+    if (
+        noaa.files_processed == 0
+        and noaa.connection_error_count > 0
+        and noaa.exception_count == 0
+    ):
         raise NoFilesProcessed(f"no files processed for {sys.argv[1]} — possible outage at NOAA")
     # check if we encountered any exceptions.
     if noaa.exception_count > 0:

--- a/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
+++ b/backend/packages/wps-jobs/src/weather_model_jobs/noaa.py
@@ -16,7 +16,6 @@ from requests import HTTPError
 from sqlalchemy.orm import Session
 from weather_model_jobs.common_model_fetchers import (
     ModelValueProcessor,
-    apply_data_retention_policy,
     check_if_model_run_complete,
     flag_file_as_processed,
 )
@@ -24,7 +23,7 @@ from weather_model_jobs.utils.process_grib import (
     GribFileProcessor,
     ModelRunInfo,
 )
-from wps_shared.chatops_notification import send_chatops_notification
+from weather_model_jobs.model_job_runner import judge_run, run_model_job
 from wps_shared.db.crud.weather_models import (
     get_prediction_model,
     get_prediction_run,
@@ -32,9 +31,7 @@ from wps_shared.db.crud.weather_models import (
     update_prediction_run,
 )
 from wps_shared.weather_models import (
-    CompletedWithSomeExceptions,
     ModelEnum,
-    NoFilesProcessed,
     ProjectionEnum,
     download,
 )
@@ -45,6 +42,8 @@ if __name__ == "__main__":
     configure_logging()
 
 logger = logging.getLogger(__name__)
+
+SOURCE = "NOAA"
 
 # ---- GFS static variables -------------#
 GFS_GRID = "0p25"  # 0.25 degree grid
@@ -426,51 +425,12 @@ def process_models():
         seconds,
         execution_time,
     )
-    if noaa.connection_error_count > 0:
-        logger.warning(
-            "%d connection error(s) during run (hourly retries will catch missed files)",
-            noaa.connection_error_count,
-        )
-    # Only an outage if nothing else went wrong. A real exception in the mix means the job
-    # failed for a reason we can act on, and must not be excused as an upstream outage.
-    if (
-        noaa.files_processed == 0
-        and noaa.connection_error_count > 0
-        and noaa.exception_count == 0
-    ):
-        raise NoFilesProcessed(f"no files processed for {sys.argv[1]} — possible outage at NOAA")
-    # check if we encountered any exceptions.
-    if noaa.exception_count > 0:
-        # if there were any exceptions, return a non-zero status.
-        raise CompletedWithSomeExceptions()
-    return noaa.files_processed
+    return judge_run(noaa, source=SOURCE, model=sys.argv[1])
 
 
 def main():
     """main script - process and download models, then do exception handling"""
-    try:
-        process_models()
-        apply_data_retention_policy()
-    except NoFilesProcessed as exc:
-        # An outage at NOAA isn't something we can act on, and the hourly retries pick up
-        # whatever we missed. Notify at warning severity and exit cleanly so it doesn't
-        # surface as a failed job.
-        logger.warning("%s", exc)
-        rc_message = f":warning: No files processed for {sys.argv[1]} model data from NOAA — hourly retries will attempt recovery"
-        send_chatops_notification(rc_message, exc, severity="warning")
-        sys.exit(os.EX_OK)
-    except CompletedWithSomeExceptions:
-        logger.warning("completed processing with some exceptions")
-        sys.exit(os.EX_SOFTWARE)
-    except Exception as exception:
-        # We catch and log any exceptions we may have missed.
-        logger.exception("unexpected exception processing")
-        rc_message = f":poop: Encountered error retrieving {sys.argv[1]} model data from NOAA"
-        send_chatops_notification(rc_message, exception)
-        # Exit with a failure code.
-        sys.exit(os.EX_SOFTWARE)
-    # We assume success if we get to this point.
-    sys.exit(os.EX_OK)
+    run_model_job(process_models, source=SOURCE, model=sys.argv[1])
 
 
 if __name__ == "__main__":

--- a/backend/packages/wps-shared/src/wps_shared/chatops_notification.py
+++ b/backend/packages/wps-shared/src/wps_shared/chatops_notification.py
@@ -17,8 +17,14 @@ logger = logging.getLogger(__name__)
 webhook_max_char_len = 2000
 
 
-def send_chatops_notification(text: str, exc_info: Exception) -> str | None:
+def send_chatops_notification(
+    text: str, exc_info: Exception, severity: str = "critical"
+) -> str | None:
     """Sends message with specified text to configured chatops webhook.
+
+    Use a severity of "warning" for conditions we expect and recover from on our own
+    (e.g. an upstream outage that the next scheduled run will pick up), and leave it at
+    "critical" for anything that needs someone to look at it now.
 
     We don't want this method to raise any exceptions, as we don't want to
     unintentionally break any kind of error management flow. (We only use
@@ -48,7 +54,7 @@ def send_chatops_notification(text: str, exc_info: Exception) -> str | None:
             },
             json={
                 "title": config.get("HOSTNAME"),
-                "severity": "critical",
+                "severity": severity,
                 "body": full_message,
                 "url": pod_logs_url,
                 "urlLabel": "View Logs",

--- a/backend/packages/wps-shared/src/wps_shared/tests/test_chatops_notification.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/test_chatops_notification.py
@@ -45,6 +45,12 @@ def test_body_severity(mock_post):
     assert body["severity"] == "critical"
 
 
+def test_body_severity_override(mock_post):
+    send_chatops_notification("test", Exception("err"), severity="warning")
+    body = mock_post.call_args.kwargs["json"]
+    assert body["severity"] == "warning"
+
+
 def test_body_url_label(mock_post):
     send_chatops_notification("test", Exception("err"))
     body = mock_post.call_args.kwargs["json"]

--- a/backend/packages/wps-shared/src/wps_shared/tests/weather_models/test_eccc_url_fetcher.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/weather_models/test_eccc_url_fetcher.py
@@ -113,3 +113,32 @@ class TestGet:
         session.get.return_value = _resp(200)
         ECCCUrlFetcher(NOW, MODEL_RUN_HOUR, session=session).get(DD_URL)
         session.get.assert_called_once()
+
+
+class TestConnectionSummary:
+    def _fetcher_with_responses(self, responses) -> ECCCUrlFetcher:
+        f = _fetcher()
+        f._session = MagicMock()
+        f._session.get.side_effect = responses
+        return f
+
+    def test_summarises_a_host_that_failed_every_attempt(self, caplog):
+        """The case from the outage: hpfx unreachable, dd serving 404s."""
+        f = self._fetcher_with_responses([requests.ConnectionError(), _resp(404)] * 2)
+        f.get(DD_URL)
+        f.get(DD_URL)
+
+        with caplog.at_level("WARNING"):
+            f.log_connection_summary()
+
+        assert "hpfx.collab.science.gc.ca: 2/2 requests failed to connect" in caplog.text
+        assert "dd.weather.gc.ca" not in caplog.text
+
+    def test_silent_when_no_connection_failures(self, caplog):
+        f = self._fetcher_with_responses([_resp(200)])
+        f.get(DD_URL)
+
+        with caplog.at_level("WARNING"):
+            f.log_connection_summary()
+
+        assert caplog.text == ""

--- a/backend/packages/wps-shared/src/wps_shared/weather_models/eccc_url_fetcher.py
+++ b/backend/packages/wps-shared/src/wps_shared/weather_models/eccc_url_fetcher.py
@@ -13,7 +13,10 @@ authoritative source with guaranteed 24/7 Internet redundancy.
 from __future__ import annotations
 
 import logging
+import time
+from collections import Counter
 from datetime import datetime
+from urllib.parse import urlsplit
 
 import requests
 
@@ -56,6 +59,9 @@ class ECCCUrlFetcher:
         self._date_str = adjust_model_day(now, model_run_hour).strftime("%Y%m%d")
         self._timeout = timeout
         self._session = session or requests.Session()
+        self._attempts: Counter[str] = Counter()
+        self._connection_failures: Counter[str] = Counter()
+        self._seconds_lost: Counter[str] = Counter()
 
     def candidates(self, dd_url: str) -> list[str]:
         """Return the ordered list of URLs to try for *dd_url*."""
@@ -88,10 +94,17 @@ class ECCCUrlFetcher:
         last_exc: Exception | None = None
 
         for url in urls:
+            host = urlsplit(url).netloc
+            self._attempts[host] += 1
+            started = time.monotonic()
             try:
                 response = self._session.get(url, timeout=self._timeout)
             except requests.RequestException as exc:
-                logger.warning("Connection failed for %s: %s", url, exc)
+                # Not a warning: a single host failing is the case the fallback exists to
+                # handle. The run-level summary reports how often it happened.
+                self._connection_failures[host] += 1
+                self._seconds_lost[host] += time.monotonic() - started
+                logger.debug("Connection failed for %s: %s", url, exc)
                 last_exc = exc
                 continue
 
@@ -111,3 +124,21 @@ class ECCCUrlFetcher:
             raise last_exc
 
         return None
+
+    def log_connection_summary(self) -> None:
+        """Log per-host connection failures for the requests made so far.
+
+        A host failing every attempt means we paid the full timeout on each one, which is
+        the difference between a slow run and a run that never finishes in its window.
+        """
+        for host, attempts in self._attempts.items():
+            failures = self._connection_failures[host]
+            if not failures:
+                continue
+            logger.warning(
+                "%s: %d/%d requests failed to connect, %.0f seconds spent on timeouts",
+                host,
+                failures,
+                attempts,
+                self._seconds_lost[host],
+            )


### PR DESCRIPTION
When an upstream provider has an outage, the weather model jobs can't tell it apart from a bug in our own code.

- If HPFX and dd.weather.gc.ca are both down, the job sends a `critical` chatops notification with a stack trace and exits `EX_SOFTWARE`, so an outage we recover from automatically looks exactly like something that needs a human right now.

- A NOMADS outage lands every failed URL in the broad `except Exception`, which ends the run in `CompletedWithSomeExceptions` and `EX_SOFTWARE` with **no chatops notification at all**. A total outage produces a failed job and silence.

**The logging told the wrong story too.** In a recent GDPS run, HPFX was unreachable for the *entire* run: every one of the ~400 requests paid a ~12 second connect timeout before falling back to dd, which then 404'd because the files weren't published yet. That produced ~400 `Connection failed for hpfx...` WARNING lines, while the run-level counter barely moved — when HPFX fails and dd answers 404, `last_exc` is reset to `None` and the fetcher returns `None`, a normal "not published yet" result. 

#### Changes

**One shared runner, `weather_model_jobs/model_job_runner.py`.** Both jobs were carrying ~80 lines of near-identical logic for judging a finished run and acting on the verdict. That now lives in one place:

- `judge_run(job, source, model)` — the connection-error summary and the success/failure verdict.
- `run_model_job(process_models, source, model)` — the retention policy, the exception branches, chatops severity, and exit codes.

Each job declares a `SOURCE` constant and shrinks to four lines. They can no longer drift on what counts as a failure.

- `send_chatops_notification` takes an optional `severity` (default `"critical"`, so every existing caller is unchanged). Both jobs now track `connection_error_count` separately from `exception_count`, raise `NoFilesProcessed` when a run is wiped out by connection failures, and respond with a `:warning:` notification at `severity="warning"` plus an `EX_OK` exit. The alert still goes out; the run no longer registers as a failed job. NOAA's existing 403/404 handling (NOMADS still generating a run) is untouched.

- `NoFilesProcessed` is excused as "the hourly retries will get it," so it must never mask a genuine bug. The outage path requires `exception_count == 0`; otherwise the run fails as `CompletedWithSomeExceptions`. Without this, a run with 50 connection errors *and* 350 real exceptions would have exited `EX_OK` and reported success.

- `ECCCUrlFetcher` counts attempts, connection failures and seconds lost to timeouts per host, and `log_connection_summary()` emits one WARNING per failing host at the end of each model run. The GDPS run above collapses to a single line:
   ````
    hpfx.collab.science.gc.ca: 396/396 requests failed to connect, 4900 seconds spent on timeouts
   ````
The per-URL `Connection failed for...` line drops from WARNING to DEBUG to reduce noise

**Bug fix: NOAA's chatops message was a broken f-string.** `rc_message = ":poop: Encountered error retrieving {sys.argv[1]} model data from NOAA"` had no `f` prefix, so every NOAA failure alert ever sent has posted the literal text `{sys.argv[1]}` instead of naming the model. One character, and it's been degrading every NOAA alert.

#### When does a job now exit non-zero?

Exactly two cases, both `EX_SOFTWARE`:

- `exception_count > 0` — a real exception on at least one URL (`CompletedWithSomeExceptions`, no chatops).
- An exception escaped `process_models()` entirely — DB unreachable, bad `sys.argv`, a failure in `ModelValueProcessor` (critical chatops).

Everything else exits `EX_OK`: a clean run, a run with nothing new to do, and now a pure upstream outage.

# Test Links:
[Landing Page](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5607-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
