### PR TITLE
ASA Go: Add date-of-interest coverage for AdvisoryText, FireZoneUnitTabs, FireZoneUnitSummary, and ASAGoMap

### DIFF
--- a/mobile/asa-go/src/components/map/asaGoMap.test.tsx
+++ b/mobile/asa-go/src/components/map/asaGoMap.test.tsx
@@ -264,16 +264,15 @@ describe('ASAGoMap', () => {
     expect(loadMapViewStateMock).toHaveBeenCalled()
   })
 
-  it('styles zones using provincial summary data for the store date of interest', async () => {
+  it('styles zones using provincial summary data for the store date of interest, and re-styles when the date changes to one with no data', async () => {
     const fireShapeStylerSpy = vi.spyOn(featureStylers, 'fireShapeStyler')
-    const runParameter = { for_date: '2025-08-01', run_datetime: '2025-08-01T00:00:00Z', run_type: RunType.FORECAST }
     const store = createTestStore({
       dateOfInterest: { dateKey: '2025-08-01' },
       data: {
         ...dataInitialState,
         provincialSummaries: {
           '2025-08-01': {
-            runParameter,
+            runParameter: { for_date: '2025-08-01', run_datetime: '2025-08-01T00:00:00Z', run_type: RunType.FORECAST },
             data: [
               {
                 fire_shape_id: 1,
@@ -296,43 +295,6 @@ describe('ASAGoMap', () => {
     await waitFor(() => {
       expect(fireShapeStylerSpy).toHaveBeenCalledWith(
         expect.arrayContaining([expect.objectContaining({ fire_shape_id: 1, status: AdvisoryStatus.WARNING })]),
-        expect.any(Boolean)
-      )
-    })
-  })
-
-  it('re-styles zones when the store date of interest changes to a date with no provincial summary data', async () => {
-    const fireShapeStylerSpy = vi.spyOn(featureStylers, 'fireShapeStyler')
-    const runParameter = { for_date: '2025-08-01', run_datetime: '2025-08-01T00:00:00Z', run_type: RunType.FORECAST }
-    const store = createTestStore({
-      dateOfInterest: { dateKey: '2025-08-01' },
-      data: {
-        ...dataInitialState,
-        provincialSummaries: {
-          '2025-08-01': {
-            runParameter,
-            data: [
-              {
-                fire_shape_id: 1,
-                fire_shape_name: 'Zone-1',
-                fire_centre_name: 'Test Fire Centre',
-                status: AdvisoryStatus.WARNING
-              }
-            ]
-          }
-        }
-      }
-    })
-
-    render(
-      <Provider store={store}>
-        <ASAGoMap {...defaultProps} />
-      </Provider>
-    )
-
-    await waitFor(() => {
-      expect(fireShapeStylerSpy).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ fire_shape_id: 1 })]),
         expect.any(Boolean)
       )
     })

--- a/mobile/asa-go/src/components/map/asaGoMap.test.tsx
+++ b/mobile/asa-go/src/components/map/asaGoMap.test.tsx
@@ -1,11 +1,16 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RunType } from '@/api/fbaAPI'
 import ASAGoMap, { type ASAGoMapProps } from '@/components/map/ASAGoMap'
 import * as mapView from '@/components/map/mapView'
+import * as featureStylers from '@/featureStylers'
+import { initialState as dataInitialState } from '@/slices/dataSlice'
+import { setDateOfInterest } from '@/slices/dateOfInterestSlice'
 import { geolocationInitialState } from '@/slices/geolocationSlice'
 import { createLayerMock, createTestStore, setupOpenLayersMocks } from '@/testUtils'
+import { AdvisoryStatus } from '@/utils/constants'
 
 vi.mock('@capacitor/filesystem', () => ({
   Filesystem: {
@@ -257,5 +262,89 @@ describe('ASAGoMap', () => {
     )
 
     expect(loadMapViewStateMock).toHaveBeenCalled()
+  })
+
+  it('styles zones using provincial summary data for the store date of interest', async () => {
+    const fireShapeStylerSpy = vi.spyOn(featureStylers, 'fireShapeStyler')
+    const runParameter = { for_date: '2025-08-01', run_datetime: '2025-08-01T00:00:00Z', run_type: RunType.FORECAST }
+    const store = createTestStore({
+      dateOfInterest: { dateKey: '2025-08-01' },
+      data: {
+        ...dataInitialState,
+        provincialSummaries: {
+          '2025-08-01': {
+            runParameter,
+            data: [
+              {
+                fire_shape_id: 1,
+                fire_shape_name: 'Zone-1',
+                fire_centre_name: 'Test Fire Centre',
+                status: AdvisoryStatus.WARNING
+              }
+            ]
+          }
+        }
+      }
+    })
+
+    render(
+      <Provider store={store}>
+        <ASAGoMap {...defaultProps} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(fireShapeStylerSpy).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ fire_shape_id: 1, status: AdvisoryStatus.WARNING })]),
+        expect.any(Boolean)
+      )
+    })
+  })
+
+  it('re-styles zones when the store date of interest changes to a date with no provincial summary data', async () => {
+    const fireShapeStylerSpy = vi.spyOn(featureStylers, 'fireShapeStyler')
+    const runParameter = { for_date: '2025-08-01', run_datetime: '2025-08-01T00:00:00Z', run_type: RunType.FORECAST }
+    const store = createTestStore({
+      dateOfInterest: { dateKey: '2025-08-01' },
+      data: {
+        ...dataInitialState,
+        provincialSummaries: {
+          '2025-08-01': {
+            runParameter,
+            data: [
+              {
+                fire_shape_id: 1,
+                fire_shape_name: 'Zone-1',
+                fire_centre_name: 'Test Fire Centre',
+                status: AdvisoryStatus.WARNING
+              }
+            ]
+          }
+        }
+      }
+    })
+
+    render(
+      <Provider store={store}>
+        <ASAGoMap {...defaultProps} />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(fireShapeStylerSpy).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ fire_shape_id: 1 })]),
+        expect.any(Boolean)
+      )
+    })
+
+    fireShapeStylerSpy.mockClear()
+
+    act(() => {
+      store.dispatch(setDateOfInterest('2025-08-02'))
+    })
+
+    await waitFor(() => {
+      expect(fireShapeStylerSpy).toHaveBeenCalledWith(undefined, expect.any(Boolean))
+    })
   })
 })

