### PR TITLE
ASA Go: Date of interest

### DIFF
--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -142,11 +142,10 @@ const App = () => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — fetchSFMSRunParameters is a stable action creator
   useEffect(() => {
-    const doiISODate = dateOfInterest.toISODate()
-    if (isActive && !isNull(doiISODate)) {
+    if (isActive) {
       dispatch(fetchSFMSRunParameters())
     }
-  }, [isActive, dateOfInterest, networkStatus.connected, dispatch])
+  }, [isActive, networkStatus.connected, dispatch])
 
   useEffect(() => {
     dispatch(fetchFireCentres())

--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -75,6 +75,7 @@ const App = () => {
   const runParameter = useRunParameterForDate(dateOfInterest)
   const { initPushNotifications } = usePushNotifications()
   const deviceId = useDeviceId()
+  const dateOfInterestKey = dateOfInterest.toISODate()
 
   const selectedFireCentreName = selectedFireShape?.mof_fire_centre_name
   const matchingFireCentre = selectedFireCentreName
@@ -142,10 +143,10 @@ const App = () => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — fetchSFMSRunParameters is a stable action creator
   useEffect(() => {
-    if (isActive) {
+    if (isActive && !isNull(dateOfInterestKey)) {
       dispatch(fetchSFMSRunParameters())
     }
-  }, [isActive, networkStatus.connected, dispatch])
+  }, [isActive, dateOfInterestKey, networkStatus.connected, dispatch])
 
   useEffect(() => {
     dispatch(fetchFireCentres())

--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -105,6 +105,22 @@ const App = () => {
     dispatch(initSubscriptions(deviceId))
   }, [deviceId, networkStatus.connected, registeredFcmToken, subscriptionsInitialized, dispatch])
 
+  useEffect(() => {
+    if (!isActive) return
+
+    const today = getToday()
+    const todayKey = today.toISODate()
+    if (isNull(todayKey)) return
+
+    setDateOfInterest(currentDate => {
+      const currentDateKey = currentDate.toISODate()
+      if (isNull(currentDateKey) || currentDateKey >= todayKey) {
+        return currentDate
+      }
+      return today
+    })
+  }, [isActive])
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — listener setup runs once on mount
   useEffect(() => {
     // Network status is disconnected by default in the networkStatusSlice. Update the status

--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -26,6 +26,12 @@ import { useIsPortrait } from '@/hooks/useIsPortrait'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
 import { useRunParameterForDate } from '@/hooks/useRunParameterForDate'
 import { fetchAndCacheData } from '@/slices/dataSlice'
+import {
+  resetDateOfInterestIfStale,
+  selectDateOfInterest,
+  selectDateOfInterestKey,
+  setDateOfInterest
+} from '@/slices/dateOfInterestSlice'
 import { fetchFireCentres } from '@/slices/fireCentresSlice'
 import { startWatchingLocation, stopWatchingLocation } from '@/slices/geolocationSlice'
 import { updateNetworkStatus } from '@/slices/networkStatusSlice'
@@ -60,7 +66,6 @@ const App = () => {
   const [tab, setTab] = useState<NavPanel>(NavPanel.MAP)
   const [fireCentre, setFireCentre] = useState<FireCentre | undefined>(undefined)
   const [selectedFireShape, setSelectedFireShape] = useState<FireShape | undefined>(undefined)
-  const [dateOfInterest, setDateOfInterest] = useState<DateTime>(() => getToday())
 
   // selected redux state
   const { fireCentres } = useSelector(selectFireCentres)
@@ -70,12 +75,13 @@ const App = () => {
   const { subscriptionsInitialized } = useSelector(selectSettings)
   const provincialSummaries = useSelector(selectProvincialSummaries)
   const pendingNotificationData = useSelector(selectPendingNotificationData)
+  const dateOfInterest = useSelector(selectDateOfInterest)
+  const dateOfInterestKey = useSelector(selectDateOfInterestKey)
 
   // hooks
   const runParameter = useRunParameterForDate(dateOfInterest)
   const { initPushNotifications } = usePushNotifications()
   const deviceId = useDeviceId()
-  const dateOfInterestKey = dateOfInterest.toISODate()
 
   const selectedFireCentreName = selectedFireShape?.mof_fire_centre_name
   const matchingFireCentre = selectedFireCentreName
@@ -108,19 +114,8 @@ const App = () => {
 
   useEffect(() => {
     if (!isActive) return
-
-    const today = getToday()
-    const todayKey = today.toISODate()
-    if (isNull(todayKey)) return
-
-    setDateOfInterest(currentDate => {
-      const currentDateKey = currentDate.toISODate()
-      if (isNull(currentDateKey) || currentDateKey >= todayKey) {
-        return currentDate
-      }
-      return today
-    })
-  }, [isActive])
+    dispatch(resetDateOfInterestIfStale())
+  }, [isActive, dispatch])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — listener setup runs once on mount
   useEffect(() => {
@@ -204,7 +199,7 @@ const App = () => {
     if (!matchingCentre || !matchingShape) return
 
     // Reacting to an external system event (push notification tap); setState calls here are intentional.
-    setDateOfInterest(advisoryDate)
+    dispatch(setDateOfInterest(notificationDateKey))
     setFireCentre(matchingCentre)
     setSelectedFireShape({
       fire_shape_id: matchingShape.fire_shape_id,
@@ -270,16 +265,12 @@ const App = () => {
             selectedFireShape={selectedFireShape}
             setSelectedFireShape={setSelectedFireShape}
             setSelectedFireCentre={setFireCentre}
-            date={dateOfInterest}
-            setDate={setDateOfInterest}
             setTab={setTab}
             testId="asa-go-map"
           />
         </TabPanel>
         <TabPanel value={tab} panel={NavPanel.PROFILE}>
           <Profile
-            date={dateOfInterest}
-            setDate={setDateOfInterest}
             selectedFireCentre={selectedFireCentre}
             setSelectedFireCentre={setFireCentre}
             selectedFireZoneUnit={selectedFireShape}
@@ -288,8 +279,6 @@ const App = () => {
         </TabPanel>
         <TabPanel value={tab} panel={NavPanel.ADVISORY}>
           <Advisory
-            date={dateOfInterest}
-            setDate={setDateOfInterest}
             selectedFireCentre={selectedFireCentre}
             setSelectedFireCentre={setFireCentre}
             selectedFireZoneUnit={selectedFireShape}

--- a/mobile/asa-go/src/app.test.tsx
+++ b/mobile/asa-go/src/app.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen, waitFor } from '@testing-library/react'
 import { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from '@/api/axios'
 import { RunType } from '@/api/fbaAPI'
 import { useIsPortrait } from '@/hooks/useIsPortrait'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
@@ -198,8 +199,7 @@ describe('App', () => {
     expect(appContainer).toBeInTheDocument()
   })
 
-  it('advances the selected date when the app resumes on a new ASA Go day', async () => {
-    mockUseAppIsActive.mockReturnValue(false)
+  it('advances the selected date and refreshes run parameters when the app resumes on a new ASA Go day', async () => {
     const store = createTestStore()
 
     const { rerender } = render(
@@ -209,6 +209,17 @@ describe('App', () => {
     )
 
     expect(screen.getByTestId('info-bar')).toHaveAttribute('data-viewing-date', '2025-07-02')
+    await act(async () => {})
+    const requestsBeforeResume = vi
+      .mocked(axios.get)
+      .mock.calls.filter(([url]) => url.startsWith('fba/latest-sfms-run-parameters/')).length
+
+    mockUseAppIsActive.mockReturnValue(false)
+    rerender(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
 
     mockGetToday.mockReturnValue(DateTime.fromISO('2025-07-03'))
     mockUseAppIsActive.mockReturnValue(true)
@@ -221,6 +232,10 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.getByTestId('info-bar')).toHaveAttribute('data-viewing-date', '2025-07-03')
     })
+    const requestsAfterResume = vi
+      .mocked(axios.get)
+      .mock.calls.filter(([url]) => url.startsWith('fba/latest-sfms-run-parameters/')).length
+    expect(requestsAfterResume).toBeGreaterThan(requestsBeforeResume)
   })
 
   it('initializes with correct styling', () => {

--- a/mobile/asa-go/src/app.test.tsx
+++ b/mobile/asa-go/src/app.test.tsx
@@ -1,5 +1,6 @@
 import { useMediaQuery } from '@mui/material'
 import { act, render, screen, waitFor } from '@testing-library/react'
+import { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RunType } from '@/api/fbaAPI'
@@ -9,6 +10,9 @@ import { initialState as pushNotificationInitialState } from '@/slices/pushNotif
 import type { NavPanel } from '@/utils/constants'
 import App from './App'
 import { createTestStore } from './testUtils'
+
+const mockGetToday = vi.hoisted(() => vi.fn())
+const mockUseAppIsActive = vi.hoisted(() => vi.fn())
 
 // Mock MUI useMediaQuery to control screen size detection
 vi.mock('@mui/material', async () => {
@@ -84,8 +88,8 @@ vi.mock('@/components/SideNavigation', () => ({
 }))
 
 vi.mock('@/components/InfoBar', () => ({
-  default: ({ statusText, status }: { statusText?: string; status: string }) => (
-    <div data-testid="info-bar" data-status={status}>
+  default: ({ statusText, status, viewingDate }: { statusText?: string; status: string; viewingDate: DateTime }) => (
+    <div data-testid="info-bar" data-status={status} data-viewing-date={viewingDate.toISODate()}>
       {statusText && <span>{statusText}</span>}
     </div>
   )
@@ -93,7 +97,7 @@ vi.mock('@/components/InfoBar', () => ({
 
 // Mock hooks
 vi.mock('@/hooks/useAppIsActive', () => ({
-  useAppIsActive: () => true
+  useAppIsActive: mockUseAppIsActive
 }))
 
 vi.mock('@/hooks/useRunParameterForDate', () => ({
@@ -142,16 +146,17 @@ vi.mock('@/api/pushNotificationsAPI', () => ({
 
 vi.mock('@/utils/dataSliceUtils', async () => {
   const actual = await vi.importActual('@/utils/dataSliceUtils')
-  const { DateTime } = await vi.importActual<typeof import('luxon')>('luxon')
   return {
     ...actual,
-    getToday: () => DateTime.fromISO('2025-07-02')
+    getToday: mockGetToday
   }
 })
 
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGetToday.mockReturnValue(DateTime.fromISO('2025-07-02'))
+    mockUseAppIsActive.mockReturnValue(true)
     vi.mocked(useIsPortrait).mockReturnValue(true)
     vi.mocked(useMediaQuery).mockReturnValue(false)
     vi.mocked(usePushNotifications).mockReturnValue({
@@ -191,6 +196,31 @@ describe('App', () => {
     // Verify the app container is present
     const appContainer = document.getElementById('asa-go-app')
     expect(appContainer).toBeInTheDocument()
+  })
+
+  it('advances the selected date when the app resumes on a new ASA Go day', async () => {
+    mockUseAppIsActive.mockReturnValue(false)
+    const store = createTestStore()
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    expect(screen.getByTestId('info-bar')).toHaveAttribute('data-viewing-date', '2025-07-02')
+
+    mockGetToday.mockReturnValue(DateTime.fromISO('2025-07-03'))
+    mockUseAppIsActive.mockReturnValue(true)
+    rerender(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('info-bar')).toHaveAttribute('data-viewing-date', '2025-07-03')
+    })
   })
 
   it('initializes with correct styling', () => {

--- a/mobile/asa-go/src/app.test.tsx
+++ b/mobile/asa-go/src/app.test.tsx
@@ -1,5 +1,5 @@
 import { useMediaQuery } from '@mui/material'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -66,7 +66,18 @@ vi.mock('@/components/BottomNavigationBar', () => ({
 }))
 
 vi.mock('@/components/map/ASAGoMap', () => ({
-  default: () => <div data-testid="asa-go-map">ASA Go Map</div>
+  default: ({ setDate }: { setDate: React.Dispatch<React.SetStateAction<DateTime>> }) => (
+    <div data-testid="asa-go-map">
+      ASA Go Map
+      <button
+        type="button"
+        data-testid="change-date"
+        onClick={() => setDate(currentDate => currentDate.plus({ days: 1 }))}
+      >
+        Change date
+      </button>
+    </div>
+  )
 }))
 
 vi.mock('@/components/profile/Profile', () => ({
@@ -236,6 +247,34 @@ describe('App', () => {
       .mocked(axios.get)
       .mock.calls.filter(([url]) => url.startsWith('fba/latest-sfms-run-parameters/')).length
     expect(requestsAfterResume).toBeGreaterThan(requestsBeforeResume)
+  })
+
+  it('refreshes run parameters when the selected date changes', async () => {
+    const store = createTestStore({
+      networkStatus: {
+        networkStatus: { connected: true, connectionType: 'wifi' }
+      }
+    })
+
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+
+    await act(async () => {})
+    const requestsBeforeDateChange = vi
+      .mocked(axios.get)
+      .mock.calls.filter(([url]) => url.startsWith('fba/latest-sfms-run-parameters/')).length
+
+    fireEvent.click(screen.getByTestId('change-date'))
+
+    await waitFor(() => {
+      const requestsAfterDateChange = vi
+        .mocked(axios.get)
+        .mock.calls.filter(([url]) => url.startsWith('fba/latest-sfms-run-parameters/')).length
+      expect(requestsAfterDateChange).toBeGreaterThan(requestsBeforeDateChange)
+    })
   })
 
   it('initializes with correct styling', () => {

--- a/mobile/asa-go/src/app.test.tsx
+++ b/mobile/asa-go/src/app.test.tsx
@@ -15,6 +15,9 @@ import { createTestStore } from './testUtils'
 
 const mockGetToday = vi.hoisted(() => vi.fn())
 const mockUseAppIsActive = vi.hoisted(() => vi.fn())
+const mockFetchHFIStats = vi.hoisted(() => vi.fn())
+const mockFetchProvincialSummaries = vi.hoisted(() => vi.fn())
+const mockFetchTpiStats = vi.hoisted(() => vi.fn())
 
 // Mock MUI useMediaQuery to control screen size detection
 vi.mock('@mui/material', async () => {
@@ -55,6 +58,23 @@ vi.mock('@capacitor/filesystem', () => ({
   Encoding: { UTF8: 'utf8' }
 }))
 
+vi.mock('@/utils/pmtilesCache', () => ({
+  PMTilesCache: class {
+    loadHFIPMTiles = vi.fn()
+    getHFICachedFileName = vi.fn(() => 'hfi.pmtiles')
+  }
+}))
+
+vi.mock('@/utils/storage', async () => {
+  const actual = await vi.importActual('@/utils/storage')
+  return {
+    ...actual,
+    clearStaleHFIPMTiles: vi.fn(),
+    readFromFilesystem: vi.fn().mockResolvedValue(null),
+    writeToFileSystem: vi.fn().mockResolvedValue(undefined)
+  }
+})
+
 // Mock components
 vi.mock('@/components/AppHeader', () => ({
   AppHeader: () => <div data-testid="app-header">App Header</div>
@@ -90,8 +110,23 @@ vi.mock('@/components/SideNavigation', () => ({
 }))
 
 vi.mock('@/components/InfoBar', () => ({
-  default: ({ statusText, status, viewingDate }: { statusText?: string; status: string; viewingDate: DateTime }) => (
-    <div data-testid="info-bar" data-status={status} data-viewing-date={viewingDate.toISODate()}>
+  default: ({
+    statusText,
+    status,
+    viewingDate,
+    validUntil
+  }: {
+    statusText?: string
+    status: string
+    viewingDate: DateTime
+    validUntil?: string
+  }) => (
+    <div
+      data-testid="info-bar"
+      data-status={status}
+      data-valid-until={validUntil}
+      data-viewing-date={viewingDate.toISODate()}
+    >
       {statusText && <span>{statusText}</span>}
     </div>
   )
@@ -100,10 +135,6 @@ vi.mock('@/components/InfoBar', () => ({
 // Mock hooks
 vi.mock('@/hooks/useAppIsActive', () => ({
   useAppIsActive: mockUseAppIsActive
-}))
-
-vi.mock('@/hooks/useRunParameterForDate', () => ({
-  useRunParameterForDate: () => undefined
 }))
 
 vi.mock('@/hooks/usePushNotifications', () => ({
@@ -150,6 +181,9 @@ vi.mock('@/utils/dataSliceUtils', async () => {
   const actual = await vi.importActual('@/utils/dataSliceUtils')
   return {
     ...actual,
+    fetchHFIStats: mockFetchHFIStats,
+    fetchProvincialSummaries: mockFetchProvincialSummaries,
+    fetchTpiStats: mockFetchTpiStats,
     getToday: mockGetToday,
     getTodayKey: () => mockGetToday()?.toISODate() ?? '2025-07-02',
     getTomorrowKey: () => mockGetToday()?.plus({ days: 1 }).toISODate() ?? '2025-07-03'
@@ -167,6 +201,18 @@ describe('App', () => {
       initPushNotifications: vi.fn().mockResolvedValue(undefined),
       retryRegistration: vi.fn().mockResolvedValue(undefined)
     })
+    vi.mocked(axios.get).mockImplementation((url: string) => {
+      if (url === 'psu/fire-centres') {
+        return Promise.resolve({ data: { fire_centres: [] } })
+      }
+      if (url.startsWith('fba/latest-sfms-run-parameters/')) {
+        return Promise.resolve({ data: { run_parameters: {} } })
+      }
+      return Promise.resolve({ data: {} })
+    })
+    mockFetchHFIStats.mockResolvedValue({})
+    mockFetchProvincialSummaries.mockResolvedValue({})
+    mockFetchTpiStats.mockResolvedValue({})
   })
 
   it('renders all main components in initial state', () => {
@@ -202,8 +248,68 @@ describe('App', () => {
     expect(appContainer).toBeInTheDocument()
   })
 
-  it('advances the selected date and refreshes run parameters when the app resumes on a new ASA Go day', async () => {
-    const store = createTestStore()
+  it('selects the new day forecast and loads its data when the app resumes after midnight', async () => {
+    const july2Actual = {
+      for_date: '2025-07-02',
+      run_datetime: '2025-07-02T12:00:00-07:00',
+      run_type: RunType.ACTUAL,
+      valid_until: '2025-07-03T00:00:00-07:00'
+    }
+    const july3Forecast = {
+      for_date: '2025-07-03',
+      run_datetime: '2025-07-02T18:00:00-07:00',
+      run_type: RunType.FORECAST,
+      valid_until: '2025-07-04T00:00:00-07:00'
+    }
+    const july4Forecast = {
+      for_date: '2025-07-04',
+      run_datetime: '2025-07-03T18:00:00-07:00',
+      run_type: RunType.FORECAST,
+      valid_until: '2025-07-05T00:00:00-07:00'
+    }
+    const beforeMidnightRunParameters = {
+      '2025-07-02': july2Actual,
+      '2025-07-03': july3Forecast
+    }
+    const afterMidnightRunParameters = {
+      '2025-07-03': { ...july3Forecast },
+      '2025-07-04': july4Forecast
+    }
+
+    vi.mocked(axios.get).mockImplementation((url: string) => {
+      if (url === 'fba/latest-sfms-run-parameters/2025-07-02/2025-07-03') {
+        return Promise.resolve({ data: { run_parameters: beforeMidnightRunParameters } })
+      }
+      if (url === 'fba/latest-sfms-run-parameters/2025-07-03/2025-07-04') {
+        return Promise.resolve({ data: { run_parameters: afterMidnightRunParameters } })
+      }
+      if (url === 'psu/fire-centres') {
+        return Promise.resolve({ data: { fire_centres: [] } })
+      }
+      return Promise.resolve({ data: {} })
+    })
+    mockFetchProvincialSummaries.mockImplementation(
+      async (todayKey: string, tomorrowKey: string, runParameters: typeof afterMidnightRunParameters) => ({
+        [todayKey]: {
+          runParameter: runParameters[todayKey as keyof typeof runParameters],
+          data: [{ fire_shape_id: 1, fire_shape_name: `${todayKey} data`, fire_centre_name: 'Test', status: null }]
+        },
+        [tomorrowKey]: {
+          runParameter: runParameters[tomorrowKey as keyof typeof runParameters],
+          data: []
+        }
+      })
+    )
+
+    const store = createTestStore({
+      networkStatus: {
+        networkStatus: { connected: true, connectionType: 'wifi' }
+      },
+      runParameters: {
+        error: null,
+        runParameters: beforeMidnightRunParameters
+      }
+    })
 
     const { rerender } = render(
       <Provider store={store}>
@@ -211,11 +317,12 @@ describe('App', () => {
       </Provider>
     )
 
-    expect(screen.getByTestId('info-bar')).toHaveAttribute('data-viewing-date', '2025-07-02')
-    await act(async () => {})
-    const requestsBeforeResume = vi
-      .mocked(axios.get)
-      .mock.calls.filter(([url]) => url.startsWith('fba/latest-sfms-run-parameters/')).length
+    await waitFor(() => {
+      expect(screen.getByTestId('info-bar')).toHaveAttribute('data-viewing-date', '2025-07-02')
+      expect(screen.getByTestId('info-bar')).toHaveAttribute('data-valid-until', july2Actual.valid_until)
+    })
+    await waitFor(() => expect(mockFetchProvincialSummaries).toHaveBeenCalled())
+    const dataRequestsBeforeResume = mockFetchProvincialSummaries.mock.calls.length
 
     mockUseAppIsActive.mockReturnValue(false)
     rerender(
@@ -234,11 +341,16 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('info-bar')).toHaveAttribute('data-viewing-date', '2025-07-03')
+      expect(screen.getByTestId('info-bar')).toHaveAttribute('data-valid-until', july3Forecast.valid_until)
     })
-    const requestsAfterResume = vi
-      .mocked(axios.get)
-      .mock.calls.filter(([url]) => url.startsWith('fba/latest-sfms-run-parameters/')).length
-    expect(requestsAfterResume).toBeGreaterThan(requestsBeforeResume)
+    await waitFor(() => {
+      expect(mockFetchProvincialSummaries.mock.calls.length).toBeGreaterThan(dataRequestsBeforeResume)
+      expect(mockFetchProvincialSummaries).toHaveBeenCalledWith('2025-07-03', '2025-07-04', afterMidnightRunParameters)
+      expect(store.getState().data.provincialSummaries?.['2025-07-03']).toEqual({
+        runParameter: july3Forecast,
+        data: [{ fire_shape_id: 1, fire_shape_name: '2025-07-03 data', fire_centre_name: 'Test', status: null }]
+      })
+    })
   })
 
   it('refreshes run parameters when the selected date changes', async () => {

--- a/mobile/asa-go/src/app.test.tsx
+++ b/mobile/asa-go/src/app.test.tsx
@@ -1,5 +1,5 @@
 import { useMediaQuery } from '@mui/material'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,6 +7,7 @@ import axios from '@/api/axios'
 import { RunType } from '@/api/fbaAPI'
 import { useIsPortrait } from '@/hooks/useIsPortrait'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
+import { setDateOfInterest } from '@/slices/dateOfInterestSlice'
 import { initialState as pushNotificationInitialState } from '@/slices/pushNotificationSlice'
 import type { NavPanel } from '@/utils/constants'
 import App from './App'
@@ -66,18 +67,7 @@ vi.mock('@/components/BottomNavigationBar', () => ({
 }))
 
 vi.mock('@/components/map/ASAGoMap', () => ({
-  default: ({ setDate }: { setDate: React.Dispatch<React.SetStateAction<DateTime>> }) => (
-    <div data-testid="asa-go-map">
-      ASA Go Map
-      <button
-        type="button"
-        data-testid="change-date"
-        onClick={() => setDate(currentDate => currentDate.plus({ days: 1 }))}
-      >
-        Change date
-      </button>
-    </div>
-  )
+  default: () => <div data-testid="asa-go-map">ASA Go Map</div>
 }))
 
 vi.mock('@/components/profile/Profile', () => ({
@@ -160,7 +150,9 @@ vi.mock('@/utils/dataSliceUtils', async () => {
   const actual = await vi.importActual('@/utils/dataSliceUtils')
   return {
     ...actual,
-    getToday: mockGetToday
+    getToday: mockGetToday,
+    getTodayKey: () => mockGetToday()?.toISODate() ?? '2025-07-02',
+    getTomorrowKey: () => mockGetToday()?.plus({ days: 1 }).toISODate() ?? '2025-07-03'
   }
 })
 
@@ -267,7 +259,9 @@ describe('App', () => {
       .mocked(axios.get)
       .mock.calls.filter(([url]) => url.startsWith('fba/latest-sfms-run-parameters/')).length
 
-    fireEvent.click(screen.getByTestId('change-date'))
+    act(() => {
+      store.dispatch(setDateOfInterest('2025-07-03'))
+    })
 
     await waitFor(() => {
       const requestsAfterDateChange = vi

--- a/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
+++ b/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
@@ -38,17 +38,11 @@ const TodayTomorrowSwitch = ({ border = false, date, setDate }: TodayTomorrowSwi
 
   const today = getToday()
   const isToday = date.toISODate() === today.toISODate()
+  const isTomorrow = date.toISODate() === today.plus({ days: 1 }).toISODate()
 
   const handleDayChange = (newValue: number) => {
     // newValue: 0 = today, 1 = tomorrow
-    const shouldBeToday = newValue === 0
-
-    if (isToday !== shouldBeToday) {
-      // If we need to go to today but we're on tomorrow, subtract a day
-      // If we need to go to tomorrow but we're on today, add a day
-      const duration = shouldBeToday ? -1 : 1
-      setDate(date.plus({ day: duration }))
-    }
+    setDate(today.plus({ days: newValue }))
   }
 
   return (
@@ -72,11 +66,11 @@ const TodayTomorrowSwitch = ({ border = false, date, setDate }: TodayTomorrowSwi
           NOW
         </StyledTextContainer>
       </StyledButton>
-      <StyledButton disabled={!isToday} onClick={() => handleDayChange(1)}>
+      <StyledButton disabled={isTomorrow} onClick={() => handleDayChange(1)}>
         <StyledTextContainer
           sx={{
-            backgroundColor: isToday ? 'white' : MAP_BUTTON_GREY,
-            color: isToday ? MAP_BUTTON_GREY : 'white'
+            backgroundColor: isTomorrow ? MAP_BUTTON_GREY : 'white',
+            color: isTomorrow ? 'white' : MAP_BUTTON_GREY
           }}
         >
           TMR

--- a/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
+++ b/mobile/asa-go/src/components/TodayTomorrowSwitch.tsx
@@ -1,13 +1,13 @@
 import { Box, Button, styled } from '@mui/material'
-import type { DateTime } from 'luxon'
+import { useDispatch, useSelector } from 'react-redux'
+import { selectDateOfInterest, setDateOfInterest } from '@/slices/dateOfInterestSlice'
+import type { AppDispatch } from '@/store'
 import { MAP_BUTTON_GREY } from '@/theme'
 import { BORDER_RADIUS, BUTTON_HEIGHT } from '@/utils/constants'
 import { getToday } from '@/utils/dataSliceUtils'
 
 interface TodayTomorrowSwitchProps {
   border?: boolean
-  date: DateTime
-  setDate: React.Dispatch<React.SetStateAction<DateTime>>
 }
 
 const BUTTON_WIDTH = 60
@@ -33,7 +33,9 @@ const StyledTextContainer = styled(Box)({
   justifyContent: 'center'
 })
 
-const TodayTomorrowSwitch = ({ border = false, date, setDate }: TodayTomorrowSwitchProps) => {
+const TodayTomorrowSwitch = ({ border = false }: TodayTomorrowSwitchProps) => {
+  const dispatch: AppDispatch = useDispatch()
+  const date = useSelector(selectDateOfInterest)
   const borderStyle = border ? `1px solid ${MAP_BUTTON_GREY}` : 'none'
 
   const today = getToday()
@@ -42,7 +44,8 @@ const TodayTomorrowSwitch = ({ border = false, date, setDate }: TodayTomorrowSwi
 
   const handleDayChange = (newValue: number) => {
     // newValue: 0 = today, 1 = tomorrow
-    setDate(today.plus({ days: newValue }))
+    const dateKey = today.plus({ days: newValue }).toISODate()
+    if (dateKey) dispatch(setDateOfInterest(dateKey))
   }
 
   return (

--- a/mobile/asa-go/src/components/map/ASAGoMap.tsx
+++ b/mobile/asa-go/src/components/map/ASAGoMap.tsx
@@ -49,6 +49,7 @@ import {
   LOCAL_BASEMAP_LAYER_NAME,
   ZONE_STATUS_LAYER_NAME
 } from '@/layerDefinitions'
+import { selectDateOfInterest } from '@/slices/dateOfInterestSlice'
 import { startWatchingLocation } from '@/slices/geolocationSlice'
 import { type AppDispatch, selectGeolocation, selectNetworkStatus } from '@/store'
 import type { FireCentre } from '@/types/fireCentre'
@@ -73,8 +74,6 @@ export interface ASAGoMapProps {
   selectedFireShape: FireShape | undefined
   setSelectedFireShape: React.Dispatch<React.SetStateAction<FireShape | undefined>>
   setSelectedFireCentre: React.Dispatch<React.SetStateAction<FireCentre | undefined>>
-  date: DateTime
-  setDate: React.Dispatch<React.SetStateAction<DateTime>>
   setTab: React.Dispatch<React.SetStateAction<NavPanel>>
 }
 
@@ -83,8 +82,6 @@ const ASAGoMap = ({
   selectedFireShape,
   setSelectedFireShape,
   setSelectedFireCentre,
-  date,
-  setDate,
   setTab
 }: ASAGoMapProps) => {
   const dispatch: AppDispatch = useDispatch()
@@ -92,6 +89,7 @@ const ASAGoMap = ({
   // selectors & hooks
   const { position, error, loading } = useSelector(selectGeolocation)
   const { networkStatus } = useSelector(selectNetworkStatus)
+  const date = useSelector(selectDateOfInterest)
 
   // hooks
   const fireShapeStatusDetails = useProvincialSummaryZonesForDate(date)
@@ -515,7 +513,7 @@ const ASAGoMap = ({
             testid="location-button"
             loading={loading}
           />
-          <TodayTomorrowSwitch date={date} setDate={setDate} />
+          <TodayTomorrowSwitch />
         </Box>
 
         <LegendPopover

--- a/mobile/asa-go/src/components/map/asaGoMap.test.tsx
+++ b/mobile/asa-go/src/components/map/asaGoMap.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ASAGoMap, { type ASAGoMapProps } from '@/components/map/ASAGoMap'
@@ -52,8 +51,6 @@ describe('ASAGoMap', () => {
     selectedFireShape: undefined,
     setSelectedFireShape: vi.fn(),
     setSelectedFireCentre: vi.fn(),
-    date: DateTime.fromISO('2024-12-15'),
-    setDate: vi.fn(),
     setTab: vi.fn()
   }
 

--- a/mobile/asa-go/src/components/profile/FireZoneUnitSummary.test.tsx
+++ b/mobile/asa-go/src/components/profile/FireZoneUnitSummary.test.tsx
@@ -1,7 +1,6 @@
 import { ThemeProvider } from '@mui/material/styles'
 import { configureStore } from '@reduxjs/toolkit'
 import { render, screen } from '@testing-library/react'
-import { DateTime } from 'luxon'
 import { Provider, useSelector } from 'react-redux'
 import { describe, expect, it, vi } from 'vitest'
 import type { FireShape, FireZoneTPIStats } from '@/api/fbaAPI'
@@ -40,7 +39,6 @@ vi.mock('react-redux', async () => {
 })
 
 describe('FireZoneUnitSummary', () => {
-  const testDate = DateTime.fromISO('2025-08-25')
   const mockFireCentre: FireCentre = {
     id: 1,
     name: 'Test Fire Centre'
@@ -88,9 +86,7 @@ describe('FireZoneUnitSummary', () => {
   })
 
   it('should render empty div when selectedFireZoneUnit is undefined', () => {
-    renderWithProvider(
-      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={undefined} date={testDate} />
-    )
+    renderWithProvider(<FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={undefined} />)
 
     const emptyDiv = screen.getByTestId('fire-zone-unit-summary-empty')
     expect(emptyDiv).toBeInTheDocument()
@@ -98,11 +94,7 @@ describe('FireZoneUnitSummary', () => {
 
   it('should render fire zone unit summary when selectedFireZoneUnit is provided', () => {
     renderWithProvider(
-      <FireZoneUnitSummary
-        selectedFireCentre={mockFireCentre}
-        selectedFireZoneUnit={mockFireZoneUnit}
-        date={testDate}
-      />
+      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
     )
 
     const summary = screen.getByTestId('fire-zone-unit-summary')
@@ -111,11 +103,7 @@ describe('FireZoneUnitSummary', () => {
 
   it('should display the fire zone name as title', () => {
     renderWithProvider(
-      <FireZoneUnitSummary
-        selectedFireCentre={mockFireCentre}
-        selectedFireZoneUnit={mockFireZoneUnit}
-        date={testDate}
-      />
+      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
     )
 
     const title = screen.getByTestId('fire-zone-title-tabs')
@@ -125,11 +113,7 @@ describe('FireZoneUnitSummary', () => {
 
   it('should render FuelSummary component', () => {
     renderWithProvider(
-      <FireZoneUnitSummary
-        selectedFireCentre={mockFireCentre}
-        selectedFireZoneUnit={mockFireZoneUnit}
-        date={testDate}
-      />
+      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
     )
 
     const fuelSummary = screen.getByTestId('fuel-summary')
@@ -139,11 +123,7 @@ describe('FireZoneUnitSummary', () => {
 
   it('should show no elevation information message when TPI stats are incomplete', () => {
     renderWithProvider(
-      <FireZoneUnitSummary
-        selectedFireCentre={mockFireCentre}
-        selectedFireZoneUnit={mockFireZoneUnit}
-        date={testDate}
-      />
+      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
     )
 
     expect(screen.getByText('No elevation information available.')).toBeInTheDocument()
@@ -151,11 +131,7 @@ describe('FireZoneUnitSummary', () => {
 
   it('should have correct styling', () => {
     renderWithProvider(
-      <FireZoneUnitSummary
-        selectedFireCentre={mockFireCentre}
-        selectedFireZoneUnit={mockFireZoneUnit}
-        date={testDate}
-      />
+      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
     )
 
     const summary = screen.getByTestId('fire-zone-unit-summary')
@@ -169,11 +145,7 @@ describe('FireZoneUnitSummary', () => {
 
   it('should render Stack container with correct props', () => {
     const { container } = renderWithProvider(
-      <FireZoneUnitSummary
-        selectedFireCentre={mockFireCentre}
-        selectedFireZoneUnit={mockFireZoneUnit}
-        date={testDate}
-      />
+      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
     )
 
     const stackContainer = container.querySelector('.MuiStack-root')
@@ -181,9 +153,7 @@ describe('FireZoneUnitSummary', () => {
   })
 
   it('should handle missing fire center', () => {
-    renderWithProvider(
-      <FireZoneUnitSummary selectedFireCentre={undefined} selectedFireZoneUnit={undefined} date={testDate} />
-    )
+    renderWithProvider(<FireZoneUnitSummary selectedFireCentre={undefined} selectedFireZoneUnit={undefined} />)
 
     const defaultMessage = screen.getByTestId('default-message')
     expect(defaultMessage).toBeInTheDocument()

--- a/mobile/asa-go/src/components/profile/FireZoneUnitSummary.test.tsx
+++ b/mobile/asa-go/src/components/profile/FireZoneUnitSummary.test.tsx
@@ -1,10 +1,11 @@
 import { ThemeProvider } from '@mui/material/styles'
 import { configureStore } from '@reduxjs/toolkit'
 import { render, screen } from '@testing-library/react'
-import { Provider, useSelector } from 'react-redux'
+import { Provider } from 'react-redux'
 import { describe, expect, it, vi } from 'vitest'
 import type { FireShape, FireZoneTPIStats } from '@/api/fbaAPI'
 import FireZoneUnitSummary from '@/components/profile/FireZoneUnitSummary'
+import dateOfInterestReducer from '@/slices/dateOfInterestSlice'
 import { theme } from '@/theme'
 import type { FireCentre } from '@/types/fireCentre'
 
@@ -24,19 +25,10 @@ vi.mock('@/components/profile/ElevationStatus', () => ({
 }))
 
 // Mock hooks
-vi.mock('@/hooks/datahooks', () => ({
+vi.mock('@/hooks/dataHooks', () => ({
   useFilteredHFIStatsForDate: vi.fn(),
   useTPIStatsForDate: vi.fn()
 }))
-
-// Mock react-redux
-vi.mock('react-redux', async () => {
-  const actual = await vi.importActual('react-redux')
-  return {
-    ...actual,
-    useSelector: vi.fn()
-  }
-})
 
 describe('FireZoneUnitSummary', () => {
   const mockFireCentre: FireCentre = {
@@ -54,9 +46,8 @@ describe('FireZoneUnitSummary', () => {
   const createMockStore = () => {
     return configureStore({
       reducer: {
-        test: (state = {}) => state
-      },
-      preloadedState: {}
+        dateOfInterest: dateOfInterestReducer
+      }
     })
   }
 
@@ -71,18 +62,6 @@ describe('FireZoneUnitSummary', () => {
   beforeEach(() => {
     // Reset all mocks before each test
     vi.clearAllMocks()
-
-    // Setup default useSelector return values
-    vi.mocked(useSelector).mockImplementation(selector => {
-      const selectorStr = selector.toString()
-      if (selectorStr.includes('selectFilteredFireCentreHFIFuelStats')) {
-        return {}
-      }
-      if (selectorStr.includes('selectFireCentreTPIStats')) {
-        return { fireCentreTPIStats: null }
-      }
-      return {}
-    })
   })
 
   it('should render empty div when selectedFireZoneUnit is undefined', () => {

--- a/mobile/asa-go/src/components/profile/FireZoneUnitSummary.tsx
+++ b/mobile/asa-go/src/components/profile/FireZoneUnitSummary.tsx
@@ -2,24 +2,25 @@ import { Box, Stack, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import type { FireShape } from 'api/fbaAPI'
 import { isNil } from 'lodash'
-import type { DateTime } from 'luxon'
 import React, { useMemo } from 'react'
+import { useSelector } from 'react-redux'
 import ElevationStatus from '@/components/profile/ElevationStatus'
 import FuelSummary from '@/components/profile/FuelSummary'
 import { AdvisoryTypography } from '@/components/report/AdvisoryTypography'
 import DefaultText from '@/components/report/DefaultText'
 import { useFilteredHFIStatsForDate, useTPIStatsForDate } from '@/hooks/dataHooks'
+import { selectDateOfInterest } from '@/slices/dateOfInterestSlice'
 import type { FireCentre } from '@/types/fireCentre'
 import { hasRequiredFields } from '@/utils/profileUtils'
 
 interface FireZoneUnitSummaryProps {
-  date: DateTime
   selectedFireCentre: FireCentre | undefined
   selectedFireZoneUnit: FireShape | undefined
 }
 
-const FireZoneUnitSummary = ({ date, selectedFireCentre, selectedFireZoneUnit }: FireZoneUnitSummaryProps) => {
+const FireZoneUnitSummary = ({ selectedFireCentre, selectedFireZoneUnit }: FireZoneUnitSummaryProps) => {
   const theme = useTheme()
+  const date = useSelector(selectDateOfInterest)
 
   // hooks
   const filteredFireZoneUnitHFIStats = useFilteredHFIStatsForDate(date)

--- a/mobile/asa-go/src/components/profile/Profile.test.tsx
+++ b/mobile/asa-go/src/components/profile/Profile.test.tsx
@@ -1,6 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { render, screen } from '@testing-library/react'
-import { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
 import { describe, expect, it, vi } from 'vitest'
 import type { FireShape } from '@/api/fbaAPI'
@@ -29,7 +28,7 @@ vi.mock('@/components/report/FireZoneUnitTabs', () => ({
 }))
 
 vi.mock('@/components/TodayTomorrowSwitch', () => ({
-  default: ({ date }: { date: DateTime }) => <div data-testid="today-tomorrow-switch">{date.toISODate()}</div>
+  default: () => <div data-testid="today-tomorrow-switch">Today/Tomorrow</div>
 }))
 
 // Mock theme constants
@@ -50,8 +49,6 @@ vi.mock('@mui/material/styles', async importOriginal => {
 })
 
 describe('Profile', () => {
-  const mockDate = DateTime.fromISO('2023-06-15')
-  const mockSetDate = vi.fn()
   const mockSetSelectedFireCentre = vi.fn()
   const mockSetSelectedFireZoneUnit = vi.fn()
 
@@ -99,8 +96,6 @@ describe('Profile', () => {
   })
 
   const defaultProps: ProfileProps = {
-    date: mockDate,
-    setDate: mockSetDate,
     selectedFireCentre: undefined,
     setSelectedFireCentre: mockSetSelectedFireCentre,
     selectedFireZoneUnit: undefined,
@@ -113,12 +108,11 @@ describe('Profile', () => {
     expect(screen.getByTestId('asa-go-profile')).toBeInTheDocument()
   })
 
-  it('should render TodayTomorrowSwitch with correct date', () => {
+  it('should render TodayTomorrowSwitch', () => {
     renderWithProvider(<Profile {...defaultProps} />)
 
     const todayTomorrowSwitch = screen.getByTestId('today-tomorrow-switch')
     expect(todayTomorrowSwitch).toBeInTheDocument()
-    expect(todayTomorrowSwitch).toHaveTextContent('2023-06-15')
   })
 
   it('should render FireCenterDropdown', () => {
@@ -186,8 +180,6 @@ describe('Profile', () => {
 
   it('should pass all props correctly to child components', () => {
     const propsWithAllValues: ProfileProps = {
-      date: mockDate,
-      setDate: mockSetDate,
       selectedFireCentre: mockFireCentre,
       setSelectedFireCentre: mockSetSelectedFireCentre,
       selectedFireZoneUnit: mockFireZoneUnit,

--- a/mobile/asa-go/src/components/profile/Profile.tsx
+++ b/mobile/asa-go/src/components/profile/Profile.tsx
@@ -1,5 +1,4 @@
 import { Box, useTheme } from '@mui/material'
-import type { DateTime } from 'luxon'
 import { useSelector } from 'react-redux'
 import type { FireShape } from '@/api/fbaAPI'
 import FireCenterDropdown from '@/components/FireCenterDropdown'
@@ -10,8 +9,6 @@ import { selectFireCentres } from '@/store'
 import type { FireCentre } from '@/types/fireCentre'
 
 export interface ProfileProps {
-  date: DateTime
-  setDate: React.Dispatch<React.SetStateAction<DateTime>>
   selectedFireCentre: FireCentre | undefined
   setSelectedFireCentre: React.Dispatch<React.SetStateAction<FireCentre | undefined>>
   selectedFireZoneUnit: FireShape | undefined
@@ -19,8 +16,6 @@ export interface ProfileProps {
 }
 
 const Profile = ({
-  date,
-  setDate,
   selectedFireCentre,
   setSelectedFireCentre,
   selectedFireZoneUnit,
@@ -49,7 +44,7 @@ const Profile = ({
         }}
       >
         <Box sx={{ alignItems: 'center', display: 'flex', pr: theme.spacing(1) }}>
-          <TodayTomorrowSwitch border={true} date={date} setDate={setDate} />
+          <TodayTomorrowSwitch border={true} />
         </Box>
         <Box sx={{ display: 'flex', flexGrow: 1, pt: theme.spacing(1) }}>
           <FireCenterDropdown
@@ -75,13 +70,8 @@ const Profile = ({
           selectedFireCentre={selectedFireCentre}
           selectedFireZoneUnit={selectedFireZoneUnit}
           setSelectedFireZoneUnit={setSelectedFireZoneUnit}
-          date={date}
         >
-          <FireZoneUnitSummary
-            selectedFireCentre={selectedFireCentre}
-            selectedFireZoneUnit={selectedFireZoneUnit}
-            date={date}
-          />
+          <FireZoneUnitSummary selectedFireCentre={selectedFireCentre} selectedFireZoneUnit={selectedFireZoneUnit} />
         </FireZoneUnitTabs>
       </Box>
     </Box>

--- a/mobile/asa-go/src/components/report/Advisory.tsx
+++ b/mobile/asa-go/src/components/report/Advisory.tsx
@@ -1,5 +1,4 @@
 import { Box, useTheme } from '@mui/material'
-import type { DateTime } from 'luxon'
 import { useSelector } from 'react-redux'
 import type { FireShape } from '@/api/fbaAPI'
 import FireCenterDropdown from '@/components/FireCenterDropdown'
@@ -10,8 +9,6 @@ import { selectFireCentres } from '@/store'
 import type { FireCentre } from '@/types/fireCentre'
 
 interface AdvisoryProps {
-  date: DateTime
-  setDate: React.Dispatch<React.SetStateAction<DateTime>>
   selectedFireCentre: FireCentre | undefined
   setSelectedFireCentre: React.Dispatch<React.SetStateAction<FireCentre | undefined>>
   selectedFireZoneUnit: FireShape | undefined
@@ -19,8 +16,6 @@ interface AdvisoryProps {
 }
 
 const Advisory = ({
-  date,
-  setDate,
   selectedFireCentre,
   setSelectedFireCentre,
   selectedFireZoneUnit,
@@ -48,7 +43,7 @@ const Advisory = ({
         }}
       >
         <Box sx={{ alignItems: 'center', display: 'flex', pr: theme.spacing(1) }}>
-          <TodayTomorrowSwitch border date={date} setDate={setDate} />
+          <TodayTomorrowSwitch border />
         </Box>
         <Box sx={{ display: 'flex', flexGrow: 1, pt: theme.spacing(1) }}>
           <FireCenterDropdown
@@ -73,13 +68,8 @@ const Advisory = ({
           selectedFireCentre={selectedFireCentre}
           selectedFireZoneUnit={selectedFireZoneUnit}
           setSelectedFireZoneUnit={setSelectedFireZoneUnit}
-          date={date}
         >
-          <AdvisoryText
-            selectedFireCentre={selectedFireCentre}
-            selectedFireZoneUnit={selectedFireZoneUnit}
-            date={date}
-          />
+          <AdvisoryText selectedFireCentre={selectedFireCentre} selectedFireZoneUnit={selectedFireZoneUnit} />
         </FireZoneUnitTabs>
       </Box>
     </Box>

--- a/mobile/asa-go/src/components/report/AdvisoryText.tsx
+++ b/mobile/asa-go/src/components/report/AdvisoryText.tsx
@@ -2,11 +2,13 @@ import { Box, useTheme } from '@mui/material'
 import { isEmpty, isNil, isUndefined } from 'lodash'
 import { DateTime } from 'luxon'
 import { useMemo } from 'react'
+import { useSelector } from 'react-redux'
 import type { FireShape, FireZoneFuelStats, FireZoneHFIStats } from '@/api/fbaAPI'
 import { AdvisoryTypography } from '@/components/report/AdvisoryTypography'
 import DefaultText from '@/components/report/DefaultText'
 import { useFilteredHFIStatsForDate, useProvincialSummaryForDate } from '@/hooks/dataHooks'
 import { useRunParameterForDate } from '@/hooks/useRunParameterForDate'
+import { selectDateOfInterest } from '@/slices/dateOfInterestSlice'
 import type { FireCentre } from '@/types/fireCentre'
 import { getTopFuelsByArea, getTopFuelsByProportion, getZoneMinWindStatsText } from '@/utils/advisoryTextUtils'
 import { AdvisoryStatus } from '@/utils/constants'
@@ -20,11 +22,11 @@ import { getToday } from '@/utils/dataSliceUtils'
 export interface AdvisoryTextProps {
   selectedFireCentre: FireCentre | undefined
   selectedFireZoneUnit: FireShape | undefined
-  date: DateTime
 }
 
-const AdvisoryText = ({ selectedFireCentre, selectedFireZoneUnit, date }: AdvisoryTextProps) => {
+const AdvisoryText = ({ selectedFireCentre, selectedFireZoneUnit }: AdvisoryTextProps) => {
   const theme = useTheme()
+  const date = useSelector(selectDateOfInterest)
 
   // hooks
   const provincialSummary = useProvincialSummaryForDate(date)

--- a/mobile/asa-go/src/components/report/FireZoneUnitTabs.tsx
+++ b/mobile/asa-go/src/components/report/FireZoneUnitTabs.tsx
@@ -1,10 +1,11 @@
 import { Tab, Tabs } from '@mui/material'
 import { Box } from '@mui/system'
 import { isEmpty } from 'lodash'
-import type { DateTime } from 'luxon'
 import { useCallback, useEffect, useMemo } from 'react'
+import { useSelector } from 'react-redux'
 import type { FireShape } from '@/api/fbaAPI'
 import { useFireCentreDetails } from '@/hooks/useFireCentreDetails'
+import { selectDateOfInterest } from '@/slices/dateOfInterestSlice'
 import type { FireCentre } from '@/types/fireCentre'
 import { calculateStatusColour } from '@/utils/calculateZoneStatus'
 
@@ -13,16 +14,15 @@ export interface FireZoneUnitTabsProps {
   selectedFireZoneUnit: FireShape | undefined
   setSelectedFireZoneUnit: React.Dispatch<React.SetStateAction<FireShape | undefined>>
   children: React.ReactNode
-  date: DateTime
 }
 
 const FireZoneUnitTabs = ({
   children,
   selectedFireCentre,
   selectedFireZoneUnit,
-  setSelectedFireZoneUnit,
-  date
+  setSelectedFireZoneUnit
 }: FireZoneUnitTabsProps) => {
+  const date = useSelector(selectDateOfInterest)
   const sortedGroupedFireZoneUnits = useFireCentreDetails(selectedFireCentre, date)
 
   const tabNumber = useMemo(() => {

--- a/mobile/asa-go/src/components/report/advisory.test.tsx
+++ b/mobile/asa-go/src/components/report/advisory.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import { DateTime } from 'luxon'
 import { useSelector } from 'react-redux'
 import { vi } from 'vitest'
 import type { FireCenterDropdownProps } from '@/components/FireCenterDropdown'
@@ -10,7 +9,7 @@ import type { FireCentre } from '@/types/fireCentre'
 
 // Mock child components with proper props
 vi.mock('@/components/TodayTomorrowSwitch', () => ({
-  default: ({ date }: { date: DateTime }) => <div data-testid="today-tomorrow-switch">Date: {date.toISODate()}</div>
+  default: () => <div data-testid="today-tomorrow-switch">Today/Tomorrow</div>
 }))
 
 vi.mock('@/components/FireCenterDropdown', () => ({
@@ -42,9 +41,6 @@ describe('Advisory Component', () => {
     { name: 'Center 2', id: 2 }
   ]
 
-  const mockDate: DateTime = DateTime.fromISO('2025-07-15')
-
-  const setDate = vi.fn()
   const setSelectedFireCentre = vi.fn()
   const setSelectedFireZoneUnit = vi.fn()
 
@@ -55,8 +51,6 @@ describe('Advisory Component', () => {
   it('renders all key sections and child components', () => {
     render(
       <Advisory
-        date={mockDate}
-        setDate={setDate}
         selectedFireCentre={mockFireCentres[0]}
         setSelectedFireCentre={setSelectedFireCentre}
         selectedFireZoneUnit={undefined}
@@ -66,7 +60,7 @@ describe('Advisory Component', () => {
 
     expect(screen.getByTestId('asa-go-advisory')).toBeInTheDocument()
     expect(screen.getByTestId('advisory-control-container')).toBeInTheDocument()
-    expect(screen.getByTestId('today-tomorrow-switch')).toHaveTextContent('2025-07-15')
+    expect(screen.getByTestId('today-tomorrow-switch')).toBeInTheDocument()
     expect(screen.getByTestId('fire-center-dropdown')).toHaveTextContent('Options: 2')
     expect(screen.getByTestId('fire-zone-tabs')).toBeInTheDocument()
     expect(screen.getByTestId('advisory-text')).toHaveTextContent('Advisory Text Content')

--- a/mobile/asa-go/src/components/report/advisoryText.test.tsx
+++ b/mobile/asa-go/src/components/report/advisoryText.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/api/fbaAPI'
 import AdvisoryText from '@/components/report/AdvisoryText'
 import dataSlice, { type DataState, initialState as dataInitialState } from '@/slices/dataSlice'
+import dateOfInterestSlice from '@/slices/dateOfInterestSlice'
 import runParametersSlice, {
   type RunParametersState,
   initialState as runParametersInitialState
@@ -37,7 +38,6 @@ import { AdvisoryStatus } from '@/utils/constants'
 import { getToday } from '@/utils/dataSliceUtils'
 
 const TEST_FOR_DATE = '2025-07-14'
-const TEST_FOR_DATE_LUXON = DateTime.fromISO(TEST_FOR_DATE)
 const TEST_RUN_DATETIME = '2025-07-13'
 const EXPECTED_FOR_DATE = DateTime.fromISO(TEST_FOR_DATE).toLocaleString({
   month: 'short',
@@ -234,13 +234,15 @@ const runParametersTestStateNoForDateState = {
 const buildTestStore = (dataInitialState: DataState, runParametersInitialState: RunParametersState) => {
   const rootReducer = combineReducers({
     data: dataSlice,
-    runParameters: runParametersSlice
+    runParameters: runParametersSlice,
+    dateOfInterest: dateOfInterestSlice
   })
   const testStore = configureStore({
     reducer: rootReducer,
     preloadedState: {
       data: dataInitialState,
-      runParameters: runParametersInitialState
+      runParameters: runParametersInitialState,
+      dateOfInterest: { dateKey: TEST_FOR_DATE }
     }
   })
   return testStore
@@ -287,7 +289,7 @@ describe('AdvisoryText', () => {
   it('should render the advisory text container', () => {
     const { getByTestId } = render(
       <Provider store={testStore}>
-        <AdvisoryText selectedFireCentre={undefined} selectedFireZoneUnit={undefined} date={TEST_FOR_DATE_LUXON} />
+        <AdvisoryText selectedFireCentre={undefined} selectedFireZoneUnit={undefined} />
       </Provider>
     )
     const advisoryText = getByTestId('advisory-text')
@@ -297,7 +299,7 @@ describe('AdvisoryText', () => {
   it('should render default message when no fire centre is selected', () => {
     const { getByTestId, queryByTestId } = render(
       <Provider store={testStore}>
-        <AdvisoryText selectedFireCentre={undefined} selectedFireZoneUnit={undefined} date={TEST_FOR_DATE_LUXON} />
+        <AdvisoryText selectedFireCentre={undefined} selectedFireZoneUnit={undefined} />
       </Provider>
     )
     const message = getByTestId('default-message')
@@ -309,7 +311,7 @@ describe('AdvisoryText', () => {
   it('should render a no data message when no fire zone unit is selected', () => {
     const { getByTestId, queryByTestId } = render(
       <Provider store={testStore}>
-        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={undefined} date={TEST_FOR_DATE_LUXON} />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={undefined} />
       </Provider>
     )
     const message = getByTestId('no-data-message')
@@ -333,7 +335,7 @@ describe('AdvisoryText', () => {
     )
     const { getByTestId, queryByTestId } = render(
       <Provider store={testStore}>
-        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={undefined} date={TEST_FOR_DATE_LUXON} />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={undefined} />
       </Provider>
     )
     const message = getByTestId('no-data-message')
@@ -357,7 +359,7 @@ describe('AdvisoryText', () => {
     )
     const { getByTestId, queryByTestId } = render(
       <Provider store={testStore}>
-        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={undefined} date={TEST_FOR_DATE_LUXON} />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={undefined} />
       </Provider>
     )
     const message = getByTestId('no-data-message')
@@ -372,11 +374,7 @@ describe('AdvisoryText', () => {
     const store = getInitialStore()
     render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     screen.debug()
@@ -396,11 +394,7 @@ describe('AdvisoryText', () => {
     const store = getInitialStore()
     render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
 
@@ -415,11 +409,7 @@ describe('AdvisoryText', () => {
   it('should render forDate as mmm/dd when different than issue date', () => {
     const { queryByTestId } = render(
       <Provider store={getInitialStore()}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     const bulletinIssueDate = queryByTestId('bulletin-issue-date')
@@ -448,11 +438,7 @@ describe('AdvisoryText', () => {
     )
     const { queryByTestId } = render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     const bulletinIssueDate = queryByTestId('bulletin-issue-date')
@@ -477,11 +463,7 @@ describe('AdvisoryText', () => {
     )
     const { queryByTestId } = render(
       <Provider store={noAdvisoryStore}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     const warningMessage = queryByTestId('advisory-message-warning')
@@ -504,11 +486,7 @@ describe('AdvisoryText', () => {
     const warningStore = getInitialStore()
     const { queryByTestId } = render(
       <Provider store={warningStore}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     const advisoryMessage = queryByTestId('advisory-message-advisory')
@@ -529,11 +507,7 @@ describe('AdvisoryText', () => {
   it('should render advisory status', () => {
     const { queryByTestId } = render(
       <Provider store={testStore}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockAdvisoryFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockAdvisoryFireZoneUnit} />
       </Provider>
     )
     const advisoryMessage = queryByTestId('advisory-message-advisory')
@@ -557,11 +531,7 @@ describe('AdvisoryText', () => {
     const store = getInitialStore()
     render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     await waitFor(() => expect(screen.queryByTestId('advisory-message-wind-speed')).toBeInTheDocument())
@@ -576,11 +546,7 @@ describe('AdvisoryText', () => {
     const store = getInitialStore()
     render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     await waitFor(() => expect(screen.queryByTestId('early-advisory-text')).toBeInTheDocument())
@@ -601,11 +567,7 @@ describe('AdvisoryText', () => {
     const store = getInitialStore()
     render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     await waitFor(async () => expect(screen.queryByTestId('early-advisory-text')).not.toBeInTheDocument())
@@ -638,11 +600,7 @@ describe('AdvisoryText', () => {
     )
     const { queryByTestId } = render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockAdvisoryFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockAdvisoryFireZoneUnit} />
       </Provider>
     )
     const advisoryMessage = queryByTestId('advisory-message-advisory')
@@ -672,11 +630,7 @@ describe('AdvisoryText', () => {
     )
     const { queryByTestId } = render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockAdvisoryFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockAdvisoryFireZoneUnit} />
       </Provider>
     )
     const advisoryMessage = queryByTestId('advisory-message-advisory')
@@ -691,11 +645,7 @@ describe('AdvisoryText', () => {
     const store = getInitialStore()
     render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     await waitFor(() => expect(screen.queryByTestId('advisory-message-slash')).not.toBeInTheDocument())
@@ -709,11 +659,7 @@ describe('AdvisoryText', () => {
     const store = getInitialStore()
     render(
       <Provider store={store}>
-        <AdvisoryText
-          selectedFireCentre={mockFireCentre}
-          selectedFireZoneUnit={mockFireZoneUnit}
-          date={TEST_FOR_DATE_LUXON}
-        />
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
       </Provider>
     )
     await waitFor(() => expect(screen.queryByTestId('advisory-message-slash')).toBeInTheDocument())

--- a/mobile/asa-go/src/components/report/fireZoneUnitTabs.test.tsx
+++ b/mobile/asa-go/src/components/report/fireZoneUnitTabs.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { DateTime } from 'luxon'
+import type { DateTime } from 'luxon'
+import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FireShape, FireShapeStatusDetail } from '@/api/fbaAPI'
 import FireZoneUnitTabs from '@/components/report/FireZoneUnitTabs'
 import { useFireCentreDetails } from '@/hooks/useFireCentreDetails'
+import { createTestStore } from '@/testUtils'
 import type { FireCentre } from '@/types/fireCentre'
 import { AdvisoryStatus } from '@/utils/constants'
 
@@ -56,15 +58,17 @@ describe('FireZoneUnitTabs', () => {
   })
 
   it('renders tabs and children', () => {
+    const store = createTestStore()
     render(
-      <FireZoneUnitTabs
-        selectedFireCentre={mockFireCentre}
-        selectedFireZoneUnit={mockFireShape}
-        setSelectedFireZoneUnit={setSelectedFireZoneUnit}
-        date={DateTime.now()}
-      >
-        <div data-testid="child-content">Child Content</div>
-      </FireZoneUnitTabs>
+      <Provider store={store}>
+        <FireZoneUnitTabs
+          selectedFireCentre={mockFireCentre}
+          selectedFireZoneUnit={mockFireShape}
+          setSelectedFireZoneUnit={setSelectedFireZoneUnit}
+        >
+          <div data-testid="child-content">Child Content</div>
+        </FireZoneUnitTabs>
+      </Provider>
     )
 
     expect(screen.getByTestId('zone-1-tab')).toBeInTheDocument()
@@ -73,15 +77,17 @@ describe('FireZoneUnitTabs', () => {
   })
 
   it('calls setSelectedFireZoneUnit when a tab is clicked', () => {
+    const store = createTestStore()
     render(
-      <FireZoneUnitTabs
-        selectedFireCentre={mockFireCentre}
-        selectedFireZoneUnit={mockFireShape}
-        setSelectedFireZoneUnit={setSelectedFireZoneUnit}
-        date={DateTime.now()}
-      >
-        <div />
-      </FireZoneUnitTabs>
+      <Provider store={store}>
+        <FireZoneUnitTabs
+          selectedFireCentre={mockFireCentre}
+          selectedFireZoneUnit={mockFireShape}
+          setSelectedFireZoneUnit={setSelectedFireZoneUnit}
+        >
+          <div />
+        </FireZoneUnitTabs>
+      </Provider>
     )
 
     const tab = screen.getByTestId('zone-2-tab')

--- a/mobile/asa-go/src/components/todayTomorrowSwitch.test.tsx
+++ b/mobile/asa-go/src/components/todayTomorrowSwitch.test.tsx
@@ -48,14 +48,28 @@ describe('TodayTomorrowSwitch', () => {
 
   it('clicking NOW updates the date to today', () => {
     const mockSetDate = vi.fn()
-    const tomorrow = getToday().plus({ days: 1 })
+    const today = getToday()
+    const tomorrow = today.plus({ days: 1 })
 
     render(<TodayTomorrowSwitch date={tomorrow} setDate={mockSetDate} />)
 
     const nowButton = screen.getByText('NOW').closest('button')!
     fireEvent.click(nowButton)
 
-    expect(mockSetDate).toHaveBeenCalledWith(tomorrow.plus({ day: -1 }))
+    expect(mockSetDate.mock.calls[0][0].toISODate()).toBe(today.toISODate())
+  })
+
+  it('clicking NOW from a stale date uses today instead of subtracting another day', () => {
+    const mockSetDate = vi.fn()
+    const today = getToday()
+    const yesterday = today.minus({ days: 1 })
+
+    render(<TodayTomorrowSwitch date={yesterday} setDate={mockSetDate} />)
+
+    expect(screen.getByText('TMR').closest('button')).not.toBeDisabled()
+    fireEvent.click(screen.getByText('NOW').closest('button')!)
+
+    expect(mockSetDate.mock.calls[0][0].toISODate()).toBe(today.toISODate())
   })
 
   it('updates internal state when date prop changes', () => {

--- a/mobile/asa-go/src/components/todayTomorrowSwitch.test.tsx
+++ b/mobile/asa-go/src/components/todayTomorrowSwitch.test.tsx
@@ -1,96 +1,85 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { DateTime } from 'luxon'
+import { Provider } from 'react-redux'
+import { describe, expect, it } from 'vitest'
+import { setDateOfInterest } from '@/slices/dateOfInterestSlice'
+import { createTestStore } from '@/testUtils'
 import { getToday } from '@/utils/dataSliceUtils'
 import TodayTomorrowSwitch from './TodayTomorrowSwitch'
 
+const renderSwitch = (date: DateTime) => {
+  const dateKey = date.toISODate()!
+  const store = createTestStore({ dateOfInterest: { dateKey } })
+  render(
+    <Provider store={store}>
+      <TodayTomorrowSwitch />
+    </Provider>
+  )
+  return store
+}
+
 describe('TodayTomorrowSwitch', () => {
   it('renders both buttons', () => {
-    const mockSetDate = vi.fn()
-    const today = getToday()
-
-    render(<TodayTomorrowSwitch date={today} setDate={mockSetDate} />)
+    renderSwitch(getToday())
 
     expect(screen.getByText('NOW')).toBeInTheDocument()
     expect(screen.getByText('TMR')).toBeInTheDocument()
   })
 
   it('disables the NOW button when date is today', () => {
-    const mockSetDate = vi.fn()
-    const today = getToday()
-
-    render(<TodayTomorrowSwitch date={today} setDate={mockSetDate} />)
+    renderSwitch(getToday())
 
     expect(screen.getByText('NOW').closest('button')).toBeDisabled()
     expect(screen.getByText('TMR').closest('button')).not.toBeDisabled()
   })
 
   it('disables the TMR button when date is tomorrow', () => {
-    const mockSetDate = vi.fn()
-    const tomorrow = getToday().plus({ days: 1 })
-
-    render(<TodayTomorrowSwitch date={tomorrow} setDate={mockSetDate} />)
+    renderSwitch(getToday().plus({ days: 1 }))
 
     expect(screen.getByText('TMR').closest('button')).toBeDisabled()
     expect(screen.getByText('NOW').closest('button')).not.toBeDisabled()
   })
 
-  it('clicking TMR updates the date to tomorrow', () => {
-    const mockSetDate = vi.fn()
+  it('clicking TMR updates the selected date to tomorrow', () => {
     const today = getToday()
+    const store = renderSwitch(today)
 
-    render(<TodayTomorrowSwitch date={today} setDate={mockSetDate} />)
+    fireEvent.click(screen.getByText('TMR').closest('button')!)
 
-    const tmrButton = screen.getByText('TMR').closest('button')!
-    fireEvent.click(tmrButton)
-
-    expect(mockSetDate).toHaveBeenCalledWith(today.plus({ day: 1 }))
+    expect(store.getState().dateOfInterest.dateKey).toBe(today.plus({ days: 1 }).toISODate())
   })
 
-  it('clicking NOW updates the date to today', () => {
-    const mockSetDate = vi.fn()
+  it('clicking NOW updates the selected date to today', () => {
     const today = getToday()
-    const tomorrow = today.plus({ days: 1 })
+    const store = renderSwitch(today.plus({ days: 1 }))
 
-    render(<TodayTomorrowSwitch date={tomorrow} setDate={mockSetDate} />)
+    fireEvent.click(screen.getByText('NOW').closest('button')!)
 
-    const nowButton = screen.getByText('NOW').closest('button')!
-    fireEvent.click(nowButton)
-
-    expect(mockSetDate.mock.calls[0][0].toISODate()).toBe(today.toISODate())
+    expect(store.getState().dateOfInterest.dateKey).toBe(today.toISODate())
   })
 
-  it('clicking NOW from a stale date uses today instead of subtracting another day', () => {
-    const mockSetDate = vi.fn()
+  it('clicking NOW from a stale date selects today instead of subtracting another day', () => {
     const today = getToday()
-    const yesterday = today.minus({ days: 1 })
-
-    render(<TodayTomorrowSwitch date={yesterday} setDate={mockSetDate} />)
+    const store = renderSwitch(today.minus({ days: 1 }))
 
     expect(screen.getByText('TMR').closest('button')).not.toBeDisabled()
     fireEvent.click(screen.getByText('NOW').closest('button')!)
 
-    expect(mockSetDate.mock.calls[0][0].toISODate()).toBe(today.toISODate())
+    expect(store.getState().dateOfInterest.dateKey).toBe(today.toISODate())
   })
 
-  it('updates internal state when date prop changes', () => {
+  it('updates when the selected date changes in the store', () => {
     const today = getToday()
-    const tomorrow = today.plus({ day: 1 })
-    const setDateMock = vi.fn()
+    const store = renderSwitch(today)
 
-    const { rerender } = render(<TodayTomorrowSwitch date={today} setDate={setDateMock} />)
+    expect(screen.getByRole('button', { name: /NOW/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /TMR/i })).not.toBeDisabled()
 
-    // Initially, NOW button should be disabled (today selected)
-    const nowButton = screen.getByRole('button', { name: /NOW/i })
-    const tmrButton = screen.getByRole('button', { name: /TMR/i })
+    act(() => {
+      store.dispatch(setDateOfInterest(today.plus({ days: 1 }).toISODate()!))
+    })
 
-    expect(nowButton).toBeDisabled()
-    expect(tmrButton).not.toBeDisabled()
-
-    // Re-render with tomorrow's date
-    rerender(<TodayTomorrowSwitch date={tomorrow} setDate={setDateMock} />)
-
-    // NOW should now be enabled, TMR should be disabled
-    expect(nowButton).not.toBeDisabled()
-    expect(tmrButton).toBeDisabled()
+    expect(screen.getByRole('button', { name: /NOW/i })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /TMR/i })).toBeDisabled()
   })
 })

--- a/mobile/asa-go/src/rootReducer.ts
+++ b/mobile/asa-go/src/rootReducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit'
 import authenticateSlice from '@/slices/authenticationSlice'
 import dataSlice from '@/slices/dataSlice'
+import dateOfInterestSlice from '@/slices/dateOfInterestSlice'
 import fireCentresSlice from '@/slices/fireCentresSlice'
 import geolocationSlice from '@/slices/geolocationSlice'
 import networkStatusSlice from '@/slices/networkStatusSlice'
@@ -15,6 +16,7 @@ export const rootReducer = combineReducers({
   runParameters: runParametersSlice,
   authentication: authenticateSlice,
   data: dataSlice,
+  dateOfInterest: dateOfInterestSlice,
   settings: settingsSlice,
   pushNotification: pushNotificationSlice
 })

--- a/mobile/asa-go/src/slices/dateOfInterestSlice.test.ts
+++ b/mobile/asa-go/src/slices/dateOfInterestSlice.test.ts
@@ -1,0 +1,64 @@
+import { DateTime } from 'luxon'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import reducer, {
+  resetDateOfInterestIfStale,
+  selectDateOfInterest,
+  selectDateOfInterestKey,
+  setDateOfInterest
+} from '@/slices/dateOfInterestSlice'
+import type { RootState } from '@/store'
+import { createTestStore } from '@/testUtils'
+import { ASA_GO_TIMEZONE } from '@/utils/constants'
+
+const mockGetTodayKey = vi.hoisted(() => vi.fn())
+
+vi.mock('@/utils/dataSliceUtils', () => ({
+  getTodayKey: mockGetTodayKey
+}))
+
+describe('dateOfInterestSlice', () => {
+  beforeEach(() => {
+    mockGetTodayKey.mockReturnValue('2025-07-02')
+  })
+
+  it('initializes from the current ASA Go day at store creation', () => {
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({ dateKey: '2025-07-02' })
+
+    mockGetTodayKey.mockReturnValue('2025-07-03')
+
+    expect(reducer(undefined, { type: 'unknown' })).toEqual({ dateKey: '2025-07-03' })
+  })
+
+  it('sets the selected date key', () => {
+    expect(reducer({ dateKey: '2025-07-02' }, setDateOfInterest('2025-07-03'))).toEqual({
+      dateKey: '2025-07-03'
+    })
+  })
+
+  it('selects the raw key and a memoized DateTime in the ASA Go timezone', () => {
+    const state = { dateOfInterest: { dateKey: '2025-07-03' } } as RootState
+
+    expect(selectDateOfInterestKey(state)).toBe('2025-07-03')
+    expect(selectDateOfInterest(state).equals(DateTime.fromISO('2025-07-03', { zone: ASA_GO_TIMEZONE }))).toBe(true)
+    expect(selectDateOfInterest(state)).toBe(selectDateOfInterest(state))
+  })
+
+  it('advances a stale selected date to today', () => {
+    const store = createTestStore({ dateOfInterest: { dateKey: '2025-07-01' } })
+
+    store.dispatch(resetDateOfInterestIfStale())
+
+    expect(store.getState().dateOfInterest.dateKey).toBe('2025-07-02')
+  })
+
+  it('preserves today and future dates', () => {
+    const todayStore = createTestStore({ dateOfInterest: { dateKey: '2025-07-02' } })
+    const tomorrowStore = createTestStore({ dateOfInterest: { dateKey: '2025-07-03' } })
+
+    todayStore.dispatch(resetDateOfInterestIfStale())
+    tomorrowStore.dispatch(resetDateOfInterestIfStale())
+
+    expect(todayStore.getState().dateOfInterest.dateKey).toBe('2025-07-02')
+    expect(tomorrowStore.getState().dateOfInterest.dateKey).toBe('2025-07-03')
+  })
+})

--- a/mobile/asa-go/src/slices/dateOfInterestSlice.ts
+++ b/mobile/asa-go/src/slices/dateOfInterestSlice.ts
@@ -1,0 +1,43 @@
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { DateTime } from 'luxon'
+import type { AppThunk, RootState } from '@/store'
+import { ASA_GO_TIMEZONE } from '@/utils/constants'
+import { getTodayKey } from '@/utils/dataSliceUtils'
+
+export interface DateOfInterestState {
+  dateKey: string
+}
+
+export const getInitialState = (): DateOfInterestState => ({
+  dateKey: getTodayKey()
+})
+
+const dateOfInterestSlice = createSlice({
+  name: 'dateOfInterest',
+  initialState: getInitialState,
+  reducers: {
+    setDateOfInterest(state, action: PayloadAction<string>) {
+      state.dateKey = action.payload
+    }
+  }
+})
+
+export const { setDateOfInterest } = dateOfInterestSlice.actions
+
+export default dateOfInterestSlice.reducer
+
+export const selectDateOfInterestKey = (state: RootState) => state.dateOfInterest.dateKey
+
+export const selectDateOfInterest = createSelector([selectDateOfInterestKey], dateKey =>
+  DateTime.fromISO(dateKey, { zone: ASA_GO_TIMEZONE })
+)
+
+export const resetDateOfInterestIfStale = (): AppThunk => (dispatch, getState) => {
+  const todayKey = getTodayKey()
+  if (!todayKey) return
+
+  const dateOfInterestKey = selectDateOfInterestKey(getState())
+  if (!dateOfInterestKey || dateOfInterestKey < todayKey) {
+    dispatch(setDateOfInterest(todayKey))
+  }
+}


### PR DESCRIPTION

  Updates ASA Go so `dateOfInterest` is refreshed when the app returns to the foreground. If the selected date is older than the current ASA Go day, it advances to today.

  ## Problem

  `dateOfInterest` is initialized only once when App mounts:

  `const [dateOfInterest, setDateOfInterest] = useState<DateTime>(() => getToday())`

  If the app was opened on July 2, backgrounded overnight, and foregrounded on July 3, the selected date could remain July 2.

  Meanwhile, the runtime date helpers and run-parameter fetches correctly moved to the new day. This could leave the UI looking up July 2 in a run-parameter window containing July 3 and July 4, resulting in missing advisory data and Valid until: n/a instead of showing July 3’s forecast generated the previous evening.

The NOW/TMR switch also assumed that any date other than today was tomorrow. After midnight, a stale selection for yesterday was therefore displayed as TMR. Pressing NOW subtracted one day from the selected date instead of selecting today directly, so repeated presses moved progressively further backward.

___

  #5639 changed the shared date logic from frozen module-level values to runtime calls:

  getToday()
  getTodayKey()
  getTomorrowKey()

  That fixed fetch, cache, and date-key calculations after midnight. It did not update the selected dateOfInterest state after the app had mounted.

  ## Change

  When useAppIsActive indicates that the app has returned to the foreground, ASA Go now:

  - Recalculates the current ASA Go day.
  - Advances dateOfInterest when it is older than today.
  - Preserves selections that are already today or tomorrow.
  - Refreshes run parameters for the current today/tomorrow window.
  - Updates the NOW/TMR switch to identify today and tomorrow independently.
  - Makes NOW select the current ASA Go day directly instead of subtracting a day.
  - Makes TMR select tomorrow directly instead of adding a day to a potentially stale date.

  This keeps the selected date aligned with the available run parameters so the new day’s forecast is displayed after resuming the app.

# Test Links:
[Landing Page](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5643-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
