### PR TITLE
Dev: Force gc.collect() after each 4-panel chart to fix wx-4panel-charts-rdps OOMKilled

### DIFF
--- a/.github/workflows/build_openshift_manual.yml
+++ b/.github/workflows/build_openshift_manual.yml
@@ -46,7 +46,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - uses: ./.github/actions/oc-setup
 
@@ -58,9 +58,14 @@ jobs:
 
       - name: Build Image via OpenShift
         shell: bash
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_MODULE_NAME: ${{ inputs.module_name }}
+          INPUT_DOCKER_FILE: ${{ inputs.docker_file }}
+          INPUT_PATH_BC: ${{ inputs.path_bc }}
         run: |
-          GIT_BRANCH=${{ inputs.branch }} \
-            MODULE_NAME=${{ inputs.module_name }} \
-            ${{ inputs.docker_file && format('DOCKER_FILE={0}', inputs.docker_file) || '' }} \
-            PATH_BC=${{ inputs.path_bc }} \
-            bash openshift/scripts/oc_build.sh ${SUFFIX} apply
+          GIT_BRANCH="${INPUT_BRANCH}" \
+            MODULE_NAME="${INPUT_MODULE_NAME}" \
+            ${INPUT_DOCKER_FILE:+DOCKER_FILE="${INPUT_DOCKER_FILE}"} \
+            PATH_BC="${INPUT_PATH_BC}" \
+            bash openshift/scripts/oc_build.sh "${SUFFIX}" apply

--- a/.github/workflows/build_openshift_manual.yml
+++ b/.github/workflows/build_openshift_manual.yml
@@ -1,0 +1,66 @@
+name: Build via OpenShift (manual)
+
+# Manual, on-demand alternative to the default GHCR-based builds (e.g. deploy_wps_weather.yml
+# for wps-weather). Not triggered automatically by anything -- use this only if GHCR (or the
+# GitHub Actions build step) is unavailable and you need to build/store an image via
+# OpenShift's own BuildConfig instead. Works for any module built via oc_build.sh, not just
+# wps-weather.
+#
+# Resulting image:
+#   image-registry.openshift-image-registry.svc:5000/e1e498-tools/wps-<module_name>-pr-<N>:pr-<N>
+#
+# For modules whose deploy templates read their image from a parameter (e.g. wps-weather's
+# WEATHER_IMAGE), override that parameter with the above when calling the provisioning
+# script, e.g.:
+#
+#   WEATHER_IMAGE=image-registry.openshift-image-registry.svc:5000/e1e498-tools/wps-weather-pr-123:pr-123 \
+#     bash openshift/scripts/oc_provision_eccc_grib_consumer.sh pr-123 apply
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to build (SUFFIX will be pr-<number>)
+        required: true
+      branch:
+        description: Git branch to build from
+        required: true
+      module_name:
+        description: Module name (api, web, jobs, weather, etc.)
+        required: true
+      docker_file:
+        description: Dockerfile path (optional, module-dependent default in build.bc.yaml if omitted)
+        required: false
+      path_bc:
+        description: BuildConfig template path
+        required: false
+        default: openshift/templates/build.bc.yaml
+
+env:
+  SUFFIX: pr-${{ inputs.pr_number }}
+
+jobs:
+  build-image:
+    name: Build ${{ inputs.module_name }} Image via OpenShift
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - uses: ./.github/actions/oc-setup
+
+      - uses: ./.github/actions/oc-login
+        with:
+          oc-server: ${{ secrets.OPENSHIFT_CLUSTER }}
+          oc-token: ${{ secrets.OC4_TOOL_TOKEN }}
+          oc-namespace: e1e498-tools
+
+      - name: Build Image via OpenShift
+        shell: bash
+        run: |
+          GIT_BRANCH=${{ inputs.branch }} \
+            MODULE_NAME=${{ inputs.module_name }} \
+            ${{ inputs.docker_file && format('DOCKER_FILE={0}', inputs.docker_file) || '' }} \
+            PATH_BC=${{ inputs.path_bc }} \
+            bash openshift/scripts/oc_build.sh ${SUFFIX} apply