--- a/mobile/asa-go/src/components/profile/FireZoneUnitSummary.test.tsx
+++ b/mobile/asa-go/src/components/profile/FireZoneUnitSummary.test.tsx
@@ -1,11 +1,12 @@
 import { ThemeProvider } from '@mui/material/styles'
 import { configureStore } from '@reduxjs/toolkit'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { describe, expect, it, vi } from 'vitest'
 import type { FireShape, FireZoneTPIStats } from '@/api/fbaAPI'
 import FireZoneUnitSummary from '@/components/profile/FireZoneUnitSummary'
-import dateOfInterestReducer from '@/slices/dateOfInterestSlice'
+import { useFilteredHFIStatsForDate, useTPIStatsForDate } from '@/hooks/dataHooks'
+import dateOfInterestReducer, { setDateOfInterest } from '@/slices/dateOfInterestSlice'
 import { theme } from '@/theme'
 import type { FireCentre } from '@/types/fireCentre'
 
@@ -43,11 +44,12 @@ describe('FireZoneUnitSummary', () => {
     area_sqm: 1000
   }
 
-  const createMockStore = () => {
+  const createMockStore = (dateKey?: string) => {
     return configureStore({
       reducer: {
         dateOfInterest: dateOfInterestReducer
-      }
+      },
+      ...(dateKey ? { preloadedState: { dateOfInterest: { dateKey } } } : {})
     })
   }
 
@@ -137,5 +139,38 @@ describe('FireZoneUnitSummary', () => {
     const defaultMessage = screen.getByTestId('default-message')
     expect(defaultMessage).toBeInTheDocument()
     expect(defaultMessage).toHaveTextContent('Please select a fire centre.')
+  })
+
+  it('passes the date of interest from the store to the data hooks', () => {
+    const store = createMockStore('2025-08-01')
+    renderWithProvider(
+      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />,
+      store
+    )
+
+    const hfiDate = vi.mocked(useFilteredHFIStatsForDate).mock.calls.at(-1)?.[0]
+    const tpiDate = vi.mocked(useTPIStatsForDate).mock.calls.at(-1)?.[0]
+    expect(hfiDate?.toISODate()).toBe('2025-08-01')
+    expect(tpiDate?.toISODate()).toBe('2025-08-01')
+  })
+
+  it('re-derives the date passed to the data hooks when the store date changes', () => {
+    const store = createMockStore('2025-08-01')
+    renderWithProvider(
+      <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />,
+      store
+    )
+
+    vi.mocked(useFilteredHFIStatsForDate).mockClear()
+    vi.mocked(useTPIStatsForDate).mockClear()
+
+    act(() => {
+      store.dispatch(setDateOfInterest('2025-08-02'))
+    })
+
+    const hfiDate = vi.mocked(useFilteredHFIStatsForDate).mock.calls.at(-1)?.[0]
+    const tpiDate = vi.mocked(useTPIStatsForDate).mock.calls.at(-1)?.[0]
+    expect(hfiDate?.toISODate()).toBe('2025-08-02')
+    expect(tpiDate?.toISODate()).toBe('2025-08-02')
   })
 })

