### PR TITLE
Dev: Adjust cronjob history limits so failed pods survive long enough to debug

### DIFF
--- a/openshift/templates/ecmwf.cronjob.yaml
+++ b/openshift/templates/ecmwf.cronjob.yaml
@@ -50,6 +50,10 @@ objects:
       # that a job will still be running when the next one is scheduled. If one job is still running,
       # we don't want to start another one, so we use "Forbid" so the running job will not be replaced.
       concurrencyPolicy: "Forbid"
+      # Keep failed jobs (and their pods) around longer than the default (1) so there's
+      # enough history to debug a failure before it gets garbage collected.
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
       jobTemplate:
         metadata:
           labels:

--- a/openshift/templates/env_canada_gdps.cronjob.yaml
+++ b/openshift/templates/env_canada_gdps.cronjob.yaml
@@ -52,6 +52,10 @@ objects:
       # that a job will still be running when the next one is scheduled. If one job is still running,
       # we don't want to start another one, so we use "Forbid" so the running job will not be replaced.
       concurrencyPolicy: "Forbid"
+      # Keep failed jobs (and their pods) around longer than the default (1) so there's
+      # enough history to debug a failure before it gets garbage collected.
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
       jobTemplate:
         metadata:
           labels:

--- a/openshift/templates/env_canada_hrdps.cronjob.yaml
+++ b/openshift/templates/env_canada_hrdps.cronjob.yaml
@@ -52,6 +52,10 @@ objects:
       # that a job will still be running when the next one is scheduled. If one job is still running,
       # we don't want to start another one, so we use "Forbid" so the running job will not be replaced.
       concurrencyPolicy: "Forbid"
+      # Keep failed jobs (and their pods) around longer than the default (1) so there's
+      # enough history to debug a failure before it gets garbage collected.
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
       jobTemplate:
         metadata:
           labels:

--- a/openshift/templates/env_canada_rdps.cronjob.yaml
+++ b/openshift/templates/env_canada_rdps.cronjob.yaml
@@ -53,6 +53,10 @@ objects:
       # that a job will still be running when the next one is scheduled. If one job is still running,
       # we don't want to start another one, so we use "Forbid" so the running job will not be replaced.
       concurrencyPolicy: "Forbid"
+      # Keep failed jobs (and their pods) around longer than the default (1) so there's
+      # enough history to debug a failure before it gets garbage collected.
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
       jobTemplate:
         metadata:
           labels:

--- a/openshift/templates/noaa_gfs.cronjob.yaml
+++ b/openshift/templates/noaa_gfs.cronjob.yaml
@@ -52,6 +52,10 @@ objects:
       # that a job will still be running when the next one is scheduled. If one job is still running,
       # we don't want to start another one, so we use "Forbid" so the running job will not be replaced.
       concurrencyPolicy: "Forbid"
+      # Keep failed jobs (and their pods) around longer than the default (1) so there's
+      # enough history to debug a failure before it gets garbage collected.
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
       jobTemplate:
         metadata:
           labels:

--- a/openshift/templates/noaa_nam.cronjob.yaml
+++ b/openshift/templates/noaa_nam.cronjob.yaml
@@ -49,6 +49,10 @@ objects:
       # that a job will still be running when the next one is scheduled. If one job is still running,
       # we don't want to start another one, so we use "Forbid" so the running job will not be replaced.
       concurrencyPolicy: "Forbid"
+      # Keep failed jobs (and their pods) around longer than the default (1) so there's
+      # enough history to debug a failure before it gets garbage collected.
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
       jobTemplate:
         metadata:
           labels:

--- a/openshift/templates/rdps_sfms.cronjob.yaml
+++ b/openshift/templates/rdps_sfms.cronjob.yaml
@@ -48,6 +48,10 @@ objects:
       # If we were to use Forbid, and a cronjob gets stuck, then we'd stop gathering data until someone
       # noticed. We don't want that.
       concurrencyPolicy: "Replace"
+      # Keep failed jobs (and their pods) around longer than the default (1) so there's
+      # enough history to debug a failure before it gets garbage collected.
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
       jobTemplate:
         metadata:
           labels:


### PR DESCRIPTION
Failed weather-model cronjob pods were being garbage collected almost immediately (Kubernetes' default `failedJobsHistoryLimit` is 1), so by the time we noticed an alert email and went to inspect the pod, it was already gone.

While debugging an `env-canada-rdps` failure alert, the pod had already been deleted before its logs could be pulled via `oc logs`/`oc describe`. With these jobs scheduled every 1-2 hours, a single subsequent run evicts the previous failed Job/Pod from history under the default limit.
# Test Links:
[Landing Page](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5609-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