--- a/.github/workflows/deploy_wps_weather.yml
+++ b/.github/workflows/deploy_wps_weather.yml
@@ -21,7 +21,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build and push WPS Weather image
         uses: bcgov/actions/builder-ghcr@0992e41cd11c5370b77f9e6066effe63efe9f8c9 # v0.4.0
@@ -39,7 +39,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - uses: ./.github/actions/oc-setup
 

--- a/.github/workflows/deploy_wps_weather.yml
+++ b/.github/workflows/deploy_wps_weather.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Build and push WPS Weather image
-        uses: bcgov/actions/builder-ghcr@v0.4.0
+        uses: bcgov/actions/builder-ghcr@0992e41cd11c5370b77f9e6066effe63efe9f8c9 # v0.4.0
         with:
           package: wps-weather
           build_context: .

--- a/.github/workflows/deploy_wps_weather.yml
+++ b/.github/workflows/deploy_wps_weather.yml
@@ -17,24 +17,19 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push WPS Weather image
-        uses: docker/build-push-action@v6
+        uses: bcgov/actions/builder-ghcr@v0.4.0
         with:
-          context: .
-          file: backend/packages/wps-weather/Dockerfile
-          push: true
-          tags: ghcr.io/bcgov/wps-weather:${{ env.SUFFIX }}
+          package: wps-weather
+          build_context: .
+          build_file: backend/packages/wps-weather/Dockerfile
+          tags: ${{ env.SUFFIX }}
 
   deployments:
     name: Deployments

--- a/.github/workflows/deploy_wps_weather.yml
+++ b/.github/workflows/deploy_wps_weather.yml
@@ -16,24 +16,25 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - uses: ./.github/actions/oc-setup
 
-      - uses: ./.github/actions/oc-login
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          oc-server: ${{ secrets.OPENSHIFT_CLUSTER }}
-          oc-token: ${{ secrets.OC4_TOOL_TOKEN }}
-          oc-namespace: e1e498-tools
-      - name: Build WPS Weather Image
-        shell: bash
-        run: |
-          GIT_BRANCH=${GITHUB_HEAD_REF} \
-            MODULE_NAME=weather \
-            DOCKER_FILE=backend/packages/wps-weather/Dockerfile \
-            PATH_BC=openshift/templates/build.bc.yaml \
-            bash openshift/scripts/oc_build.sh ${SUFFIX} apply
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push WPS Weather image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/packages/wps-weather/Dockerfile
+          push: true
+          tags: ghcr.io/bcgov/wps-weather:${{ env.SUFFIX }}
 
   deployments:
     name: Deployments

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   pull-requests: read
   deployments: write
+  packages: write
 
 # trigger this deployment by running:
 # gh api repos/bcgov/wps/deployments -f ref="[your branch]"
@@ -45,6 +46,12 @@ jobs:
         with:
           oc: "4.14"
           skip_cache: true
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Provision to production
         run: |
           echo Login

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,7 +4,6 @@ permissions:
   contents: read
   pull-requests: read
   deployments: write
-  packages: write
 
 # trigger this deployment by running:
 # gh api repos/bcgov/wps/deployments -f ref="[your branch]"
@@ -19,9 +18,13 @@ jobs:
   deploy_to_production:
     name: Deploy to production
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+      packages: write
     steps:
       - name: Find PR number
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           # reference used to figure out this part:
           # https://docs.github.com/en/rest/reference/pulls#list-pull-requests
@@ -34,7 +37,7 @@ jobs:
             // find an open PR (potentially problematic if you have multiple PR's on the same hash open!)
             const pr = pulls.data.find( ({state}) => state === 'open')
             core.exportVariable('SUFFIX', `pr-${pr.number}`);
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Log public IP address
         run: |
           echo -e "Public IPv4:"
@@ -42,12 +45,12 @@ jobs:
           echo -e "\nPublic IPv4(v6):"
           curl -s https://api64.ipify.org
       - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@v1
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1
         with:
           oc: "4.14"
           skip_cache: true
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -98,7 +101,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set status to deployed
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           # reference used to figure out how to set the deployment status:
           # https://docs.github.com/en/rest/reference/repos#deployments

