### PR TITLE
ASA Go: Advisory Expiry tweak

### DIFF
--- a/backend/packages/wps-api/src/app/routers/fba.py
+++ b/backend/packages/wps-api/src/app/routers/fba.py
@@ -67,9 +67,7 @@ router = APIRouter(
 )
 
 
-def get_advisory_valid_until(
-    run_type: RunType | RunTypeEnum | str, run_datetime: datetime
-) -> datetime:
+def get_advisory_valid_until(run_type: RunType, run_datetime: datetime) -> datetime:
     """
     Advisories are valid until the next expected replacement data. Actuals expire at local
     midnight. Forecasts expire the same day at 18:00 when run before 17:30 local time,
@@ -77,9 +75,7 @@ def get_advisory_valid_until(
     """
     ensure_timezone(run_datetime)
     local_run_datetime = run_datetime.astimezone(vancouver_tz)
-    run_type_value = getattr(run_type, "value", run_type)
-
-    if run_type_value == RunType.ACTUAL.value:
+    if run_type.value == RunType.ACTUAL.value:
         return (
             (local_run_datetime + timedelta(days=1))
             .replace(hour=0, minute=0, second=0, microsecond=0)
@@ -266,7 +262,7 @@ async def get_latest_sfms_run_datetime_for_date(
             run_datetime=latest_run_parameter.run_datetime,
             run_type=latest_run_parameter.run_type,
             valid_until=get_advisory_valid_until(
-                latest_run_parameter.run_type, latest_run_parameter.run_datetime
+                RunType(latest_run_parameter.run_type), latest_run_parameter.run_datetime
             ),
         )
         return LatestSFMSRunParameterResponse(run_parameter=run_parameter)
@@ -376,7 +372,7 @@ async def get_latest_sfms_run_datetime_for_date_range(
                 for_date=row.for_date,
                 run_type=row.run_type,
                 run_datetime=row.run_datetime,
-                valid_until=get_advisory_valid_until(row.run_type, row.run_datetime),
+                valid_until=get_advisory_valid_until(RunType(row.run_type), row.run_datetime),
             )
             latest_run_parameters[row.for_date] = run_parameter
         return LatestSFMSRunParameterRangeResponse(run_parameters=latest_run_parameters)

--- a/backend/packages/wps-api/src/app/routers/fba.py
+++ b/backend/packages/wps-api/src/app/routers/fba.py
@@ -73,7 +73,7 @@ def get_advisory_valid_until(
     """
     Advisories are valid until the next expected replacement data. Actuals expire at local
     midnight. Forecasts expire the same day at 18:00 when run before 17:30 local time,
-    otherwise they expire the following day at 08:00.
+    otherwise they expire the following day at 08:30.
     """
     ensure_timezone(run_datetime)
     local_run_datetime = run_datetime.astimezone(vancouver_tz)
@@ -92,7 +92,7 @@ def get_advisory_valid_until(
         valid_until = local_run_datetime.replace(hour=18, minute=0, second=0, microsecond=0)
     else:
         valid_until = (local_run_datetime + timedelta(days=1)).replace(
-            hour=8, minute=0, second=0, microsecond=0
+            hour=8, minute=30, second=0, microsecond=0
         )
 
     return valid_until.astimezone(timezone.utc)

--- a/backend/packages/wps-api/src/app/routers/fba.py
+++ b/backend/packages/wps-api/src/app/routers/fba.py
@@ -67,14 +67,25 @@ router = APIRouter(
 )
 
 
-def get_advisory_valid_until(run_datetime: datetime) -> datetime:
+def get_advisory_valid_until(
+    run_type: RunType | RunTypeEnum | str, run_datetime: datetime
+) -> datetime:
     """
-    Advisories are only valid until the next run of forecasted data. Forecasts run at 08:00 and 17:45 PDT.
-    SFMS runs in the morning will expire on thes same day at 18:00. SFMS runs in the afternoon/evening
-    will expire the following day at 08:00.
+    Advisories are valid until the next expected replacement data. Actuals expire at local
+    midnight. Forecasts expire the same day at 18:00 when run before 17:30 local time,
+    otherwise they expire the following day at 08:00.
     """
     ensure_timezone(run_datetime)
     local_run_datetime = run_datetime.astimezone(vancouver_tz)
+    run_type_value = getattr(run_type, "value", run_type)
+
+    if run_type_value == RunType.ACTUAL.value:
+        return (
+            (local_run_datetime + timedelta(days=1))
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+            .astimezone(timezone.utc)
+        )
+
     cutoff = local_run_datetime.replace(hour=17, minute=30, second=0, microsecond=0)
 
     if local_run_datetime < cutoff:
@@ -254,7 +265,9 @@ async def get_latest_sfms_run_datetime_for_date(
             for_date=latest_run_parameter.for_date,
             run_datetime=latest_run_parameter.run_datetime,
             run_type=latest_run_parameter.run_type,
-            valid_until=get_advisory_valid_until(latest_run_parameter.run_datetime),
+            valid_until=get_advisory_valid_until(
+                latest_run_parameter.run_type, latest_run_parameter.run_datetime
+            ),
         )
         return LatestSFMSRunParameterResponse(run_parameter=run_parameter)
 
@@ -363,7 +376,7 @@ async def get_latest_sfms_run_datetime_for_date_range(
                 for_date=row.for_date,
                 run_type=row.run_type,
                 run_datetime=row.run_datetime,
-                valid_until=get_advisory_valid_until(row.run_datetime),
+                valid_until=get_advisory_valid_until(row.run_type, row.run_datetime),
             )
             latest_run_parameters[row.for_date] = run_parameter
         return LatestSFMSRunParameterRangeResponse(run_parameters=latest_run_parameters)

--- a/backend/packages/wps-api/src/app/tests/asa_go/test_asa_go_router.py
+++ b/backend/packages/wps-api/src/app/tests/asa_go/test_asa_go_router.py
@@ -106,7 +106,7 @@ def test_public_latest_sfms_run_datetime_range_endpoint(
                 "for_date": "2025-08-26",
                 "run_datetime": "2025-08-27T00:31:00Z",
                 "run_type": RunType.FORECAST.value,
-                "valid_until": "2025-08-27T15:00:00Z",
+                "valid_until": "2025-08-27T15:30:00Z",
             }
         }
     }

--- a/backend/packages/wps-api/src/app/tests/fba/test_advisory_valid_until.py
+++ b/backend/packages/wps-api/src/app/tests/fba/test_advisory_valid_until.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
+from wps_shared.run_type import RunType
 
 from app.routers.fba import get_advisory_valid_until
 
@@ -8,23 +9,37 @@ from app.routers.fba import get_advisory_valid_until
 def test_get_advisory_valid_until_before_cutoff():
     run_datetime = datetime(2025, 8, 27, 0, 29, tzinfo=timezone.utc)
 
-    assert get_advisory_valid_until(run_datetime) == datetime(2025, 8, 27, 1, tzinfo=timezone.utc)
+    assert get_advisory_valid_until(RunType.FORECAST, run_datetime) == datetime(
+        2025, 8, 27, 1, tzinfo=timezone.utc
+    )
 
 
 def test_get_advisory_valid_until_at_cutoff():
     run_datetime = datetime(2025, 8, 27, 0, 30, tzinfo=timezone.utc)
 
-    assert get_advisory_valid_until(run_datetime) == datetime(2025, 8, 27, 15, tzinfo=timezone.utc)
+    assert get_advisory_valid_until(RunType.FORECAST, run_datetime) == datetime(
+        2025, 8, 27, 15, tzinfo=timezone.utc
+    )
 
 
 def test_get_advisory_valid_until_after_cutoff():
     run_datetime = datetime(2025, 8, 27, 0, 31, tzinfo=timezone.utc)
 
-    assert get_advisory_valid_until(run_datetime) == datetime(2025, 8, 27, 15, tzinfo=timezone.utc)
+    assert get_advisory_valid_until(RunType.FORECAST, run_datetime) == datetime(
+        2025, 8, 27, 15, tzinfo=timezone.utc
+    )
+
+
+def test_get_advisory_valid_until_actual_expires_at_midnight():
+    run_datetime = datetime(2025, 8, 26, 15, tzinfo=timezone.utc)
+
+    assert get_advisory_valid_until(RunType.ACTUAL, run_datetime) == datetime(
+        2025, 8, 27, 7, tzinfo=timezone.utc
+    )
 
 
 def test_get_advisory_valid_until_without_timezone():
     run_datetime = datetime(2025, 8, 26, 17, 29)
 
     with pytest.raises(ValueError, match=f"{run_datetime} must be timezone-aware."):
-        get_advisory_valid_until(run_datetime)
+        get_advisory_valid_until(RunType.FORECAST, run_datetime)

--- a/backend/packages/wps-api/src/app/tests/fba/test_advisory_valid_until.py
+++ b/backend/packages/wps-api/src/app/tests/fba/test_advisory_valid_until.py
@@ -18,7 +18,7 @@ def test_get_advisory_valid_until_at_cutoff():
     run_datetime = datetime(2025, 8, 27, 0, 30, tzinfo=timezone.utc)
 
     assert get_advisory_valid_until(RunType.FORECAST, run_datetime) == datetime(
-        2025, 8, 27, 15, tzinfo=timezone.utc
+        2025, 8, 27, 15, 30, tzinfo=timezone.utc
     )
 
 
@@ -26,7 +26,7 @@ def test_get_advisory_valid_until_after_cutoff():
     run_datetime = datetime(2025, 8, 27, 0, 31, tzinfo=timezone.utc)
 
     assert get_advisory_valid_until(RunType.FORECAST, run_datetime) == datetime(
-        2025, 8, 27, 15, tzinfo=timezone.utc
+        2025, 8, 27, 15, 30, tzinfo=timezone.utc
     )
 
 

--- a/backend/packages/wps-api/src/app/tests/fba/test_fba_endpoint.py
+++ b/backend/packages/wps-api/src/app/tests/fba/test_fba_endpoint.py
@@ -14,12 +14,10 @@ from wps_shared.db.models.auto_spatial_advisory import (
 )
 from wps_shared.db.models.fuel_type_raster import FuelTypeRaster
 from wps_shared.db.models.psu import FireCentre
-from wps_shared.schemas.auto_spatial_advisory import SFMSRunType
 from wps_shared.schemas.fba import (
     FireZoneHFIStats,
     HFIStatsResponse,
     HfiThreshold,
-    SFMSRunParameter,
 )
 
 mock_fire_centre_name = "PGFireCentre"
@@ -258,17 +256,15 @@ async def mock_get_most_recent_run_datetime_for_date_range(*_, **__):
     for_date_1 = date(2025, 8, 25)
     for_date_2 = date(2025, 8, 26)
     run_datetime = datetime(2025, 8, 25, tzinfo=timezone.utc)
-    run_parameter_1 = SFMSRunParameter(
+    run_parameter_1 = RunParameters(
         for_date=for_date_1,
         run_datetime=run_datetime,
-        run_type=SFMSRunType.FORECAST,
-        valid_until=datetime(2025, 8, 25, 1, tzinfo=timezone.utc),
+        run_type="forecast",
     )
-    run_parameter_2 = SFMSRunParameter(
+    run_parameter_2 = RunParameters(
         for_date=for_date_2,
         run_datetime=run_datetime,
-        run_type=SFMSRunType.FORECAST,
-        valid_until=datetime(2025, 8, 25, 1, tzinfo=timezone.utc),
+        run_type="forecast",
     )
     return [run_parameter_1, run_parameter_2]
 


### PR DESCRIPTION
If it's an ACTUAL, it should expire at midnight on the same day.

Otherwise, it should expire at the time of the next FORECAST run, with a buffer for processing time. 18:00 expiry for the 17:45 forecast run, and 08:30 expiry for the 08:00 run.

# Test Links:
[Landing Page](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5631-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
