### PR TITLE
Dev: Alert on OOMKilled pods 

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -162,6 +162,11 @@ jobs:
           END_HOUR=48 STEP=6 MODEL=GDPS bash openshift/scripts/oc_provision_wx_4panel_charts_cronjob.sh ${SUFFIX} apply
           END_HOUR=15 STEP=3 MODEL=RDPS bash openshift/scripts/oc_provision_wx_4panel_charts_cronjob.sh ${SUFFIX} apply
 
+      - name: Logging alerts
+        shell: bash
+        run: |
+          oc process -f openshift/logging-alerts/oom_alerts.yaml -p NAMESPACE=e1e498-dev -p SEVERITY=warning | oc apply -f -
+
   deploy-asa-go-dev:
     name: Deploy ASA Go API to Dev
     if: github.triggering_actor != 'renovate'

--- a/openshift/logging-alerts/oom_alerts.yaml
+++ b/openshift/logging-alerts/oom_alerts.yaml
@@ -1,0 +1,42 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: oom-alerts-template
+parameters:
+  - name: NAMESPACE
+    description: Namespace to watch for OOMKilled pods, and to deploy the PrometheusRule into
+    required: true
+  - name: SEVERITY
+    description: Alertmanager severity label
+    value: critical
+objects:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+      labels:
+        app: "oom-alerts"
+      name: oom-alerts
+      namespace: ${NAMESPACE}
+    spec:
+      groups:
+        - name: OOMAlerts
+          interval: 1m
+          rules:
+            - alert: PodOOMKilled
+              annotations:
+                description: >-
+                  {{ $labels.pod }} (container {{ $labels.container }}) was OOMKilled. This
+                  does not produce an application-level log line, so this metric is the only
+                  signal - check the container's memory limit against its actual usage.
+                summary: A pod in ${NAMESPACE} was OOMKilled
+              # kube_pod_container_status_last_terminated_reason is a gauge that stays at 1 for
+              # as long as the terminated pod object exists (bounded by failedJobsHistoryLimit
+              # for job pods, or until the next restart for long-running deployments), so this
+              # will keep firing/re-notifying (per Alertmanager's repeat_interval) rather than
+              # firing once and going silent - that's intentional, not a bug.
+              expr: |
+                kube_pod_container_status_last_terminated_reason{namespace="${NAMESPACE}", reason="OOMKilled"} == 1
+              for: 0s
+              labels:
+                namespace: ${NAMESPACE}
+                severity: ${SEVERITY}

--- a/openshift/logging-alerts/oom_alerts.yaml
+++ b/openshift/logging-alerts/oom_alerts.yaml
@@ -36,7 +36,10 @@ objects:
               # firing once and going silent - that's intentional, not a bug.
               expr: |
                 kube_pod_container_status_last_terminated_reason{namespace="${NAMESPACE}", reason="OOMKilled"} == 1
-              for: 0s
+              # Require the condition to hold across more than one evaluation before firing, so a
+              # single missed/delayed scrape (kube-state-metrics restart, scrape timeout, API
+              # server blip) can't cause a spurious or flapping fire.
+              for: 2m
               labels:
                 namespace: ${NAMESPACE}
                 severity: ${SEVERITY}

--- a/openshift/scripts/oc_deploy_to_production.sh
+++ b/openshift/scripts/oc_deploy_to_production.sh
@@ -99,3 +99,4 @@ PROJ_TARGET=${PROJ_TARGET} END_HOUR=84 STEP=3 MODEL=RDPS bash $(dirname ${0})/oc
 echo Logging alerts
 oc apply -f $(dirname ${0})/../logging-alerts/nats_alerts.yaml
 oc apply -f $(dirname ${0})/../logging-alerts/sfms_alerts.yaml
+oc process -f $(dirname ${0})/../logging-alerts/oom_alerts.yaml -p NAMESPACE=e1e498-prod -p SEVERITY=critical | oc apply -f -


### PR DESCRIPTION
There was no alerting for OOMKilled pods - the `env-canada-rdps`/`env-canada-hrdps` OOM failures earlier this week were only caught because we looked for it. The existing `nats_alerts.yaml`/`sfms_alerts.yaml` couldn't be extended to cover this: they're Loki rules that scan log lines, and an OOMKill never produces an application-level log line.

`openshift/logging-alerts/oom_alerts.yaml` is a new `PrometheusRule` template against kube-state-metrics (`kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}`), processed once for `e1e498-prod` (`severity: critical`, applied via `oc_deploy_to_production.sh`) and once for `e1e498-dev` (`severity: warning`, applied per-PR in `deployment.yml`'s "Deploy to Dev" job) - dev is a shared namespace across every open PR, so it's set to `warning` rather than `critical` to avoid paging on routine PR-testing noise.
# Test Links:
[Landing Page](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5611-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