--- a/mobile/asa-go/src/components/profile/FireZoneUnitSummary.test.tsx
+++ b/mobile/asa-go/src/components/profile/FireZoneUnitSummary.test.tsx
@@ -1,12 +1,12 @@
 import { ThemeProvider } from '@mui/material/styles'
-import { configureStore } from '@reduxjs/toolkit'
 import { act, render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { describe, expect, it, vi } from 'vitest'
 import type { FireShape, FireZoneTPIStats } from '@/api/fbaAPI'
 import FireZoneUnitSummary from '@/components/profile/FireZoneUnitSummary'
 import { useFilteredHFIStatsForDate, useTPIStatsForDate } from '@/hooks/dataHooks'
-import dateOfInterestReducer, { setDateOfInterest } from '@/slices/dateOfInterestSlice'
+import { setDateOfInterest } from '@/slices/dateOfInterestSlice'
+import { createTestStore } from '@/testUtils'
 import { theme } from '@/theme'
 import type { FireCentre } from '@/types/fireCentre'
 
@@ -44,16 +44,7 @@ describe('FireZoneUnitSummary', () => {
     area_sqm: 1000
   }
 
-  const createMockStore = (dateKey?: string) => {
-    return configureStore({
-      reducer: {
-        dateOfInterest: dateOfInterestReducer
-      },
-      ...(dateKey ? { preloadedState: { dateOfInterest: { dateKey } } } : {})
-    })
-  }
-
-  const renderWithProvider = (component: React.ReactElement<any>, store = createMockStore()) => {
+  const renderWithProvider = (component: React.ReactElement<any>, store = createTestStore()) => {
     return render(
       <Provider store={store}>
         <ThemeProvider theme={theme}>{component}</ThemeProvider>
@@ -142,7 +133,7 @@ describe('FireZoneUnitSummary', () => {
   })
 
   it('passes the date of interest from the store to the data hooks', () => {
-    const store = createMockStore('2025-08-01')
+    const store = createTestStore({ dateOfInterest: { dateKey: '2025-08-01' } })
     renderWithProvider(
       <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />,
       store
@@ -155,7 +146,7 @@ describe('FireZoneUnitSummary', () => {
   })
 
   it('re-derives the date passed to the data hooks when the store date changes', () => {
-    const store = createMockStore('2025-08-01')
+    const store = createTestStore({ dateOfInterest: { dateKey: '2025-08-01' } })
     renderWithProvider(
       <FireZoneUnitSummary selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />,
       store

--- a/mobile/asa-go/src/components/report/advisoryText.test.tsx
+++ b/mobile/asa-go/src/components/report/advisoryText.test.tsx
@@ -678,7 +678,7 @@ describe('AdvisoryText', () => {
     await waitFor(() => expect(screen.queryByTestId('advisory-message-warning')).toBeInTheDocument())
 
     act(() => {
-      store.dispatch(setDateOfInterest(DateTime.fromISO(TEST_FOR_DATE).plus({ days: 1 }).toISODate()!))
+      store.dispatch(setDateOfInterest('2025-07-15'))
     })
 
     await waitFor(() => {

--- a/mobile/asa-go/src/components/report/advisoryText.test.tsx
+++ b/mobile/asa-go/src/components/report/advisoryText.test.tsx
@@ -675,15 +675,13 @@ describe('AdvisoryText', () => {
       </Provider>
     )
 
-    await waitFor(() => expect(screen.queryByTestId('advisory-message-warning')).toBeInTheDocument())
+    expect(await screen.findByTestId('advisory-message-warning')).toBeInTheDocument()
 
     act(() => {
       store.dispatch(setDateOfInterest('2025-07-15'))
     })
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('advisory-message-warning')).not.toBeInTheDocument()
-      expect(screen.queryByTestId('no-advisory-message')).toBeInTheDocument()
-    })
+    expect(await screen.findByTestId('no-advisory-message')).toBeInTheDocument()
+    expect(screen.queryByTestId('advisory-message-warning')).not.toBeInTheDocument()
   })
 })

--- a/mobile/asa-go/src/components/report/advisoryText.test.tsx
+++ b/mobile/asa-go/src/components/report/advisoryText.test.tsx
@@ -1,5 +1,5 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { cloneDeep } from 'lodash'
 import { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
@@ -13,7 +13,7 @@ import {
 } from '@/api/fbaAPI'
 import AdvisoryText from '@/components/report/AdvisoryText'
 import dataSlice, { type DataState, initialState as dataInitialState } from '@/slices/dataSlice'
-import dateOfInterestSlice from '@/slices/dateOfInterestSlice'
+import dateOfInterestSlice, { setDateOfInterest } from '@/slices/dateOfInterestSlice'
 import runParametersSlice, {
   type RunParametersState,
   initialState as runParametersInitialState
@@ -663,5 +663,27 @@ describe('AdvisoryText', () => {
       </Provider>
     )
     await waitFor(() => expect(screen.queryByTestId('advisory-message-slash')).toBeInTheDocument())
+  })
+
+  it('re-derives the provincial summary shown when the store date of interest changes', async () => {
+    ;(useRunParameterForDate as Mock).mockReturnValue(testRunParameter)
+    ;(useFilteredHFIStatsForDate as Mock).mockReturnValue(mockFireZoneHFIStatsDictionary)
+    const store = getInitialStore()
+    render(
+      <Provider store={store}>
+        <AdvisoryText selectedFireCentre={mockFireCentre} selectedFireZoneUnit={mockFireZoneUnit} />
+      </Provider>
+    )
+
+    await waitFor(() => expect(screen.queryByTestId('advisory-message-warning')).toBeInTheDocument())
+
+    act(() => {
+      store.dispatch(setDateOfInterest(DateTime.fromISO(TEST_FOR_DATE).plus({ days: 1 }).toISO()!))
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('advisory-message-warning')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('no-advisory-message')).toBeInTheDocument()
+    })
   })
 })

--- a/mobile/asa-go/src/components/report/advisoryText.test.tsx
+++ b/mobile/asa-go/src/components/report/advisoryText.test.tsx
@@ -678,7 +678,7 @@ describe('AdvisoryText', () => {
     await waitFor(() => expect(screen.queryByTestId('advisory-message-warning')).toBeInTheDocument())
 
     act(() => {
-      store.dispatch(setDateOfInterest(DateTime.fromISO(TEST_FOR_DATE).plus({ days: 1 }).toISO()!))
+      store.dispatch(setDateOfInterest(DateTime.fromISO(TEST_FOR_DATE).plus({ days: 1 }).toISODate()!))
     })
 
     await waitFor(() => {

--- a/mobile/asa-go/src/components/report/advisoryText.test.tsx
+++ b/mobile/asa-go/src/components/report/advisoryText.test.tsx
@@ -1,4 +1,3 @@
-import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import { cloneDeep } from 'lodash'
 import { DateTime } from 'luxon'
@@ -12,12 +11,10 @@ import {
   RunType
 } from '@/api/fbaAPI'
 import AdvisoryText from '@/components/report/AdvisoryText'
-import dataSlice, { type DataState, initialState as dataInitialState } from '@/slices/dataSlice'
-import dateOfInterestSlice, { setDateOfInterest } from '@/slices/dateOfInterestSlice'
-import runParametersSlice, {
-  type RunParametersState,
-  initialState as runParametersInitialState
-} from '@/slices/runParametersSlice'
+import { type DataState, initialState as dataInitialState } from '@/slices/dataSlice'
+import { setDateOfInterest } from '@/slices/dateOfInterestSlice'
+import { type RunParametersState, initialState as runParametersInitialState } from '@/slices/runParametersSlice'
+import { createTestStore } from '@/testUtils'
 import type { FireCentre } from '@/types/fireCentre'
 
 // Mock hooks
@@ -231,22 +228,12 @@ const runParametersTestStateNoForDateState = {
   }
 }
 
-const buildTestStore = (dataInitialState: DataState, runParametersInitialState: RunParametersState) => {
-  const rootReducer = combineReducers({
-    data: dataSlice,
-    runParameters: runParametersSlice,
-    dateOfInterest: dateOfInterestSlice
+const buildTestStore = (dataInitialState: DataState, runParametersInitialState: RunParametersState) =>
+  createTestStore({
+    data: dataInitialState,
+    runParameters: runParametersInitialState,
+    dateOfInterest: { dateKey: TEST_FOR_DATE }
   })
-  const testStore = configureStore({
-    reducer: rootReducer,
-    preloadedState: {
-      data: dataInitialState,
-      runParameters: runParametersInitialState,
-      dateOfInterest: { dateKey: TEST_FOR_DATE }
-    }
-  })
-  return testStore
-}
 
 describe('AdvisoryText', () => {
   const testStore = buildTestStore(

--- a/mobile/asa-go/src/components/report/fireZoneUnitTabs.test.tsx
+++ b/mobile/asa-go/src/components/report/fireZoneUnitTabs.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import type { DateTime } from 'luxon'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FireShape, FireShapeStatusDetail } from '@/api/fbaAPI'
 import FireZoneUnitTabs from '@/components/report/FireZoneUnitTabs'
 import { useFireCentreDetails } from '@/hooks/useFireCentreDetails'
+import { setDateOfInterest } from '@/slices/dateOfInterestSlice'
 import { createTestStore } from '@/testUtils'
 import type { FireCentre } from '@/types/fireCentre'
 import { AdvisoryStatus } from '@/utils/constants'
@@ -98,5 +99,47 @@ describe('FireZoneUnitTabs', () => {
       mof_fire_centre_name: 'Fire Center 1',
       mof_fire_zone_name: 'Zone-2'
     })
+  })
+
+  it('passes the date of interest from the store to useFireCentreDetails', () => {
+    const store = createTestStore({ dateOfInterest: { dateKey: '2025-08-01' } })
+    render(
+      <Provider store={store}>
+        <FireZoneUnitTabs
+          selectedFireCentre={mockFireCentre}
+          selectedFireZoneUnit={mockFireShape}
+          setSelectedFireZoneUnit={setSelectedFireZoneUnit}
+        >
+          <div />
+        </FireZoneUnitTabs>
+      </Provider>
+    )
+
+    const [, forDate] = mockUseFireCentreDetails.mock.calls[0]
+    expect(forDate?.toISODate()).toBe('2025-08-01')
+  })
+
+  it('re-derives the date passed to useFireCentreDetails when the store date changes', () => {
+    const store = createTestStore({ dateOfInterest: { dateKey: '2025-08-01' } })
+    render(
+      <Provider store={store}>
+        <FireZoneUnitTabs
+          selectedFireCentre={mockFireCentre}
+          selectedFireZoneUnit={mockFireShape}
+          setSelectedFireZoneUnit={setSelectedFireZoneUnit}
+        >
+          <div />
+        </FireZoneUnitTabs>
+      </Provider>
+    )
+
+    mockUseFireCentreDetails.mockClear()
+
+    act(() => {
+      store.dispatch(setDateOfInterest('2025-08-02'))
+    })
+
+    const lastCall = mockUseFireCentreDetails.mock.calls.at(-1)
+    expect(lastCall?.[1]?.toISODate()).toBe('2025-08-02')
   })
 })


### PR DESCRIPTION
Several components read `dateOfInterest` via `selectDateOfInterest` but their tests either mocked away everything downstream of it or only ever exercised a single fixed date, so a regression in the selector (e.g. a timezone bug) wouldn't have been caught by any of them.

Added tests to `advisoryText.test.tsx`, `fireZoneUnitTabs.test.tsx`, `FireZoneUnitSummary.test.tsx`, and `asaGoMap.test.tsx` that seed a specific `dateOfInterest.dateKey`, dispatch `setDateOfInterest` to a different date, and assert the downstream hooks/rendered output actually change.
# Test Links:
[Landing Page](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5652-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
