### PR TITLE
Dev: Bump RDPS/HRDPS memory limits

### DIFF
--- a/openshift/templates/env_canada_hrdps.cronjob.yaml
+++ b/openshift/templates/env_canada_hrdps.cronjob.yaml
@@ -199,8 +199,8 @@ objects:
                           key: env.data_retention_threshold
                   resources:
                     limits:
-                      memory: 512Mi
+                      memory: 1Gi
                     requests:
                       cpu: "500m"
-                      memory: 256Mi
+                      memory: 512Mi
               restartPolicy: OnFailure

--- a/openshift/templates/env_canada_rdps.cronjob.yaml
+++ b/openshift/templates/env_canada_rdps.cronjob.yaml
@@ -200,8 +200,8 @@ objects:
                           key: env.data_retention_threshold
                   resources:
                     limits:
-                      memory: 512Mi
+                      memory: 1Gi
                     requests:
                       cpu: "500m"
-                      memory: 256Mi
+                      memory: 512Mi
               restartPolicy: OnFailure


### PR DESCRIPTION
`env-canada-rdps` and `env-canada-hrdps` pods were found to be OOMKilled against their 512Mi memory limit, which explained why logs showed no application-level errors despite the job failing.
# Test Links:
[Landing Page](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5610-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
