### PR TITLE
ASA Go: HFI PMTiles timezone

### DIFF
--- a/mobile/asa-go/src/App.tsx
+++ b/mobile/asa-go/src/App.tsx
@@ -141,15 +141,10 @@ const App = () => {
       const hfiFilesToKeep: string[] = []
       for (const value of Object.values(runParameters)) {
         const pmtilesCache = new PMTilesCache(Filesystem)
-        pmtilesCache.loadHFIPMTiles(
-          DateTime.fromISO(value.for_date),
-          value.run_type,
-          DateTime.fromISO(value.run_datetime),
-          'hfi.pmtiles'
-        )
-        hfiFilesToKeep.push(
-          pmtilesCache.getHFIFileName(value.for_date, value.run_type, value.run_datetime, 'hfi.pmtiles')
-        )
+        const forDate = DateTime.fromISO(value.for_date)
+        const runDate = DateTime.fromISO(value.run_datetime)
+        pmtilesCache.loadHFIPMTiles(forDate, value.run_type, runDate, 'hfi.pmtiles')
+        hfiFilesToKeep.push(pmtilesCache.getHFICachedFileName(forDate, value.run_type, runDate, 'hfi.pmtiles'))
       }
       clearStaleHFIPMTiles(Filesystem, hfiFilesToKeep)
     }

