### PR TITLE
ASA Go: PMTiles fix

### DIFF
--- a/mobile/asa-go/src/components/map/ASAGoMap.tsx
+++ b/mobile/asa-go/src/components/map/ASAGoMap.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/featureStylers'
 import { fireZoneExtentsMap } from '@/fireZoneUnitExtents'
 import { useProvincialSummaryZonesForDate } from '@/hooks/dataHooks'
+import { useAppIsActive } from '@/hooks/useAppIsActive'
 import { useRunParameterForDate } from '@/hooks/useRunParameterForDate'
 import {
   BASEMAP_LAYER_NAME,
@@ -89,6 +90,7 @@ const ASAGoMap = ({
   // selectors & hooks
   const { position, error, loading } = useSelector(selectGeolocation)
   const { networkStatus } = useSelector(selectNetworkStatus)
+  const isActive = useAppIsActive()
   const date = useSelector(selectDateOfInterest)
 
   // hooks
@@ -122,6 +124,8 @@ const ASAGoMap = ({
   )
 
   const toggleLayersRef = useRef<Record<string, VectorTileLayer | null>>({})
+  // only reload after a real background-to-foreground transition, not the initial render
+  const wasInactiveRef = useRef(false)
 
   const mapRef = useRef<HTMLDivElement | null>(null) as React.MutableRefObject<HTMLElement>
   const scaleRef = useRef<HTMLDivElement | null>(null) as React.MutableRefObject<HTMLElement>
@@ -193,6 +197,31 @@ const ASAGoMap = ({
   useEffect(() => {
     saveLayerVisibility(layerVisibility)
   }, [layerVisibility])
+
+  useEffect(() => {
+    if (!isActive) {
+      wasInactiveRef.current = true
+      return
+    }
+    if (!wasInactiveRef.current || !map) {
+      return
+    }
+    wasInactiveRef.current = false
+
+    const sources = new Set<PMTilesFileVectorSource>()
+    map
+      .getLayers()
+      .getArray()
+      .forEach(layer => {
+        const source = layer instanceof VectorTileLayer ? layer.getSource() : null
+        if (source instanceof PMTilesFileVectorSource) {
+          sources.add(source)
+        }
+      })
+    sources.forEach(source => {
+      source.reloadTiles()
+    })
+  }, [isActive, map])
 
   // center map when position is updated after requesting location
   useEffect(() => {

--- a/mobile/asa-go/src/utils/pmtilesVectorSource.test.ts
+++ b/mobile/asa-go/src/utils/pmtilesVectorSource.test.ts
@@ -162,4 +162,18 @@ describe('pmTilesVectorSource', () => {
     assert(tileGrid.getMinZoom() === testPMTilesHeader.minZoom)
     assert(instance.getState() === 'ready')
   })
+
+  it('changes the tile URL without reopening the PMTiles file', async () => {
+    const testCache: IPMTilesCache = buildPMTilesTestCache(new TestPMTiles())
+    const pmTilesCacheSpy = sandbox.spy(testCache)
+    const instance = await PMTilesFileVectorSource.createStaticLayer(testCache, {
+      filename: 'test.pmtiles'
+    })
+
+    instance.reloadTiles()
+    instance.reloadTiles()
+
+    assert(instance.getUrls()?.[0] === 'pmtiles://{z}/{x}/{y}?reload=2')
+    sinon.assert.calledOnce(pmTilesCacheSpy.loadPMTiles)
+  })
 })

--- a/mobile/asa-go/src/utils/pmtilesVectorSource.ts
+++ b/mobile/asa-go/src/utils/pmtilesVectorSource.ts
@@ -6,6 +6,7 @@ import type RenderFeature from 'ol/render/Feature'
 import VectorTileSource, { type Options as VectorTileSourceOptions } from 'ol/source/VectorTile'
 import TileState from 'ol/TileState'
 import { createXYZ } from 'ol/tilegrid'
+import type VectorTile from 'ol/VectorTile'
 import type { PMTiles } from 'pmtiles'
 import type { RunType } from '@/api/fbaAPI'
 import type { IPMTilesCache } from '@/utils/pmtilesCache'
@@ -24,12 +25,11 @@ export type HFIPMTilesFileVectorOptions = VectorTileSourceOptions &
 const PMTILES_TILE_URL = 'pmtiles://{z}/{x}/{y}'
 
 export class PMTilesFileVectorSource extends VectorTileSource {
-  // @ts-expect-error
-  private pmtiles_: PMTiles
+  private pmtiles_!: PMTiles
   private tileGeneration = 0
 
   tileLoadFunction = (tile: Tile, url: string) => {
-    const vtile = tile as unknown as VectorTileSource
+    const vectorTile = tile as VectorTile<RenderFeature>
     const re = new RegExp(/pmtiles:\/\/(\d+)\/(\d+)\/(\d+)/)
     const result = url.match(re)
 
@@ -49,28 +49,20 @@ export class PMTilesFileVectorSource extends VectorTileSource {
         if (tile_result) {
           const format = new MVT({ layerName: 'mvt:layer' }) // Create the MVT format
           const features = format.readFeatures(tile_result.data, {
-            // @ts-expect-error
-            extent: vtile.extent,
-            // @ts-expect-error
-            featureProjection: vtile.projection
+            extent: vectorTile.extent,
+            featureProjection: vectorTile.projection
           })
-          // @ts-expect-error
-          vtile.setFeatures(features) // Set the features on the tile (which can now handle vector data)
-          // @ts-expect-error
-          vtile.setState(TileState.LOADED) // Mark the tile as loaded
+          vectorTile.setFeatures(features) // Set the features on the tile (which can now handle vector data)
+          vectorTile.setState(TileState.LOADED) // Mark the tile as loaded
         } else {
-          // @ts-expect-error
-          vtile.setFeatures([])
-          // @ts-expect-error
-          vtile.setState(TileState.EMPTY) // Mark the tile as empty if no data is found
+          vectorTile.setFeatures([])
+          vectorTile.setState(TileState.EMPTY) // Mark the tile as empty if no data is found
         }
       })
       .catch(err => {
         console.log(err)
-        // @ts-expect-error
-        vtile.setFeatures([])
-        // @ts-expect-error
-        vtile.setState(TileState.ERROR) // Mark the tile as error if the loading fails
+        vectorTile.setFeatures([])
+        vectorTile.setState(TileState.ERROR) // Mark the tile as error if the loading fails
       })
   }
 

--- a/mobile/asa-go/src/utils/pmtilesVectorSource.ts
+++ b/mobile/asa-go/src/utils/pmtilesVectorSource.ts
@@ -21,9 +21,12 @@ export type HFIPMTilesFileVectorOptions = VectorTileSourceOptions &
     run_date: DateTime
   }
 
+const PMTILES_TILE_URL = 'pmtiles://{z}/{x}/{y}'
+
 export class PMTilesFileVectorSource extends VectorTileSource {
   // @ts-expect-error
   private pmtiles_: PMTiles
+  private tileGeneration = 0
 
   tileLoadFunction = (tile: Tile, url: string) => {
     const vtile = tile as unknown as VectorTileSource
@@ -75,9 +78,15 @@ export class PMTilesFileVectorSource extends VectorTileSource {
     super({
       ...options,
       state: 'loading',
-      url: 'pmtiles://{z}/{x}/{y}', // only used for parsing out the z, x, y parameters when tile loading
+      url: PMTILES_TILE_URL,
       format: options.format || new MVT({ layerName: 'mvt:layer' })
     })
+  }
+
+  reloadTiles() {
+    // changing the URL gives OpenLayers new tile identities without reopening the PMTiles file
+    this.tileGeneration += 1
+    this.setUrl(`${PMTILES_TILE_URL}?reload=${this.tileGeneration}`)
   }
 
   // Static async factory method

--- a/mobile/asa-go/src/utils/pmtilesVectorSource.ts
+++ b/mobile/asa-go/src/utils/pmtilesVectorSource.ts
@@ -11,20 +11,19 @@ import type { PMTiles } from 'pmtiles'
 import type { RunType } from '@/api/fbaAPI'
 import type { IPMTilesCache } from '@/utils/pmtilesCache'
 
-export type PMTilesFileVectorOptions = VectorTileSourceOptions & {
+export type PMTilesFileVectorOptions = VectorTileSourceOptions<RenderFeature> & {
   filename: string
 }
 
-export type HFIPMTilesFileVectorOptions = VectorTileSourceOptions &
-  PMTilesFileVectorOptions & {
-    for_date: DateTime
-    run_type: RunType
-    run_date: DateTime
-  }
+export type HFIPMTilesFileVectorOptions = PMTilesFileVectorOptions & {
+  for_date: DateTime
+  run_type: RunType
+  run_date: DateTime
+}
 
 const PMTILES_TILE_URL = 'pmtiles://{z}/{x}/{y}'
 
-export class PMTilesFileVectorSource extends VectorTileSource {
+export class PMTilesFileVectorSource extends VectorTileSource<RenderFeature> {
   private pmtiles_!: PMTiles
   private tileGeneration = 0
 


### PR DESCRIPTION
Addresses an issue where PMTiles occasionally fail to load after ASA Go returns from the background.

  The exact cause has not been confirmed. The issue happens occasionally after ASA Go returns to the foreground, often around application data updates.

  ASA Go’s map runs through several layers:

  - Capacitor app lifecycle
  - iOS or Android WebView
  - OpenLayers tile state
  - Custom PMTiles tile loader
  - Local PMTiles file

  These layers maintain separate lifecycle and cache state. The local PMTiles file may remain healthy while OpenLayers continues using a tile object that is no longer loading or rendering correctly. A PMTiles request overlapping WebView suspension is one possible cause, but I'm not certain about that

  Native map renderers integrate their rendering surface directly with the platform lifecycle, reducing the number of independent lifecycle and caching layers. They can pause and restore the rendering surface while keeping offline map storage separate. ASA Go instead runs OpenLayers and its tile loader inside the Capacitor WebView.

  After a background to foreground transition, ASA Go increments the synthetic URL for each PMTiles source attached to the map. The URL does not identify different PMTiles data or trigger a network request. It acts as an OpenLayers cache key.

  Changing the URL tells OpenLayers: "The file is unchanged, but stop trusting the old tile objects"

  OpenLayers can then create new tile objects and request the visible tiles again using the existing PMTiles file.

This PR also resolves some typing issues in ASA Go/PMTiles

closes #5636

# Test Links:
[Landing Page](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5671-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
