### PR TITLE
ASA Go/SFMS timing fix

### DIFF
--- a/backend/packages/wps-shared/src/wps_shared/db/crud/auto_spatial_advisory.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/crud/auto_spatial_advisory.py
@@ -459,7 +459,9 @@ async def get_most_recent_run_datetime_for_date_range(
             .over(partition_by=RunParameters.for_date, order_by=desc(RunParameters.run_datetime))
             .label("row_num"),
         )
-        .where(RunParameters.for_date.between(start_date, end_date))
+        .where(
+            RunParameters.for_date.between(start_date, end_date), RunParameters.complete.is_(True)
+        )
         .subquery()
     )
 

--- a/backend/packages/wps-shared/src/wps_shared/tests/db/crud/test_auto_spatial_advisory.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/db/crud/test_auto_spatial_advisory.py
@@ -8,6 +8,7 @@ from sqlalchemy.future import select
 from testcontainers.postgres import PostgresContainer
 from wps_shared.db.crud.auto_spatial_advisory import (
     get_fire_centre_info,
+    get_most_recent_run_datetime_for_date_range,
     get_provincial_rollup,
     mark_run_parameter_complete,
 )
@@ -125,6 +126,44 @@ async def test_mark_run_parameter_complete(async_session, session_factory):
         )
         updated_param = result.scalar_one()
         assert updated_param.complete is True
+
+
+@pytest.mark.anyio
+async def test_get_most_recent_run_datetime_for_date_range_ignores_incomplete_runs(async_session):
+    today = datetime(2025, 8, 1, tzinfo=timezone.utc).date()
+    tomorrow = datetime(2025, 8, 2, tzinfo=timezone.utc).date()
+    older_complete_run_datetime = datetime(2025, 8, 1, 15, tzinfo=timezone.utc)
+    newer_incomplete_run_datetime = datetime(2025, 8, 1, 20, tzinfo=timezone.utc)
+    tomorrow_run_datetime = datetime(2025, 8, 2, 15, tzinfo=timezone.utc)
+    async_session.add_all(
+        [
+            RunParameters(
+                run_type=RunType.FORECAST.value,
+                run_datetime=older_complete_run_datetime,
+                for_date=today,
+                complete=True,
+            ),
+            RunParameters(
+                run_type=RunType.FORECAST.value,
+                run_datetime=newer_incomplete_run_datetime,
+                for_date=today,
+                complete=False,
+            ),
+            RunParameters(
+                run_type=RunType.FORECAST.value,
+                run_datetime=tomorrow_run_datetime,
+                for_date=tomorrow,
+                complete=True,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    result = await get_most_recent_run_datetime_for_date_range(async_session, today, tomorrow)
+
+    result_by_date = {row.for_date: row for row in result}
+    assert result_by_date[today].run_datetime == older_complete_run_datetime
+    assert result_by_date[tomorrow].run_datetime == tomorrow_run_datetime
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes an issue where SFMS runs could be selected in ASA Go before the run was completely processed.
 
ASA Go uses the `/latest-sfms-run-parameters` endpoint to decide which `run_datetime` to use for map/advisory data. That query was selecting the newest run for each date regardless of whether the run was marked complete.

 If a newer SFMS run existed but the ASA/FBA processing pipeline was still running, the app could request advisory data for that incomplete run and show no map advisory data. This would then get cached in the app and the user would never see any advisory until we processed SFMS data later that day/tomorrow.
 
 This would only happen if the user happened to open the app while SFMS data was currently processing

# Test Links:
[Landing Page](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5629-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