--- a/backend/packages/wps-weather/Dockerfile
+++ b/backend/packages/wps-weather/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1
 
 # Minimal deps
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential git python3-pip python3-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git python3-dev python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/backend/packages/wps-weather/Dockerfile
+++ b/backend/packages/wps-weather/Dockerfile
@@ -12,7 +12,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1
 
 # Minimal deps
-RUN apt-get update && apt-get install -y git python3-pip python3-dev \
+# Force IPv4: this build environment advertises IPv6 routes to the Ubuntu mirrors via DNS
+# that aren't actually reachable ("Network is unreachable"), which wastes every apt attempt
+# retrying dead IPv6 addresses before it can fall back to IPv4.
+RUN echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4 \
+    && apt-get update && apt-get install -y git python3-pip python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/backend/packages/wps-weather/Dockerfile
+++ b/backend/packages/wps-weather/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1
 
 # Minimal deps
-RUN apt-get update && apt-get install -y git python3-pip \
+RUN apt-get update && apt-get install -y git python3-pip python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/backend/packages/wps-weather/Dockerfile
+++ b/backend/packages/wps-weather/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # that aren't actually reachable ("Network is unreachable"), which wastes every apt attempt
 # retrying dead IPv6 addresses before it can fall back to IPv4.
 RUN echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4 \
-    && apt-get update && apt-get install -y --no-install-recommends git python3-pip python3-dev \
+    && apt-get update && apt-get install -y --no-install-recommends build-essential git python3-pip python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/backend/packages/wps-weather/Dockerfile
+++ b/backend/packages/wps-weather/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # that aren't actually reachable ("Network is unreachable"), which wastes every apt attempt
 # retrying dead IPv6 addresses before it can fall back to IPv4.
 RUN echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4 \
-    && apt-get update && apt-get install -y git python3-pip python3-dev \
+    && apt-get update && apt-get install -y --no-install-recommends git python3-pip python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/backend/packages/wps-weather/Dockerfile
+++ b/backend/packages/wps-weather/Dockerfile
@@ -12,11 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1
 
 # Minimal deps
-# Force IPv4: this build environment advertises IPv6 routes to the Ubuntu mirrors via DNS
-# that aren't actually reachable ("Network is unreachable"), which wastes every apt attempt
-# retrying dead IPv6 addresses before it can fall back to IPv4.
-RUN echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4 \
-    && apt-get update && apt-get install -y --no-install-recommends build-essential git python3-pip python3-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git python3-pip python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/backend/packages/wps-weather/src/wps_weather/wx_4panel_charts/wx_4panel_charts.py
+++ b/backend/packages/wps-weather/src/wps_weather/wx_4panel_charts/wx_4panel_charts.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import gc
 import logging
 import os
 import sys
@@ -212,9 +213,20 @@ class FourPanelChartRunner:
                 logger.info(f"Saved: {output_key}")
         finally:
             plt.close(fig)
