### PR TITLE
Landing Page: API Section

### DIFF
--- a/web/apps/wps-web/src/features/landingPage/ExternalToolInfos.tsx
+++ b/web/apps/wps-web/src/features/landingPage/ExternalToolInfos.tsx
@@ -17,7 +17,7 @@ export const sfmsDailyFireWeatherIndexInfo: ToolInfo = {
   section: 'api',
   description: (
     <Typography>
-      Access the SFMS Fire Weather Index API through the API Services Portal. The available data can be viewed{' '}
+      Access the SFMS Fire Weather Index API through the API Services Portal. The available FWI data can be viewed{' '}
       <Link href="https://wfapps.nrs.gov.bc.ca/pub/wfwx-info-war/sfms" rel="noreferrer" target="_blank">
         here
       </Link>

--- a/web/apps/wps-web/src/features/landingPage/ExternalToolInfos.tsx
+++ b/web/apps/wps-web/src/features/landingPage/ExternalToolInfos.tsx
@@ -1,17 +1,39 @@
 import AreaChartOutlinedIcon from '@mui/icons-material/AreaChartOutlined'
 import CellTowerIcon from '@mui/icons-material/CellTower'
+import ThermostatOutlinedIcon from '@mui/icons-material/ThermostatOutlined'
+import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
-import { PUBLIC_TOOL_ICON_COLOUR } from '@wps/ui/theme'
-import { BCWS_PREDICTIVE_SERVICES_MANAGED_BY } from './managedBy'
+import { API_ACCESS_COLOUR, PUBLIC_TOOL_ICON_COLOUR } from '@wps/ui/theme'
+import { BCWS_PREDICTIVE_SERVICES_MANAGED_BY, CSBC_PREDICTIVE_SERVICES_MANAGED_BY } from './managedBy'
 import type { ToolInfo } from './toolInfo'
 
+export const SFMS_DAILY_FIRE_WEATHER_INDEX_ROUTE = 'https://api.gov.bc.ca/devportal/api-directory/4336'
 export const WX_DATA_VIEWER_ROUTE = 'https://huggingface.co/spaces/ssidds/WX_data_viewer'
 export const WX_WEATHER_ALERTS_ROUTE = 'https://riodeoro.github.io/wx-network-alerts/'
+
+export const sfmsDailyFireWeatherIndexInfo: ToolInfo = {
+  name: 'SFMS Fire Weather Index',
+  route: SFMS_DAILY_FIRE_WEATHER_INDEX_ROUTE,
+  section: 'api',
+  description: (
+    <Typography>
+      Access the SFMS Fire Weather Index API through the API Services Portal. The available data can be viewed{' '}
+      <Link href="https://wfapps.nrs.gov.bc.ca/pub/wfwx-info-war/sfms" rel="noreferrer" target="_blank">
+        here
+      </Link>
+      .
+    </Typography>
+  ),
+  icon: <ThermostatOutlinedIcon fontSize="large" htmlColor={API_ACCESS_COLOUR} />,
+  isBeta: false,
+  managedBy: CSBC_PREDICTIVE_SERVICES_MANAGED_BY,
+  isExternal: true
+}
 
 export const wxDataViewerInfo: ToolInfo = {
   name: 'WX Data Viewer',
   route: WX_DATA_VIEWER_ROUTE,
-  access: 'public',
+  section: 'public',
   description: (
     <Typography>
       A near real time and historical hourly visualizer of BCWS weather station data. Plots actuals and climatology,
@@ -27,7 +49,7 @@ export const wxDataViewerInfo: ToolInfo = {
 export const wxWeatherAlertsInfo: ToolInfo = {
   name: 'WX Weather Alerts',
   route: WX_WEATHER_ALERTS_ROUTE,
-  access: 'public',
+  section: 'public',
   description: (
     <Typography>A dashboard to visualize and monitor sensor performance using hourly weather observations.</Typography>
   ),
@@ -37,4 +59,4 @@ export const wxWeatherAlertsInfo: ToolInfo = {
   isExternal: true
 }
 
-export const externalToolInfos = [wxDataViewerInfo, wxWeatherAlertsInfo]
+export const externalToolInfos = [wxDataViewerInfo, wxWeatherAlertsInfo, sfmsDailyFireWeatherIndexInfo]

--- a/web/apps/wps-web/src/features/landingPage/ExternalToolInfos.tsx
+++ b/web/apps/wps-web/src/features/landingPage/ExternalToolInfos.tsx
@@ -9,7 +9,7 @@ import type { ToolInfo } from './toolInfo'
 
 export const SFMS_DAILY_FIRE_WEATHER_INDEX_ROUTE = 'https://api.gov.bc.ca/devportal/api-directory/4336'
 export const WX_DATA_VIEWER_ROUTE = 'https://huggingface.co/spaces/ssidds/WX_data_viewer'
-export const WX_WEATHER_ALERTS_ROUTE = 'https://riodeoro.github.io/wx-network-alerts/'
+export const WX_NETWORK_ALERTS_ROUTE = 'https://riodeoro.github.io/wx-network-alerts/'
 
 export const sfmsDailyFireWeatherIndexInfo: ToolInfo = {
   name: 'SFMS Fire Weather Index',
@@ -46,9 +46,9 @@ export const wxDataViewerInfo: ToolInfo = {
   isExternal: true
 }
 
-export const wxWeatherAlertsInfo: ToolInfo = {
-  name: 'WX Weather Alerts',
-  route: WX_WEATHER_ALERTS_ROUTE,
+export const wxNetworkAlertsInfo: ToolInfo = {
+  name: 'WX Network Alerts',
+  route: WX_NETWORK_ALERTS_ROUTE,
   section: 'public',
   description: (
     <Typography>A dashboard to visualize and monitor sensor performance using hourly weather observations.</Typography>
@@ -59,4 +59,4 @@ export const wxWeatherAlertsInfo: ToolInfo = {
   isExternal: true
 }
 
-export const externalToolInfos = [wxDataViewerInfo, wxWeatherAlertsInfo, sfmsDailyFireWeatherIndexInfo]
+export const externalToolInfos = [wxDataViewerInfo, wxNetworkAlertsInfo, sfmsDailyFireWeatherIndexInfo]

--- a/web/apps/wps-web/src/features/landingPage/components/QuickAccessDrawer.tsx
+++ b/web/apps/wps-web/src/features/landingPage/components/QuickAccessDrawer.tsx
@@ -12,6 +12,8 @@ import QuickAccessList from './QuickAccessList'
 import SupportSection from './SupportSection'
 
 interface QuickAccessDrawerProps {
+  apiAccessColour: string
+  apiTools: ToolInfo[]
   favouritesColour: string
   favouriteRoutes: string[]
   favouriteTools: ToolInfo[]
@@ -23,6 +25,8 @@ interface QuickAccessDrawerProps {
 }
 
 const QuickAccessDrawer = ({
+  apiAccessColour,
+  apiTools,
   favouritesColour,
   favouriteRoutes,
   favouriteTools,
@@ -89,6 +93,19 @@ const QuickAccessDrawer = ({
               onToggleFavourite={onToggleFavourite}
               title="Public Access"
               tools={publicTools}
+            />
+          </>
+        )}
+        {apiTools.length > 0 && (
+          <>
+            <Divider />
+            <QuickAccessList
+              favouriteRoutes={favouriteRoutes}
+              headingColor={apiAccessColour}
+              onNavigate={onClose}
+              onToggleFavourite={onToggleFavourite}
+              title="API Access"
+              tools={apiTools}
             />
           </>
         )}

--- a/web/apps/wps-web/src/features/landingPage/landingPageTools.ts
+++ b/web/apps/wps-web/src/features/landingPage/landingPageTools.ts
@@ -3,5 +3,6 @@ import { toolInfos } from './toolInfo'
 
 export const landingPageTools = [...toolInfos, ...externalToolInfos]
 
-export const publicTools = landingPageTools.filter(tool => tool.access === 'public')
-export const bcpsTools = landingPageTools.filter(tool => tool.access === 'bcps')
+export const apiTools = landingPageTools.filter(tool => tool.section === 'api')
+export const publicTools = landingPageTools.filter(tool => tool.section === 'public')
+export const bcpsTools = landingPageTools.filter(tool => tool.section === 'bcps')

--- a/web/apps/wps-web/src/features/landingPage/pages/LandingPage.test.tsx
+++ b/web/apps/wps-web/src/features/landingPage/pages/LandingPage.test.tsx
@@ -5,7 +5,7 @@ import { MS_TEAMS_SPRINT_REVIEW_URL } from '@wps/utils/env'
 import { fbpGoInfo, percentileCalcInfo, toolInfos, weatherToolkitInfo } from 'features/landingPage/toolInfo'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { sfmsDailyFireWeatherIndexInfo, wxDataViewerInfo, wxWeatherAlertsInfo } from '../ExternalToolInfos'
+import { sfmsDailyFireWeatherIndexInfo, wxDataViewerInfo, wxNetworkAlertsInfo } from '../ExternalToolInfos'
 import { LANDING_PAGE_FAVOURITES_STORAGE_KEY } from '../favouritesStorage'
 import { apiTools, bcpsTools, publicTools } from '../landingPageTools'
 import { BCWS_PREDICTIVE_SERVICES_MANAGED_BY } from '../managedBy'
@@ -72,7 +72,7 @@ describe('LandingPage', () => {
     expect(within(accessSection).queryByText(percentileCalcInfo.name)).not.toBeInTheDocument()
     expect(within(accessSection).queryByText(weatherToolkitInfo.name)).not.toBeInTheDocument()
     expect(within(accessSection).queryByText(wxDataViewerInfo.name)).not.toBeInTheDocument()
-    expect(within(accessSection).queryByText(wxWeatherAlertsInfo.name)).not.toBeInTheDocument()
+    expect(within(accessSection).queryByText(wxNetworkAlertsInfo.name)).not.toBeInTheDocument()
     expect(within(accessSection).queryByText(sfmsDailyFireWeatherIndexInfo.name)).not.toBeInTheDocument()
     const publicSection = screen.getByRole('region', { name: 'Public Access' })
     for (const tool of publicTools) {
@@ -134,8 +134,8 @@ describe('LandingPage', () => {
     const wxDataViewerCard = within(publicSection)
       .getByRole('heading', { name: wxDataViewerInfo.name })
       .closest('article')
-    const wxWeatherAlertsCard = within(publicSection)
-      .getByRole('heading', { name: wxWeatherAlertsInfo.name })
+    const wxNetworkAlertsCard = within(publicSection)
+      .getByRole('heading', { name: wxNetworkAlertsInfo.name })
       .closest('article')
     const apiSection = screen.getByRole('region', { name: 'API Access' })
     const sfmsDailyFireWeatherIndexCard = within(apiSection)
@@ -145,8 +145,8 @@ describe('LandingPage', () => {
     const wxDataViewerTitleLink = within(wxDataViewerCard as HTMLElement).getByRole('link', {
       name: wxDataViewerInfo.name
     })
-    const wxWeatherAlertsTitleLink = within(wxWeatherAlertsCard as HTMLElement).getByRole('link', {
-      name: wxWeatherAlertsInfo.name
+    const wxNetworkAlertsTitleLink = within(wxNetworkAlertsCard as HTMLElement).getByRole('link', {
+      name: wxNetworkAlertsInfo.name
     })
     const sfmsDailyFireWeatherIndexTitleLink = within(sfmsDailyFireWeatherIndexCard as HTMLElement).getByRole('link', {
       name: sfmsDailyFireWeatherIndexInfo.name
@@ -168,13 +168,13 @@ describe('LandingPage', () => {
     expect(wxDataViewerTitleLink).toHaveAttribute('href', wxDataViewerInfo.route)
     expect(wxDataViewerTitleLink).toHaveAttribute('target', '_blank')
     expect(wxDataViewerTitleLink).toHaveAttribute('rel', 'noreferrer')
-    expect(within(wxWeatherAlertsCard as HTMLElement).getByRole('link', { name: 'Open' })).toHaveAttribute(
+    expect(within(wxNetworkAlertsCard as HTMLElement).getByRole('link', { name: 'Open' })).toHaveAttribute(
       'target',
       '_blank'
     )
-    expect(wxWeatherAlertsTitleLink).toHaveAttribute('href', wxWeatherAlertsInfo.route)
-    expect(wxWeatherAlertsTitleLink).toHaveAttribute('target', '_blank')
-    expect(wxWeatherAlertsTitleLink).toHaveAttribute('rel', 'noreferrer')
+    expect(wxNetworkAlertsTitleLink).toHaveAttribute('href', wxNetworkAlertsInfo.route)
+    expect(wxNetworkAlertsTitleLink).toHaveAttribute('target', '_blank')
+    expect(wxNetworkAlertsTitleLink).toHaveAttribute('rel', 'noreferrer')
     expect(within(sfmsDailyFireWeatherIndexCard as HTMLElement).getByRole('link', { name: 'Open' })).toHaveAttribute(
       'target',
       '_blank'

--- a/web/apps/wps-web/src/features/landingPage/pages/LandingPage.test.tsx
+++ b/web/apps/wps-web/src/features/landingPage/pages/LandingPage.test.tsx
@@ -5,8 +5,9 @@ import { MS_TEAMS_SPRINT_REVIEW_URL } from '@wps/utils/env'
 import { fbpGoInfo, percentileCalcInfo, toolInfos, weatherToolkitInfo } from 'features/landingPage/toolInfo'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { wxDataViewerInfo, wxWeatherAlertsInfo } from '../ExternalToolInfos'
+import { sfmsDailyFireWeatherIndexInfo, wxDataViewerInfo, wxWeatherAlertsInfo } from '../ExternalToolInfos'
 import { LANDING_PAGE_FAVOURITES_STORAGE_KEY } from '../favouritesStorage'
+import { apiTools, bcpsTools, publicTools } from '../landingPageTools'
 import { BCWS_PREDICTIVE_SERVICES_MANAGED_BY } from '../managedBy'
 import LandingPage from './LandingPage'
 
@@ -60,18 +61,11 @@ describe('LandingPage', () => {
     expect(screen.getByText('Collaboard', { selector: 'a' })).toBeInTheDocument()
   })
 
-  it('shows public tools publicly and the remaining tools in the BCPS access section', () => {
+  it('shows tools in their configured sections', () => {
     renderPage()
 
     const accessSection = screen.getByRole('region', { name: 'BCPS Access Only' })
-    const publicRoutes = [
-      fbpGoInfo.route,
-      percentileCalcInfo.route,
-      weatherToolkitInfo.route,
-      wxDataViewerInfo.route,
-      wxWeatherAlertsInfo.route
-    ]
-    for (const tool of toolInfos.filter(toolInfo => !publicRoutes.includes(toolInfo.route))) {
+    for (const tool of bcpsTools) {
       expect(within(accessSection).getByRole('heading', { name: tool.name })).toBeInTheDocument()
     }
     expect(within(accessSection).queryByText(fbpGoInfo.name)).not.toBeInTheDocument()
@@ -79,20 +73,33 @@ describe('LandingPage', () => {
     expect(within(accessSection).queryByText(weatherToolkitInfo.name)).not.toBeInTheDocument()
     expect(within(accessSection).queryByText(wxDataViewerInfo.name)).not.toBeInTheDocument()
     expect(within(accessSection).queryByText(wxWeatherAlertsInfo.name)).not.toBeInTheDocument()
+    expect(within(accessSection).queryByText(sfmsDailyFireWeatherIndexInfo.name)).not.toBeInTheDocument()
     const publicSection = screen.getByRole('region', { name: 'Public Access' })
-    expect(within(publicSection).getByText(fbpGoInfo.name)).toBeInTheDocument()
-    expect(within(publicSection).getByText(percentileCalcInfo.name)).toBeInTheDocument()
-    expect(within(publicSection).getByText(weatherToolkitInfo.name)).toBeInTheDocument()
-    expect(within(publicSection).getByText(wxDataViewerInfo.name)).toBeInTheDocument()
-    expect(within(publicSection).getByText(wxWeatherAlertsInfo.name)).toBeInTheDocument()
+    for (const tool of publicTools) {
+      expect(within(publicSection).getByText(tool.name)).toBeInTheDocument()
+    }
+    expect(within(publicSection).queryByText(sfmsDailyFireWeatherIndexInfo.name)).not.toBeInTheDocument()
+    const apiSection = screen.getByRole('region', { name: 'API Access' })
+    for (const tool of apiTools) {
+      expect(within(apiSection).getByText(tool.name)).toBeInTheDocument()
+    }
+    const sfmsApiCard = within(apiSection)
+      .getByRole('heading', { name: sfmsDailyFireWeatherIndexInfo.name })
+      .closest('article')
     expect(
       screen.getByText('A dashboard to visualize and monitor sensor performance using hourly weather observations.')
     ).toBeInTheDocument()
+    expect(within(sfmsApiCard as HTMLElement).getByRole('link', { name: 'here' })).toHaveAttribute(
+      'href',
+      'https://wfapps.nrs.gov.bc.ca/pub/wfwx-info-war/sfms'
+    )
     expect(screen.getByRole('img', { name: 'Auto Spatial Advisory logo' })).toHaveAttribute(
       'src',
       '/images/asa-go-logo.png'
     )
-    expect(screen.getAllByRole('link', { name: 'CSBC - Predictive Services' })).toHaveLength(toolInfos.length)
+    expect(screen.getAllByRole('link', { name: 'CSBC - Predictive Services' })).toHaveLength(
+      toolInfos.length + apiTools.length
+    )
     const bcwsManagedByLinks = screen.getAllByRole('link', { name: BCWS_PREDICTIVE_SERVICES_MANAGED_BY.name })
     expect(bcwsManagedByLinks).toHaveLength(2)
     for (const managedByLink of bcwsManagedByLinks) {
@@ -130,12 +137,19 @@ describe('LandingPage', () => {
     const wxWeatherAlertsCard = within(publicSection)
       .getByRole('heading', { name: wxWeatherAlertsInfo.name })
       .closest('article')
+    const apiSection = screen.getByRole('region', { name: 'API Access' })
+    const sfmsDailyFireWeatherIndexCard = within(apiSection)
+      .getByRole('heading', { name: sfmsDailyFireWeatherIndexInfo.name })
+      .closest('article')
     const fbpGoTitleLink = within(fbpGoCard as HTMLElement).getByRole('link', { name: fbpGoInfo.name })
     const wxDataViewerTitleLink = within(wxDataViewerCard as HTMLElement).getByRole('link', {
       name: wxDataViewerInfo.name
     })
     const wxWeatherAlertsTitleLink = within(wxWeatherAlertsCard as HTMLElement).getByRole('link', {
       name: wxWeatherAlertsInfo.name
+    })
+    const sfmsDailyFireWeatherIndexTitleLink = within(sfmsDailyFireWeatherIndexCard as HTMLElement).getByRole('link', {
+      name: sfmsDailyFireWeatherIndexInfo.name
     })
 
     expect(within(fbpGoCard as HTMLElement).getByRole('link', { name: 'Open' })).toHaveAttribute('target', '_blank')
@@ -161,6 +175,13 @@ describe('LandingPage', () => {
     expect(wxWeatherAlertsTitleLink).toHaveAttribute('href', wxWeatherAlertsInfo.route)
     expect(wxWeatherAlertsTitleLink).toHaveAttribute('target', '_blank')
     expect(wxWeatherAlertsTitleLink).toHaveAttribute('rel', 'noreferrer')
+    expect(within(sfmsDailyFireWeatherIndexCard as HTMLElement).getByRole('link', { name: 'Open' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+    expect(sfmsDailyFireWeatherIndexTitleLink).toHaveAttribute('href', sfmsDailyFireWeatherIndexInfo.route)
+    expect(sfmsDailyFireWeatherIndexTitleLink).toHaveAttribute('target', '_blank')
+    expect(sfmsDailyFireWeatherIndexTitleLink).toHaveAttribute('rel', 'noreferrer')
   })
 
   it('uses router navigation for internal tool links', async () => {

--- a/web/apps/wps-web/src/features/landingPage/pages/LandingPage.tsx
+++ b/web/apps/wps-web/src/features/landingPage/pages/LandingPage.tsx
@@ -1,3 +1,4 @@
+import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined'
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined'
 import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined'
 import StarIcon from '@mui/icons-material/Star'
@@ -5,7 +6,7 @@ import Box from '@mui/material/Box'
 import Container from '@mui/material/Container'
 import GlobalStyles from '@mui/material/GlobalStyles'
 import Stack from '@mui/material/Stack'
-import { PUBLIC_TOOL_ICON_COLOUR } from '@wps/ui/theme'
+import { API_ACCESS_COLOUR, PUBLIC_TOOL_ICON_COLOUR } from '@wps/ui/theme'
 import { LANDING_PAGE_DOC_TITLE } from '@wps/utils/constants'
 import Footer from 'features/landingPage/components/Footer'
 import { useEffect, useState } from 'react'
@@ -13,17 +14,19 @@ import { readFavouriteRoutes, storeFavouriteRoutes } from '@/features/landingPag
 import LandingPageHeader from '../components/LandingPageHeader'
 import QuickAccessDrawer from '../components/QuickAccessDrawer'
 import ToolSection from '../components/ToolSection'
-import { bcpsTools, landingPageTools, publicTools } from '../landingPageTools'
+import { apiTools, bcpsTools, landingPageTools, publicTools } from '../landingPageTools'
 
+const API_ACCESS_SECTION_ID = 'api-access-heading'
 const BCPS_SECTION_ID = 'bcps-access-only-heading'
-const FAVOURITES_COLOUR = '#3f743f'
 const FAVOURITES_SECTION_ID = 'favourites-heading'
 const PUBLIC_SECTION_ID = 'public-access-heading'
+const FAVOURITES_COLOUR = '#3f743f'
 
 const LandingPage = () => {
   const [favouriteRoutes, setFavouriteRoutes] = useState<string[]>(readFavouriteRoutes)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const favouriteTools = landingPageTools.filter(tool => favouriteRoutes.includes(tool.route))
+  const visibleApiTools = apiTools.filter(tool => !favouriteRoutes.includes(tool.route))
   const visibleBcpsTools = bcpsTools.filter(tool => !favouriteRoutes.includes(tool.route))
   const visiblePublicTools = publicTools.filter(tool => !favouriteRoutes.includes(tool.route))
 
@@ -45,6 +48,8 @@ const LandingPage = () => {
     <Box sx={{ bgcolor: 'grey.50', display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       <GlobalStyles styles={{ html: { scrollbarGutter: 'stable' } }} />
       <QuickAccessDrawer
+        apiAccessColour={API_ACCESS_COLOUR}
+        apiTools={visibleApiTools}
         bcpsTools={visibleBcpsTools}
         favouritesColour={FAVOURITES_COLOUR}
         favouriteRoutes={favouriteRoutes}
@@ -103,6 +108,18 @@ const LandingPage = () => {
               onToggleFavourite={toggleFavourite}
               title="Public Access"
               tools={visiblePublicTools}
+            />
+          )}
+          {visibleApiTools.length > 0 && (
+            <ToolSection
+              backgroundColour="#F9F6FF"
+              borderColour="#D4C2C2"
+              headingId={API_ACCESS_SECTION_ID}
+              icon={<CloudOutlinedIcon sx={{ color: API_ACCESS_COLOUR, fontSize: 18 }} />}
+              isFavourite={route => favouriteRoutes.includes(route)}
+              onToggleFavourite={toggleFavourite}
+              title="API Access"
+              tools={visibleApiTools}
             />
           )}
         </Stack>

--- a/web/apps/wps-web/src/features/landingPage/toolInfo.tsx
+++ b/web/apps/wps-web/src/features/landingPage/toolInfo.tsx
@@ -35,12 +35,12 @@ import { CSBC_PREDICTIVE_SERVICES_MANAGED_BY, type ManagedByInfo } from './manag
 
 const ICON_FONT_SIZE = 'large'
 
-export type ToolAccess = 'bcps' | 'public'
+export type ToolSectionId = 'bcps' | 'public' | 'api'
 
 export interface ToolInfo {
   name: string
   route: string
-  access: ToolAccess
+  section: ToolSectionId
   description: React.ReactNode | string
   icon: React.ReactNode
   isBeta: boolean
@@ -51,7 +51,7 @@ export interface ToolInfo {
 export const fireBehaviourAdvisoryInfo: ToolInfo = {
   name: FIRE_BEHAVIOUR_ADVISORY_NAME,
   route: FIRE_BEHAVIOUR_ADVISORY_ROUTE,
-  access: 'bcps',
+  section: 'bcps',
   description: (
     <Typography>
       An app for BC Wildland Firefighters that automates the continuous monitoring, updating, and communication of
@@ -82,7 +82,7 @@ export const fireBehaviourAdvisoryInfo: ToolInfo = {
 export const fireBehaviourCalcInfo: ToolInfo = {
   name: FIRE_BEHAVIOUR_CALC_NAME,
   route: FIRE_BEHAVIOR_CALC_ROUTE,
-  access: 'bcps',
+  section: 'bcps',
   description: (
     <Typography>
       Supports the calculation of fire behaviour metrics given forecast or actual weather conditions and user-specified
@@ -97,7 +97,7 @@ export const fireBehaviourCalcInfo: ToolInfo = {
 export const hfiCalcInfo: ToolInfo = {
   name: HFI_CALC_NAME,
   route: HFI_CALC_ROUTE,
-  access: 'bcps',
+  section: 'bcps',
   description: (
     <Typography>
       Informs preparedness levels throughout the province based on anticipated head fire intensities and fire
@@ -112,7 +112,7 @@ export const hfiCalcInfo: ToolInfo = {
 export const moreCastInfo: ToolInfo = {
   name: MORE_CAST_NAME,
   route: MORECAST_ROUTE,
-  access: 'bcps',
+  section: 'bcps',
   description: (
     <Typography>
       Enhances how the predictive services team creates weather forecasts and integrates this information with other
@@ -127,7 +127,7 @@ export const moreCastInfo: ToolInfo = {
 export const percentileCalcInfo: ToolInfo = {
   name: PERCENTILE_CALC_NAME,
   route: PERCENTILE_CALC_ROUTE,
-  access: 'public',
+  section: 'public',
   description: (
     <Typography>
       Helps users identify fire weather indices coinciding with historically uncommon fire danger at weather stations
@@ -142,7 +142,7 @@ export const percentileCalcInfo: ToolInfo = {
 export const fbpGoInfo: ToolInfo = {
   name: FBP_GO_NAME,
   route: FBP_GO_ROUTE,
-  access: 'public',
+  section: 'public',
   description: (
     <Typography>
       Calculates fire behaviour in the field. Available for download from the&nbsp;
@@ -166,7 +166,7 @@ export const fbpGoInfo: ToolInfo = {
 export const sfmsInsightsInfo: ToolInfo = {
   name: SFMS_INSIGHTS_NAME,
   route: SFMS_INSIGHTS_ROUTE,
-  access: 'bcps',
+  section: 'bcps',
   description: (
     <Typography>
       Provides an interactive map-based interface to analyze and understand critical wildfire-related data.
@@ -180,7 +180,7 @@ export const sfmsInsightsInfo: ToolInfo = {
 export const fireWatchInfo: ToolInfo = {
   name: FIRE_WATCH_NAME,
   route: FIRE_WATCH_ROUTE,
-  access: 'bcps',
+  section: 'bcps',
   description: (
     <Typography>
       Indicates when specified fire weather and fire behaviour could occur over the next ten days.
@@ -214,7 +214,7 @@ export const fireWatchInfo: ToolInfo = {
 export const weatherToolkitInfo: ToolInfo = {
   name: WEATHER_TOOLKIT_NAME,
   route: WEATHER_TOOLKIT_ROUTE,
-  access: 'public',
+  section: 'public',
   description: <Typography>A tool for visualizing GDPS and RDPS 4-Panel Charts.</Typography>,
   icon: <BorderAllIcon fontSize={ICON_FONT_SIZE} htmlColor={PUBLIC_TOOL_ICON_COLOUR} />,
   isBeta: true,

--- a/web/packages/ui/src/theme.ts
+++ b/web/packages/ui/src/theme.ts
@@ -84,6 +84,7 @@ export const fireTableTheme = createTheme({
 })
 
 export const BACKGROUND_COLOR = { backgroundColor: '#e9ecf5' }
+export const API_ACCESS_COLOUR = '#4700D4'
 export const PUBLIC_TOOL_ICON_COLOUR = '#FF6900'
 
 export const PLANNING_AREA = {


### PR DESCRIPTION
- Closes #5478 
- Adds `API Access` section to the Landing Page
- Changes `ToolInfo` property from `access` to `section` to better indicate that the tool belongs in a specific section, not necessarily tool access
- Changes `WX Weather Alerts` to `WX Network Alerts`
# Test Links:
[Landing Page](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5640-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
