### PR TITLE
Dev: Pin backoffLimit explicitly across weather model cronjobs

### DIFF
--- a/openshift/templates/ecmwf.cronjob.yaml
+++ b/openshift/templates/ecmwf.cronjob.yaml
@@ -60,6 +60,7 @@ objects:
             cronjob: ${JOB_NAME}
             app: ${APP_LABEL}
         spec:
+          backoffLimit: 6
           template:
             spec:
               containers:

--- a/openshift/templates/env_canada_gdps.cronjob.yaml
+++ b/openshift/templates/env_canada_gdps.cronjob.yaml
@@ -62,6 +62,7 @@ objects:
             cronjob: ${JOB_NAME}
             app: ${APP_LABEL}
         spec:
+          backoffLimit: 6
           template:
             spec:
               containers:

--- a/openshift/templates/env_canada_hrdps.cronjob.yaml
+++ b/openshift/templates/env_canada_hrdps.cronjob.yaml
@@ -62,6 +62,7 @@ objects:
             cronjob: ${JOB_NAME}
             app: ${APP_LABEL}
         spec:
+          backoffLimit: 6
           template:
             spec:
               containers:

--- a/openshift/templates/env_canada_rdps.cronjob.yaml
+++ b/openshift/templates/env_canada_rdps.cronjob.yaml
@@ -63,6 +63,7 @@ objects:
             cronjob: ${JOB_NAME}
             app: ${APP_LABEL}
         spec:
+          backoffLimit: 6
           template:
             spec:
               containers:

--- a/openshift/templates/noaa_gfs.cronjob.yaml
+++ b/openshift/templates/noaa_gfs.cronjob.yaml
@@ -62,6 +62,7 @@ objects:
             cronjob: ${JOB_NAME}
             app: ${APP_LABEL}
         spec:
+          backoffLimit: 6
           template:
             spec:
               containers:

--- a/openshift/templates/noaa_nam.cronjob.yaml
+++ b/openshift/templates/noaa_nam.cronjob.yaml
@@ -59,6 +59,7 @@ objects:
             cronjob: ${JOB_NAME}
             app: ${APP_LABEL}
         spec:
+          backoffLimit: 6
           template:
             spec:
               containers:

--- a/openshift/templates/rdps_sfms.cronjob.yaml
+++ b/openshift/templates/rdps_sfms.cronjob.yaml
@@ -58,6 +58,7 @@ objects:
             cronjob: ${JOB_NAME}
             app: ${APP_LABEL}
         spec:
+          backoffLimit: 6
           template:
             spec:
               containers:


### PR DESCRIPTION
`env-canada-hrdps-wps-prod` was silently running with `backoffLimit: 0` in prod which resulted in a single container failure permanently failing the whole job with zero retries, unlike every sibling job which gets Kubernetes' default of 6. The value only existed on the live cluster object, not in `env_canada_hrdps.cronjob.yaml`, so nothing in git explained it.

Since `oc apply` only merges fields present in the manifest and wouldn't have overwritten it once dropped from the template. `ecmwf`, `env_canada_gdps`, `env_canada_rdps`, `noaa_gfs`, `noaa_nam`, and `rdps_sfms` now also get an explicit `backoffLimit: 6`, so this class of silent, permanent drift can't happen again on any of these jobs. A future `oc apply` will always enforce whatever's in git rather than leaving an absent field untouched.
# Test Links:
[Landing Page](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5614-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