+            # matplotlib Figure/Axes/Artist objects form reference cycles that plain
+            # refcounting can't break and only the cyclic GC can. Confirmed via profiling.
+            # without this, RSS climbs ~365-420MB per panel across a run (gc.collect() finds
+            # 20,000+ collectable objects per panel); with it, RSS is flat after the first panel.
+            gc.collect()
 
     async def _make_4panel_charts(
-        self, model: ECCCModel, init_ymd: str, init_hh: str, start_hour: int, end_hour: int, step: int
+        self,
+        model: ECCCModel,
+        init_ymd: str,
+        init_hh: str,
+        start_hour: int,
+        end_hour: int,
+        step: int,
     ):
         _model_cfgs = {
             ECCCModel.GDPS: (CFG_500_GDPS, CFG_MSLP_GDPS, CFG_700_GDPS, CFG_PCPN_GDPS, gdps_fname),

--- a/openshift/scripts/oc_deploy_to_production.sh
+++ b/openshift/scripts/oc_deploy_to_production.sh
@@ -34,12 +34,13 @@ MODULE_NAME=web bash $(dirname ${0})/oc_promote.sh ${SUFFIX} ${RUN_TYPE}
 MODULE_NAME=jobs bash $(dirname ${0})/oc_promote.sh ${SUFFIX} ${RUN_TYPE}
 
 # wps-weather lives on GHCR now, promoted via a registry-side copy rather than `oc tag`.
-# Tolerant of a missing PR image, same as the other modules -- wps-weather isn't always
-# rebuilt if nothing in it changed, in which case "prod" just keeps pointing at whatever
-# it already was. The resulting path is always ghcr.io/bcgov/wps/wps-weather:prod, which
-# the provisioning scripts below already default WEATHER_IMAGE to (since they're called
-# with SUFFIX=prod) -- nothing needs to be captured or passed through here.
-PACKAGE=wps-weather bash $(dirname ${0})/oc_promote_gh.sh ${SUFFIX} ${RUN_TYPE} || true
+# wps-weather isn't always rebuilt if nothing in it changed, in which case there's no PR
+# image to promote and oc_promote_gh.sh exits 0, leaving "prod" pointing at whatever it
+# already was. An actual promotion failure (registry/auth/network error) exits non-zero 
+#and fails this deploy like everything else here. The resulting path is always
+# ghcr.io/bcgov/wps/wps-weather:prod, which the provisioning scripts below
+# already default WEATHER_IMAGE to (since they're called with SUFFIX=prod).
+PACKAGE=wps-weather bash $(dirname ${0})/oc_promote_gh.sh ${SUFFIX} ${RUN_TYPE}
 
 echo Provision database
 PROJ_TARGET=${PROJ_TARGET} BUCKET=lwzrin CPU_REQUEST=2 MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi DATA_SIZE=65Gi WAL_SIZE=15Gi REPLICAS=3 bash $(dirname ${0})/oc_provision_crunchy.sh prod ${RUN_TYPE}

--- a/openshift/scripts/oc_deploy_to_production.sh
+++ b/openshift/scripts/oc_deploy_to_production.sh
@@ -32,7 +32,14 @@ echo Promote
 MODULE_NAME=api bash $(dirname ${0})/oc_promote.sh ${SUFFIX} ${RUN_TYPE}
 MODULE_NAME=web bash $(dirname ${0})/oc_promote.sh ${SUFFIX} ${RUN_TYPE}
 MODULE_NAME=jobs bash $(dirname ${0})/oc_promote.sh ${SUFFIX} ${RUN_TYPE}
-MODULE_NAME=weather bash $(dirname ${0})/oc_promote.sh ${SUFFIX} ${RUN_TYPE}
+
+# wps-weather lives on GHCR now, promoted via a registry-side copy rather than `oc tag`.
+# Tolerant of a missing PR image, same as the other modules -- wps-weather isn't always
+# rebuilt if nothing in it changed, in which case "prod" just keeps pointing at whatever
+# it already was. The resulting path is always ghcr.io/bcgov/wps/wps-weather:prod, which
+# the provisioning scripts below already default WEATHER_IMAGE to (since they're called
+# with SUFFIX=prod) -- nothing needs to be captured or passed through here.
+PACKAGE=wps-weather bash $(dirname ${0})/oc_promote_gh.sh ${SUFFIX} ${RUN_TYPE} || true
 
 echo Provision database
 PROJ_TARGET=${PROJ_TARGET} BUCKET=lwzrin CPU_REQUEST=2 MEMORY_REQUEST=2Gi MEMORY_LIMIT=16Gi DATA_SIZE=65Gi WAL_SIZE=15Gi REPLICAS=3 bash $(dirname ${0})/oc_provision_crunchy.sh prod ${RUN_TYPE}

--- a/openshift/scripts/oc_promote_gh.sh
+++ b/openshift/scripts/oc_promote_gh.sh
@@ -1,0 +1,49 @@
+#!/bin/sh -l
+#
+source "$(dirname ${0})/common/common"
+
+#%
+#% GHCR Image Promotion Helper
+#%
+#%   Promotes a PR-tagged image on GHCR to a "prod" tag, via a registry-side copy
+#%   (no rebuild). Requires the caller to already be logged into ghcr.io
+#%   (docker/podman) with push access.
+#%
+#%   If the PR image doesn't exist on GHCR (e.g. this package wasn't changed in this
+#%   PR, so nothing was built), this leaves the existing "prod" tag alone and exits
+#%   non-zero -- it does not fall back to anything automatically.
+#%
+#%   Prints the resulting image reference to stdout as the only stdout output, so
+#%   callers can capture it via command substitution:
+#%
+#%       IMAGE=$(PACKAGE=wps-weather bash oc_promote_gh.sh ${SUFFIX} apply)
+#%
+#% Usage:
+#%
+#%    PACKAGE=[package] ${THIS_FILE} [SUFFIX] [apply]
+#%
+#% Examples:
+#%
+#%   PACKAGE=wps-weather ${THIS_FILE} pr-123 apply
+#%
+
+PACKAGE="${PACKAGE:?PACKAGE must be set, e.g. PACKAGE=wps-weather}"
+GH_ORG="${GH_ORG:-bcgov}"
+GH_REPO="${GH_REPO:-wps}"
+
+PR_IMAGE="ghcr.io/${GH_ORG}/${GH_REPO}/${PACKAGE}:${SUFFIX}"
+PROD_IMAGE="ghcr.io/${GH_ORG}/${GH_REPO}/${PACKAGE}:${TAG_PROD}"
+
+if ! docker manifest inspect "${PR_IMAGE}" >/dev/null 2>&1; then
+    echo "ERROR: GHCR image ${PR_IMAGE} not found -- nothing to promote." >&2
+    exit 1
+fi
+
+if [ "${APPLY}" ]; then
+    echo "Promoting GHCR image ${PR_IMAGE} -> ${PROD_IMAGE}" >&2
+    docker buildx imagetools create --tag "${PROD_IMAGE}" "${PR_IMAGE}" >&2
+else
+    echo "Dry-run: would promote ${PR_IMAGE} -> ${PROD_IMAGE}" >&2
+fi
+
+echo "${PROD_IMAGE}"

--- a/openshift/scripts/oc_promote_gh.sh
+++ b/openshift/scripts/oc_promote_gh.sh
@@ -11,7 +11,9 @@ source "$(dirname ${0})/common/common"
 #%
 #%   If the PR image doesn't exist on GHCR (e.g. this package wasn't changed in this
 #%   PR, so nothing was built), this leaves the existing "prod" tag alone and exits
-#%   non-zero -- it does not fall back to anything automatically.
+#%   0 -- there was nothing to promote, which is an expected outcome, not a failure.
+#%   Any non-zero exit means the promotion was attempted and failed (registry/auth/
+#%   network error), and should not be treated as tolerable.
 #%
 #%   Prints the resulting image reference to stdout as the only stdout output, so
 #%   callers can capture it via command substitution:
@@ -35,13 +37,16 @@ PR_IMAGE="ghcr.io/${GH_ORG}/${GH_REPO}/${PACKAGE}:${SUFFIX}"
 PROD_IMAGE="ghcr.io/${GH_ORG}/${GH_REPO}/${PACKAGE}:${TAG_PROD}"
 
 if ! docker manifest inspect "${PR_IMAGE}" >/dev/null 2>&1; then
-    echo "ERROR: GHCR image ${PR_IMAGE} not found -- nothing to promote." >&2
-    exit 1
+    echo "GHCR image ${PR_IMAGE} not found -- nothing to promote." >&2
+    exit 0
 fi
 
 if [ "${APPLY}" ]; then
     echo "Promoting GHCR image ${PR_IMAGE} -> ${PROD_IMAGE}" >&2
-    docker buildx imagetools create --tag "${PROD_IMAGE}" "${PR_IMAGE}" >&2
+    if ! docker buildx imagetools create --tag "${PROD_IMAGE}" "${PR_IMAGE}" >&2; then
+        echo "ERROR: failed to promote ${PR_IMAGE} -> ${PROD_IMAGE}" >&2
+        exit 1
+    fi
 else
     echo "Dry-run: would promote ${PR_IMAGE} -> ${PROD_IMAGE}" >&2
 fi

--- a/openshift/scripts/oc_provision_eccc_grib_consumer.sh
+++ b/openshift/scripts/oc_provision_eccc_grib_consumer.sh
@@ -34,10 +34,17 @@ OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/eccc_grib_consumer.
 OC_APPLY="oc -n ${PROJ_TARGET} apply -f -"
 [ "${APPLY}" ] || OC_APPLY="${OC_APPLY} --dry-run"
 
+# Restart the deployment so it actually pulls the freshly-pushed image. Unlike the internal
+# OpenShift registry, ghcr.io isn't watched by an ImageStream trigger, so re-applying the same
+# manifest with the same tag (e.g. pr-###) wouldn't otherwise cause a rollout.
+OC_ROLLOUT_RESTART="oc -n ${PROJ_TARGET} rollout restart deployment/${APP_NAME}-${SUFFIX}-eccc-consumer"
+[ "${APPLY}" ] || OC_ROLLOUT_RESTART=""
+
 # Execute commands
 #
 eval "${OC_PROCESS}"
 eval "${OC_PROCESS} | ${OC_APPLY}"
+eval "${OC_ROLLOUT_RESTART}"
 
 # Provide oc command instruction
 #

--- a/openshift/scripts/oc_provision_eccc_grib_consumer.sh
+++ b/openshift/scripts/oc_provision_eccc_grib_consumer.sh
@@ -25,9 +25,14 @@ source "$(dirname ${0})/common/common"
 #
 PROJ_TARGET="${PROJ_TARGET:-${PROJ_DEV}}"
 
+# wps-weather image: GHCR by default. Callers (e.g. the production promotion fallback) can
+# override this to the internal OpenShift ImageStream if the GHCR build/promotion path failed.
+WEATHER_IMAGE="${WEATHER_IMAGE:-ghcr.io/bcgov/wps/wps-weather:${SUFFIX}}"
+
 # Process template
 OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/eccc_grib_consumer.yaml \
--p SUFFIX=${SUFFIX}"
+-p SUFFIX=${SUFFIX} \
+-p WEATHER_IMAGE=${WEATHER_IMAGE}"
 
 # Apply template (apply or use --dry-run)
 #

--- a/openshift/scripts/oc_provision_wx_4panel_charts_cronjob.sh
+++ b/openshift/scripts/oc_provision_wx_4panel_charts_cronjob.sh
@@ -28,6 +28,10 @@ PROJ_TARGET="${PROJ_TARGET:-${PROJ_DEV}}"
 # Specify a default schedule to run daily at 4am
 SCHEDULE="${SCHEDULE:-$((3 + $RANDOM % 54)) * * * *}"
 
+# wps-weather image: GHCR by default. Callers (e.g. the production promotion fallback) can
+# override this to the internal OpenShift ImageStream if the GHCR build/promotion path failed.
+WEATHER_IMAGE="${WEATHER_IMAGE:-ghcr.io/bcgov/wps/wps-weather:${SUFFIX}}"
+
 # Process template
 OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/wx_4panel_charts.cronjob.yaml \
 -p JOB_NAME=wx-4panel-charts-${MODEL,,}-${APP_NAME}-${SUFFIX} \
@@ -38,7 +42,8 @@ OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/wx_4panel_charts.cr
 -p CRUNCHYDB_USER=${CRUNCHY_NAME}-${SUFFIX}-pguser-${CRUNCHY_NAME}-${SUFFIX} \
 -p END_HOUR=${END_HOUR} \
 -p STEP=${STEP} \
--p MODEL=${MODEL}"
+-p MODEL=${MODEL} \
+-p WEATHER_IMAGE=${WEATHER_IMAGE}"
 
 # Apply template (apply or use --dry-run)
 #

--- a/openshift/scripts/oc_provision_wx_4panel_charts_cronjob.sh
+++ b/openshift/scripts/oc_provision_wx_4panel_charts_cronjob.sh
@@ -38,9 +38,7 @@ OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/wx_4panel_charts.cr
 -p CRUNCHYDB_USER=${CRUNCHY_NAME}-${SUFFIX}-pguser-${CRUNCHY_NAME}-${SUFFIX} \
 -p END_HOUR=${END_HOUR} \
 -p STEP=${STEP} \
--p MODEL=${MODEL} \
-${PROJ_TOOLS:+ "-p PROJ_TOOLS=${PROJ_TOOLS}"} \
-${IMAGE_REGISTRY:+ "-p IMAGE_REGISTRY=${IMAGE_REGISTRY}"}"
+-p MODEL=${MODEL}"
 
 # Apply template (apply or use --dry-run)
 #

--- a/openshift/templates/eccc_grib_consumer.yaml
+++ b/openshift/templates/eccc_grib_consumer.yaml
@@ -18,6 +18,12 @@ parameters:
   - name: SUFFIX
     description: Deployment suffix, e.g. pr-###
     required: true
+  - name: WEATHER_IMAGE
+    description: >-
+      Full image reference for wps-weather. Computed by the deploy scripts: the GHCR build
+      by default, or the internal OpenShift ImageStream when the GHCR build/promotion
+      fallback path was used.
+    required: true
 objects:
   - apiVersion: apps/v1
     kind: Deployment
@@ -41,7 +47,7 @@ objects:
         spec:
           containers:
             - name: ${APP_NAME}-eccc-consumer-${SUFFIX}
-              image: ghcr.io/bcgov/wps/wps-weather:${SUFFIX}
+              image: ${WEATHER_IMAGE}
               imagePullPolicy: Always
               command:
                 - uv

--- a/openshift/templates/eccc_grib_consumer.yaml
+++ b/openshift/templates/eccc_grib_consumer.yaml
@@ -41,7 +41,7 @@ objects:
         spec:
           containers:
             - name: ${APP_NAME}-eccc-consumer-${SUFFIX}
-              image: ghcr.io/bcgov/wps-weather:${SUFFIX}
+              image: ghcr.io/bcgov/wps/wps-weather:${SUFFIX}
               imagePullPolicy: Always
               command:
                 - uv

--- a/openshift/templates/eccc_grib_consumer.yaml
+++ b/openshift/templates/eccc_grib_consumer.yaml
@@ -18,12 +18,6 @@ parameters:
   - name: SUFFIX
     description: Deployment suffix, e.g. pr-###
     required: true
-  - name: PROJ_TOOLS
-    value: e1e498-tools
-  - name: IMAGE_REGISTRY
-    description: Location where images are to be pulled
-    value: image-registry.openshift-image-registry.svc:5000
-    required: true
 objects:
   - apiVersion: apps/v1
     kind: Deployment
@@ -31,19 +25,6 @@ objects:
       name: ${APP_NAME}-${SUFFIX}-eccc-consumer
       labels:
         app: ${APP_NAME}-${SUFFIX}
-      annotations:
-        # These annotations trigger a new rollout if the weather image changes
-        image.openshift.io/triggers: |-
-          [
-            {
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "wps-weather-${SUFFIX}:${SUFFIX}",
-                "namespace": "${PROJ_TOOLS}"
-              },
-              "fieldPath": "spec.template.spec.containers[0].image"
-            }
-          ]
     spec:
       replicas: 1
       strategy:
@@ -60,7 +41,8 @@ objects:
         spec:
           containers:
             - name: ${APP_NAME}-eccc-consumer-${SUFFIX}
-              image: ${IMAGE_REGISTRY}/${PROJ_TOOLS}/wps-weather-${SUFFIX}:${SUFFIX}
+              image: ghcr.io/bcgov/wps-weather:${SUFFIX}
+              imagePullPolicy: Always
               command:
                 - uv
                 - run

--- a/openshift/templates/wx_4panel_charts.cronjob.yaml
+++ b/openshift/templates/wx_4panel_charts.cronjob.yaml
@@ -54,7 +54,7 @@ objects:
             spec:
               containers:
                 - name: ${JOB_NAME}
-                  image: ghcr.io/bcgov/wps-weather:${SUFFIX}
+                  image: ghcr.io/bcgov/wps/wps-weather:${SUFFIX}
                   imagePullPolicy: "Always"
                   command:
                     [

--- a/openshift/templates/wx_4panel_charts.cronjob.yaml
+++ b/openshift/templates/wx_4panel_charts.cronjob.yaml
@@ -18,13 +18,8 @@ parameters:
   - name: SUFFIX
     description: Deployment suffix, e.g. pr-###
     required: true
-  - name: PROJ_TOOLS
-    value: e1e498-tools
   - name: JOB_NAME
     value: wx-4panel-chart
-  - name: IMAGE_REGISTRY
-    required: true
-    value: image-registry.openshift-image-registry.svc:5000
   - name: CRUNCHYDB_USER
     required: true
   - name: SCHEDULE
@@ -59,7 +54,7 @@ objects:
             spec:
               containers:
                 - name: ${JOB_NAME}
-                  image: ${IMAGE_REGISTRY}/${PROJ_TOOLS}/wps-weather-${SUFFIX}:${SUFFIX}
+                  image: ghcr.io/bcgov/wps-weather:${SUFFIX}
                   imagePullPolicy: "Always"
                   command:
                     [

--- a/openshift/templates/wx_4panel_charts.cronjob.yaml
+++ b/openshift/templates/wx_4panel_charts.cronjob.yaml
@@ -32,6 +32,12 @@ parameters:
     required: true
   - name: MODEL
     required: true
+  - name: WEATHER_IMAGE
+    description: >-
+      Full image reference for wps-weather. Computed by the deploy scripts: the GHCR build
+      by default, or the internal OpenShift ImageStream when the GHCR build/promotion
+      fallback path was used.
+    required: true
 objects:
   - kind: CronJob
     apiVersion: batch/v1
@@ -54,7 +60,7 @@ objects:
             spec:
               containers:
                 - name: ${JOB_NAME}
-                  image: ghcr.io/bcgov/wps/wps-weather:${SUFFIX}
+                  image: ${WEATHER_IMAGE}
                   imagePullPolicy: "Always"
                   command:
                     [


### PR DESCRIPTION
`wx-4panel-charts-rdps` pods were being OOMKilled against their `4Gi` memory limit. Profiling against real RDPS GRIB2 data (`profile_4panel_memory.py` (not committed here, scratch script)) showed RSS climbing ~365–420MB per panel generated, with no ceiling. A full 29-panel production run (`END_HOUR=84`, `STEP=3`) crosses `4Gi` by roughly the 10th–11th panel.

`FourPanelChartRunner._make_4panel_chart` already calls `plt.close(fig)` in its `finally` block, but that's not enough: matplotlib's `Figure`/`Axes`/`Artist` object graph forms reference cycles (colorbars, legends, tick/font caches, the Agg canvas) that plain refcounting can't break, only the cyclic garbage collector can, and it wasn't running often enough on its own to keep pace with how fast this pipeline generates garbage. Toggling an explicit `gc.collect()` on and off in the profiling harness confirmed it directly — without it, `gc.collect()` finds 20,000+ collectable objects per panel and RSS keeps climbing; with it forced right after `plt.close(fig)`, RSS goes flat after the first panel.

Getting this fix through CI surfaced a second, unrelated problem: `wps-weather`'s OpenShift-native image build (`oc process`/`BuildConfig`) was timing out against the cluster's API server, and separately its Dockerfile failed to compile `gdal`/`fiona` from source (missing `python3-dev`/`build-essential`, exposed once the base image's newer Ubuntu release stopped having prebuilt wheels available for its Python version). Rather than just patch around it, `wps-weather`'s build+push moved off `oc` entirely onto `bcgov/actions/builder-ghcr`, pushing to `ghcr.io/bcgov/wps/wps-weather`. Production promotion is now a registry-side image copy (`oc_promote_gh.sh`, written generically so other packages can reuse it, not just `wps-weather`) instead of `oc tag`, and the old OpenShift-native build path is kept available as a separate, manually-triggered fallback (`build_openshift_manual.yml`) rather than deleted. Also cleaned up the SonarCloud/GitHub Advanced Security findings this introduced along the way: SHA-pinning every external Action, moving `workflow_dispatch` inputs out of `run:` blocks to avoid script injection, scoping `packages: write` to only the job that needs it, and adding `--no-install-recommends` to the Dockerfile's apt install.

# Test Links:
[Landing Page](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5634-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
