### PR TITLE
ASA Go: Actual expiry midnight

### DIFF
--- a/mobile/asa-go/src/components/InfoBar.test.tsx
+++ b/mobile/asa-go/src/components/InfoBar.test.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from '@mui/material/styles'
 import { render, screen } from '@testing-library/react'
-import { DateTime } from 'luxon'
+import { DateTime, Settings } from 'luxon'
 import type { ComponentProps } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { theme } from '@/theme'
@@ -18,6 +18,7 @@ const renderInfoBar = (props: Partial<ComponentProps<typeof InfoBar>> = {}) =>
 describe('InfoBar', () => {
   afterEach(() => {
     vi.useRealTimers()
+    Settings.defaultZone = 'system'
   })
 
   it('renders viewing date in correct format', () => {
@@ -41,6 +42,34 @@ describe('InfoBar', () => {
 
     renderInfoBar({ validUntil })
     expect(screen.getByText(/Valid until: 08:00 Tomorrow\./)).toBeInTheDocument()
+  })
+
+  it('renders valid until as midnight tonight when the expiry is local midnight tomorrow', () => {
+    Settings.defaultZone = 'America/Vancouver'
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-07-15T19:00:00Z'))
+    const validUntil = DateTime.fromISO('2024-07-16T00:00:00', {
+      zone: 'America/Vancouver'
+    })
+      .toUTC()
+      .toISO()
+
+    renderInfoBar({ validUntil })
+    expect(screen.getByText(/Valid until: Midnight Tonight\./)).toBeInTheDocument()
+  })
+
+  it('renders valid until as tomorrow when the expiry is not local midnight', () => {
+    Settings.defaultZone = 'America/Toronto'
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-07-15T16:00:00Z'))
+    const validUntil = DateTime.fromISO('2024-07-16T00:00:00', {
+      zone: 'America/Vancouver'
+    })
+      .toUTC()
+      .toISO()
+
+    renderInfoBar({ validUntil })
+    expect(screen.getByText(/Valid until: 03:00 Tomorrow\./)).toBeInTheDocument()
   })
 
   it('renders valid until as a date when the expiry date is in the past', () => {

--- a/mobile/asa-go/src/components/InfoBar.tsx
+++ b/mobile/asa-go/src/components/InfoBar.tsx
@@ -33,6 +33,9 @@ const getValidUntilString = (validUntil?: string | null) => {
   }
 
   if (validUntilDay.equals(today.plus({ days: 1 }))) {
+    if (validUntilDateTime.hour === 0 && validUntilDateTime.minute === 0) {
+      return 'Midnight Tonight'
+    }
     return `${validUntilDateTime.toFormat('HH:mm')} Tomorrow`
   }
 


### PR DESCRIPTION
If the expiry/valid date is the same day midnight, the text should say `Midnight tonight` rather than `00:00 Tomorrow` to reduce ambiguity.
# Test Links:
[Landing Page](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5633-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
