### PR TITLE
ASA Go: Today fix and timezone

### DIFF
--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -45,7 +45,7 @@ import {
 import { theme } from '@/theme'
 import type { FireCentre } from '@/types/fireCentre'
 import { NavPanel, StatusEnum } from '@/utils/constants'
-import { today } from '@/utils/dataSliceUtils'
+import { getToday } from '@/utils/dataSliceUtils'
 import { PMTilesCache } from '@/utils/pmtilesCache'
 import { clearStaleHFIPMTiles } from '@/utils/storage'
 
@@ -60,7 +60,7 @@ const App = () => {
   const [tab, setTab] = useState<NavPanel>(NavPanel.MAP)
   const [fireCentre, setFireCentre] = useState<FireCentre | undefined>(undefined)
   const [selectedFireShape, setSelectedFireShape] = useState<FireShape | undefined>(undefined)
-  const [dateOfInterest, setDateOfInterest] = useState<DateTime>(today)
+  const [dateOfInterest, setDateOfInterest] = useState<DateTime>(() => getToday())
 
   // selected redux state
   const { fireCentres } = useSelector(selectFireCentres)
@@ -171,7 +171,7 @@ const App = () => {
 
     const advisoryDate = DateTime.fromISO(pendingNotificationData.advisory_date)
     const notificationDateKey = advisoryDate.toISODate()
-    const todayKey = today.toISODate()
+    const todayKey = getToday().toISODate()
 
     // Only process notifications whose date matches today
     if (!notificationDateKey || notificationDateKey !== todayKey) {

--- a/mobile/asa-go/src/app.test.tsx
+++ b/mobile/asa-go/src/app.test.tsx
@@ -145,7 +145,7 @@ vi.mock('@/utils/dataSliceUtils', async () => {
   const { DateTime } = await vi.importActual<typeof import('luxon')>('luxon')
   return {
     ...actual,
-    today: DateTime.fromISO('2025-07-02')
+    getToday: () => DateTime.fromISO('2025-07-02')
   }
 })
 

--- a/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
+++ b/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
@@ -2,7 +2,7 @@ import { Box, Button, styled } from '@mui/material'
 import type { DateTime } from 'luxon'
 import { MAP_BUTTON_GREY } from '@/theme'
 import { BORDER_RADIUS, BUTTON_HEIGHT } from '@/utils/constants'
-import { today } from '@/utils/dataSliceUtils'
+import { getToday } from '@/utils/dataSliceUtils'
 
 interface TodayTomorrowSwitchProps {
   border?: boolean
@@ -36,7 +36,8 @@ const StyledTextContainer = styled(Box)({
 const TodayTomorrowSwitch = ({ border = false, date, setDate }: TodayTomorrowSwitchProps) => {
   const borderStyle = border ? `1px solid ${MAP_BUTTON_GREY}` : 'none'
 
-  const isToday = date.day === today.day
+  const today = getToday()
+  const isToday = date.toISODate() === today.toISODate()
 
   const handleDayChange = (newValue: number) => {
     // newValue: 0 = today, 1 = tomorrow

--- a/mobile/asa-go/src/components/report/AdvisoryText.tsx
+++ b/mobile/asa-go/src/components/report/AdvisoryText.tsx
@@ -15,7 +15,7 @@ import {
   formatCriticalHoursTimeText,
   getMinStartAndMaxEndTime
 } from '@/utils/criticalHoursStartEndTime'
-import { today } from '@/utils/dataSliceUtils'
+import { getToday } from '@/utils/dataSliceUtils'
 
 export interface AdvisoryTextProps {
   selectedFireCentre: FireCentre | undefined
@@ -173,7 +173,7 @@ const AdvisoryText = ({ selectedFireCentre, selectedFireZoneUnit, date }: Adviso
 
   const renderAdvisoryText = () => {
     const zoneTitle = `${selectedFireZoneUnit?.mof_fire_zone_name}:\n\n`
-    const forToday = runParameter?.for_date === today.toISODate()
+    const forToday = runParameter?.for_date === getToday().toISODate()
     const displayForDate = forToday
       ? 'today'
       : DateTime.fromISO(runParameter!.for_date).toLocaleString({

--- a/mobile/asa-go/src/components/report/advisoryText.test.tsx
+++ b/mobile/asa-go/src/components/report/advisoryText.test.tsx
@@ -33,7 +33,8 @@ vi.mock(import('@/hooks/dataHooks'), async importOriginal => {
 
 import { useFilteredHFIStatsForDate } from '@/hooks/dataHooks'
 import { useRunParameterForDate } from '@/hooks/useRunParameterForDate'
-import { AdvisoryStatus, PST_UTC_OFFSET } from '@/utils/constants'
+import { AdvisoryStatus } from '@/utils/constants'
+import { getToday } from '@/utils/dataSliceUtils'
 
 const TEST_FOR_DATE = '2025-07-14'
 const TEST_FOR_DATE_LUXON = DateTime.fromISO(TEST_FOR_DATE)
@@ -430,7 +431,7 @@ describe('AdvisoryText', () => {
     const todayRunParameter = cloneDeep(testRunParameter)
     ;(useRunParameterForDate as Mock).mockReturnValue({
       ...todayRunParameter,
-      for_date: DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`).toISODate()
+      for_date: getToday().toISODate()
     })
     ;(useFilteredHFIStatsForDate as Mock).mockReturnValue({})
     const store = buildTestStore(

--- a/mobile/asa-go/src/components/todayTomorrowSwitch.test.tsx
+++ b/mobile/asa-go/src/components/todayTomorrowSwitch.test.tsx
@@ -1,13 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { DateTime } from 'luxon'
 import { describe, expect, it, vi } from 'vitest'
-import { PST_UTC_OFFSET } from '@/utils/constants'
+import { getToday } from '@/utils/dataSliceUtils'
 import TodayTomorrowSwitch from './TodayTomorrowSwitch'
 
 describe('TodayTomorrowSwitch', () => {
   it('renders both buttons', () => {
     const mockSetDate = vi.fn()
-    const today = DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`)
+    const today = getToday()
 
     render(<TodayTomorrowSwitch date={today} setDate={mockSetDate} />)
 
@@ -17,7 +16,7 @@ describe('TodayTomorrowSwitch', () => {
 
   it('disables the NOW button when date is today', () => {
     const mockSetDate = vi.fn()
-    const today = DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`)
+    const today = getToday()
 
     render(<TodayTomorrowSwitch date={today} setDate={mockSetDate} />)
 
@@ -27,7 +26,7 @@ describe('TodayTomorrowSwitch', () => {
 
   it('disables the TMR button when date is tomorrow', () => {
     const mockSetDate = vi.fn()
-    const tomorrow = DateTime.now().plus({ days: 1 }).setZone(`UTC${PST_UTC_OFFSET}`)
+    const tomorrow = getToday().plus({ days: 1 })
 
     render(<TodayTomorrowSwitch date={tomorrow} setDate={mockSetDate} />)
 
@@ -37,7 +36,7 @@ describe('TodayTomorrowSwitch', () => {
 
   it('clicking TMR updates the date to tomorrow', () => {
     const mockSetDate = vi.fn()
-    const today = DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`)
+    const today = getToday()
 
     render(<TodayTomorrowSwitch date={today} setDate={mockSetDate} />)
 
@@ -49,7 +48,7 @@ describe('TodayTomorrowSwitch', () => {
 
   it('clicking NOW updates the date to today', () => {
     const mockSetDate = vi.fn()
-    const tomorrow = DateTime.now().plus({ days: 1 }).setZone(`UTC${PST_UTC_OFFSET}`)
+    const tomorrow = getToday().plus({ days: 1 })
 
     render(<TodayTomorrowSwitch date={tomorrow} setDate={mockSetDate} />)
 
@@ -60,7 +59,7 @@ describe('TodayTomorrowSwitch', () => {
   })
 
   it('updates internal state when date prop changes', () => {
-    const today = DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`)
+    const today = getToday()
     const tomorrow = today.plus({ day: 1 })
     const setDateMock = vi.fn()
 

--- a/mobile/asa-go/src/slices/fireCentresSlice.ts
+++ b/mobile/asa-go/src/slices/fireCentresSlice.ts
@@ -5,7 +5,7 @@ import { isNull } from 'lodash'
 import { DateTime } from 'luxon'
 import type { AppThunk } from '@/store'
 import type { FireCentre } from '@/types/fireCentre'
-import { today } from '@/utils/dataSliceUtils'
+import { getToday } from '@/utils/dataSliceUtils'
 import { FIRE_CENTRES_CACHE_EXPIRATION, FIRE_CENTRES_KEY, readFromFilesystem, writeToFileSystem } from '@/utils/storage'
 
 export interface FireCentresState {
@@ -47,6 +47,7 @@ export default fireCentresSlice.reducer
 
 export const fetchFireCentres = (): AppThunk => async (dispatch, getState) => {
   // Check for cached fire centers data. If the data is not stale save it in redux state.
+  const today = getToday()
   const cachedFireCentres = await readFromFilesystem(Filesystem, FIRE_CENTRES_KEY)
   const networkStatus = getState().networkStatus
   if (!isNull(cachedFireCentres)) {

--- a/mobile/asa-go/src/slices/settingsSlice.ts
+++ b/mobile/asa-go/src/slices/settingsSlice.ts
@@ -6,7 +6,7 @@ import { getNotificationSettings } from 'api/pushNotificationsAPI'
 import { isNil, isNull } from 'lodash'
 import { DateTime } from 'luxon'
 import type { AppThunk } from '@/store'
-import { today } from '@/utils/dataSliceUtils'
+import { getToday } from '@/utils/dataSliceUtils'
 import { retryWithBackoff } from '@/utils/retryWithBackoff'
 import {
   FIRE_CENTRE_INFO_CACHE_EXPIRATION,
@@ -111,6 +111,7 @@ export const savePinnedFireCentre =
 
 export const fetchFireCentreInfo = (): AppThunk => async (dispatch, getState) => {
   // Check for cached fire centers data. If the data is not stale save it in redux state.
+  const today = getToday()
   const cachedFireCentreInfo = await readFromFilesystem(Filesystem, FIRE_CENTRE_INFO_KEY)
   const networkStatus = getState().networkStatus
   if (!isNull(cachedFireCentreInfo)) {

--- a/mobile/asa-go/src/utils/constants.ts
+++ b/mobile/asa-go/src/utils/constants.ts
@@ -15,8 +15,7 @@ export const FFMC_VALUES_DECIMAL = 1
 export const ISI_VALUES_DECIMAL = 1
 
 export const PACIFIC_IANA_TIMEZONE = 'Canada/Pacific'
-export const PST_UTC_OFFSET = -8
-export const PST_ISO_TIMEZONE = 'T00:00-08:00'
+export const ASA_GO_TIMEZONE = 'UTC-7'
 
 // Map center
 export const CENTER_OF_BC = [-125, 54.5]

--- a/mobile/asa-go/src/utils/dataSliceUtils.test.ts
+++ b/mobile/asa-go/src/utils/dataSliceUtils.test.ts
@@ -1,5 +1,4 @@
-import { DateTime } from 'luxon'
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import {
   type FireShapeStatusDetail,
   getHFIStats,
@@ -14,6 +13,9 @@ import {
   fetchProvincialSummaries,
   fetchProvincialSummary,
   fetchTpiStatsForRunParameter,
+  getToday,
+  getTodayKey,
+  getTomorrowKey,
   runParametersMatch,
   shapeDataForCaching
 } from '@/utils/dataSliceUtils'
@@ -35,14 +37,45 @@ const mockRunParameter: RunParameter = {
   for_date: '2025-11-21'
 }
 
-const today = DateTime.now()
+const today = getToday()
 const todayKey = today.toISODate()
 const tomorrowKey = today.plus({ days: 1 }).toISODate()
 
 describe('Utility Functions', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
+
+  describe('getToday', () => {
+    it('uses the fixed ASA Go UTC-7 timezone', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-23T07:30:00Z'))
+
+      const today = getToday()
+
+      expect(today.zoneName).toBe('UTC-7')
+      expect(today.toISODate()).toBe('2026-07-23')
+      expect(today.offset).toBe(-420)
+    })
+
+    it('recalculates date keys after Vancouver midnight', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-23T06:59:00Z'))
+
+      expect(getTodayKey()).toBe('2026-07-22')
+      expect(getTomorrowKey()).toBe('2026-07-23')
+
+      vi.setSystemTime(new Date('2026-07-23T07:01:00Z'))
+
+      expect(getTodayKey()).toBe('2026-07-23')
+      expect(getTomorrowKey()).toBe('2026-07-24')
+    })
+  })
+
   describe('runParametersMatch', () => {
     it('returns true when runParameters match cached data', () => {
       const runParameters = {

--- a/mobile/asa-go/src/utils/dataSliceUtils.ts
+++ b/mobile/asa-go/src/utils/dataSliceUtils.ts
@@ -9,14 +9,17 @@ import {
   getTPIStats,
   type RunParameter
 } from '@/api/fbaAPI'
-import { PST_UTC_OFFSET } from '@/utils/constants'
+import { ASA_GO_TIMEZONE } from '@/utils/constants'
 import type { CacheableData, CacheableDataType } from '@/utils/storage'
 
-export const today = DateTime.now().setZone(`UTC${PST_UTC_OFFSET}`)
+export const getToday = () => DateTime.now().setZone(ASA_GO_TIMEZONE)
+
 export const getTodayKey = () => {
+  const today = getToday()
   return today.isValid ? today.toISODate() : ''
 }
 export const getTomorrowKey = () => {
+  const today = getToday()
   return today.isValid ? today.plus({ days: 1 }).toISODate() : ''
 }
 


### PR DESCRIPTION
 - Updates ASA Go date handling to use a fixed UTC-7 app timezone for advisory date keys instead of fixed PST
- updates to call `getToday()` at runtime instead of calculating today once in `dataSliceUtils`
   - If the app stayed open across midnight, that value could remain stuck on yesterday. Then ASA Go could keep fetching, caching, comparing, or displaying data using the wrong advisory date until the app restarted
# Test Links:
[Landing Page](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5639-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