--- a/mobile/asa-go/src/api/pmtilesAPI.test.ts
+++ b/mobile/asa-go/src/api/pmtilesAPI.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+
+import { DateTime, Settings } from 'luxon'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RunType } from '@/api/fbaAPI'
+import { fetchHFIPMTiles } from '@/api/pmtilesAPI'
+
+vi.mock('@/utils/env', () => ({
+  PMTILES_BUCKET: 'https://pmtiles.example/'
+}))
+
+describe('pmtilesAPI', () => {
+  afterEach(() => {
+    Settings.defaultZone = 'system'
+    vi.unstubAllGlobals()
+  })
+
+  it('uses the ASA Go timezone for hfi run date paths', async () => {
+    Settings.defaultZone = 'Pacific/Auckland'
+    const blob = new Blob(['test'])
+    const fetchMock = vi.fn().mockResolvedValue({
+      blob: vi.fn().mockResolvedValue(blob)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchHFIPMTiles(DateTime.fromISO('2025-08-28'), RunType.FORECAST, DateTime.fromISO('2025-08-27T15:30:00Z'))
+
+    expect(fetchMock).toHaveBeenCalledWith('https://pmtiles.example/hfi/forecast/2025-08-27/hfi20250828.pmtiles')
+  })
+})

--- a/mobile/asa-go/src/api/pmtilesAPI.ts
+++ b/mobile/asa-go/src/api/pmtilesAPI.ts
@@ -1,6 +1,7 @@
 import type { DateTime } from 'luxon'
 import type { RunType } from '@/api/fbaAPI'
 import { PMTILES_BUCKET } from '@/utils/env'
+import { getHFIRunDateKey } from '@/utils/pmtilesUtils'
 
 /**
  *
@@ -10,7 +11,8 @@ import { PMTILES_BUCKET } from '@/utils/env'
  * @returns pmtiles blob
  */
 export const fetchHFIPMTiles = async (for_date: DateTime, run_type: RunType, run_date: DateTime): Promise<Blob> => {
-  const PMTilesURL = `${PMTILES_BUCKET}hfi/${run_type.toLowerCase()}/${run_date.toISODate()}/hfi${for_date.toISODate({
+  const runDateKey = getHFIRunDateKey(run_date)
+  const PMTilesURL = `${PMTILES_BUCKET}hfi/${run_type.toLowerCase()}/${runDateKey}/hfi${for_date.toISODate({
     format: 'basic'
   })}.pmtiles`
 

--- a/mobile/asa-go/src/utils/pmtilesCache.test.ts
+++ b/mobile/asa-go/src/utils/pmtilesCache.test.ts
@@ -26,7 +26,7 @@ import type {
   WriteFileOptions,
   WriteFileResult
 } from '@capacitor/filesystem'
-import { DateTime } from 'luxon'
+import { DateTime, Settings } from 'luxon'
 import sinon from 'sinon'
 import { RunType } from '@/api/fbaAPI'
 import { PMTilesCache } from '@/utils/pmtilesCache'
@@ -111,6 +111,7 @@ describe('pmtilesCache', () => {
   })
   afterEach(() => {
     sandbox.restore()
+    Settings.defaultZone = 'system'
   })
 
   it('should attempt to load stored static pmtiles', async () => {
@@ -164,5 +165,25 @@ describe('pmtilesCache', () => {
     )
     sinon.assert.calledThrice(stubFetch)
     sinon.assert.callOrder(stubRead, stubFetch, stubFetch, stubFetch)
+  })
+
+  it('uses the ASA Go timezone for hfi run date filenames', async () => {
+    Settings.defaultZone = 'Pacific/Auckland'
+    const mockFs = new MockFilesystem()
+
+    const stubRead = sandbox.stub(mockFs, 'readFile')
+    stubRead.resolves({ data: btoa('mocked file content') })
+    const testCache = new PMTilesCache(mockFs)
+
+    await testCache.loadHFIPMTiles(
+      DateTime.fromISO('2025-08-27'),
+      RunType.FORECAST,
+      DateTime.fromISO('2025-08-27T15:30:00Z'),
+      'hfi.pmtiles'
+    )
+
+    sinon.assert.calledWithMatch(stubRead, {
+      path: '2025-08-27_FORECAST_2025-08-27_hfi.pmtiles'
+    })
   })
 })

--- a/mobile/asa-go/src/utils/pmtilesCache.ts
+++ b/mobile/asa-go/src/utils/pmtilesCache.ts
@@ -3,6 +3,7 @@ import type { DateTime } from 'luxon'
 import { FileSource, PMTiles } from 'pmtiles'
 import type { RunType } from '@/api/fbaAPI'
 import { fetchHFIPMTiles, fetchStaticPMTiles } from '@/api/pmtilesAPI'
+import { getHFIRunDateKey } from '@/utils/pmtilesUtils'
 
 const base64ToBlob = (base64: string, contentType = 'application/octet-stream') => {
   const byteCharacters = atob(base64.split(',')[1]) // Remove Base64 prefix
@@ -148,11 +149,14 @@ export class PMTilesCache implements IPMTilesCache {
     filename: string,
     fetchAndStoreCallback?: () => Promise<PMTiles | undefined>
   ) => {
-    const cachedFilename = this.getHFIFileName(for_date.toISODate()!, run_type, run_date.toISODate()!, filename)
+    const cachedFilename = this.getHFICachedFileName(for_date, run_type, run_date, filename)
     const fetchAndStore =
       fetchAndStoreCallback ?? fetchAndStoreHFIPMTiles(for_date, run_type, run_date, cachedFilename, this.fileSystem)
     return this.loadPMTiles(cachedFilename, fetchAndStore)
   }
+
+  public readonly getHFICachedFileName = (for_date: DateTime, run_type: string, run_date: DateTime, filename: string) =>
+    this.getHFIFileName(for_date.toISODate()!, run_type, getHFIRunDateKey(run_date), filename)
 
   public readonly getHFIFileName = (for_date: string, run_type: string, run_date: string, filename: string) => {
     return `${for_date}_${run_type}_${run_date}_${filename}`

--- a/mobile/asa-go/src/utils/pmtilesUtils.ts
+++ b/mobile/asa-go/src/utils/pmtilesUtils.ts
@@ -1,0 +1,4 @@
+import type { DateTime } from 'luxon'
+import { ASA_GO_TIMEZONE } from '@/utils/constants'
+
+export const getHFIRunDateKey = (runDate: DateTime) => runDate.setZone(ASA_GO_TIMEZONE).toISODate()!


### PR DESCRIPTION
  Fixes ASA Go HFI PMTiles loading for users whose device timezone is outside BC/PDT.

  Previously, the app used the device local date from `run_datetime` when building the HFI PMTiles path and cache filename. In timezones ahead of BC, that could shift the run date to the next day and request a PMTiles file path that does not exist.

  This change centralizes HFI run date formatting and uses that normalized ASA Go timezone date for both remote PMTiles URLs and cached filenames

# Test Links:
[Landing Page](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5644-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
