### PR TITLE
Docs: Fix broken links and commands that no longer work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Issues](https://img.shields.io/github/issues/bcgov/wps.svg?style=for-the-badge)](/../../issues)
-[![MIT License](https://img.shields.io/github/license/bcgov/wps.svg?style=for-the-badge)](/LICENSE)
+[![Apache 2.0 License](https://img.shields.io/github/license/bcgov/wps.svg?style=for-the-badge)](/LICENSE)
 [![Lifecycle](https://img.shields.io/badge/Lifecycle-Stable-97ca00?style=for-the-badge)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 [![codecov](https://codecov.io/gh/bcgov/wps/branch/main/graph/badge.svg?token=QZh80UTLpT)](https://codecov.io/gh/bcgov/wps)
 
@@ -60,7 +60,7 @@ Refer to [web/README.md](web/README.md)
 
 ## License
 
-[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) License - see the [LICENSE.md](https://github.com/bcgov/wps/blob/main/LICENSE)
+[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) License - see the [LICENSE](https://github.com/bcgov/wps/blob/main/LICENSE)
 
 ## Contributing
 
@@ -71,8 +71,8 @@ Your Github PR is required to pass all our CI checks, including our test coverag
 ### Resources
 
 - [Issues](https://github.com/bcgov/wps/issues)
-- [PEP8](https://github.com/python/peps/blob/master/pep-0008.txt) and [PEP20](https://github.com/python/peps/blob/master/pep-0020.txt) coding conventions, but with 110 character line breaks
-- [Code of Conduct](https://github.com/bcgov/wps/blob/master/CONDUCT.md)
+- [PEP8](https://peps.python.org/pep-0008/) and [PEP20](https://peps.python.org/pep-0020/) coding conventions, but with 110 character line breaks
+- [Code of Conduct](https://github.com/bcgov/wps/blob/main/CONDUCT.md)
 
 ## Acknowledgments
 

--- a/backend/packages/wps-api/src/app/jobs/model_data.md
+++ b/backend/packages/wps-api/src/app/jobs/model_data.md
@@ -202,7 +202,7 @@ TODO - We need to amend our back-end code to only pull the necessary value from 
 
 ~~For example, a small portion of the grid for a temperature raster band of a GRIB file might look like the image below. In this example, each point on the grid is spaced 5km apart. You can see that a fire weather station is located within one cell of this grid, where the 4 corners of the cell have temperature values of 3.1&deg;, 2.4&deg;, 2.7&deg;, and 2.7&deg;C. In order to approximate the predicted temperature at the weather station's exact location, we perform linear interpolation of the 4 temperature values listed above, where the weight of each data point is inversely proportional to the distance from the weather station to that point on the grid. Consequently, the 2.4&deg;C from the top right corner of the cell will have the highest weight as it is closest to the weather station, and the 2.7&deg;C from the bottom left corner will have the lowest weight as it is the furthest away.~~
 
-~~![Location-based linear interpolation for a weather station](../../../docs/images/Grid_wx_station.png)~~
+~~![Location-based linear interpolation for a weather station](../../../../../../docs/images/Grid_wx_station.png)~~
 
 ~~This linear interpolation process is repeated for each of the weather variables in a model run, and for each of the weather stations in BC. These calculations are stored in the `weather_station_model_predictions` table.~~
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,19 +1,21 @@
 ## Coding conventions
 
 Code must be [PEP8](https://www.python.org/dev/peps/pep-0008/) compliant with the exception of allowing for line lengths up to 110 characters.
-Compliance is enforced using [ruff](https://beta.ruff.rs/docs/)
+Compliance is enforced using [ruff](https://docs.astral.sh/ruff/), configured in [ruff.toml](../ruff.toml).
 
 Run ruff to check that your code conforms before pushing code to the repository:
 
 ```bash
-make lint
+cd backend
+uv run ruff check packages/wps-api/src packages/wps-shared/src packages/wps-jobs/src
 ```
 
-Or enforce by running [scripts/lint.sh](scripts/lint.sh) as part of your ci/cd pipeline.
+This is the same check that runs in CI — see the `lint-api` job in
+[.github/workflows/integration.yml](../.github/workflows/integration.yml).
 
 ### Branch naming conventions
 
-Branches must be named in accordance with the rules specified in [.githooks/pre-push](.githooks/pre-push).
+Branches must be named in accordance with the rules specified in [.githooks/pre-push](../.githooks/pre-push).
 
 - branch names should be informative, meaningful and concise.
 - branch names should follow the pattern (category)/(description)/(ticket number)

--- a/docs/NATS.md
+++ b/docs/NATS.md
@@ -34,7 +34,7 @@ Look for:
 
 Or anything else that should be changed in the config
 
-### 4. Delete the durable consumer so the app can recreate it
+### 2. Delete the durable consumer so the app can recreate it
 
 Scale the NATS consumer pods down to 0.
 
@@ -44,11 +44,11 @@ Inside the toolbox shell:
 nats --server nats://consumer:consumer@wps-prod-nats:4222 consumer rm wps-prodsfms hfi_classify
 ```
 
-### 5. Scale the consumer deployment back up
+### 3. Scale the consumer deployment back up
 
 Scale the pods back up with UI or CLI.
 
-### 6. Verify the recreated consumer config
+### 4. Verify the recreated consumer config
 
 ```bash
 nats --server nats://consumer:consumer@wps-prod-nats:4222 consumer info wps-prodsfms hfi_classify
@@ -98,8 +98,8 @@ lima nerdctl run -p 4222:4222 -ti nats:latest -js
 ##### 3. Open up a new terminal and run the api:
 
 ```bash
-cd {path_to_repo}/wps/api
-make run
+cd {path_to_repo}/wps/backend/packages/wps-api
+uv run --package wps-api python -m app.main
 ```
 
 ##### 4. Run the nats consumer from VS Code, click the debug button on the sidebar, choose the 'nats' option from the drop-down and click the play button.

--- a/docs/database/CLUSTER_DB.MD
+++ b/docs/database/CLUSTER_DB.MD
@@ -28,7 +28,7 @@ Source: <https://access.crunchydata.com/documentation/postgres-operator/latest/a
     - **Differential Backup**: taken daily at 1am, except on Sundays
     - **Manual Backup**: are enabled through the `manual` configured property
 
-      - **Trigger a manual backup**, by annotating the primary cluster with: `kubectl annotate -n <namespace-license-plate> postgrescluster <postgres-cluster> --overwritepostgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F\_%H:%M:%S' )"`
+      - **Trigger a manual backup**, by annotating the primary cluster with: `kubectl annotate -n <namespace-license-plate> postgrescluster <postgres-cluster> --overwrite postgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F\_%H:%M:%S' )"`
 
     - To see the status of a backup look in the condition block of the result of`oc describe postgrescluster <postgres-cluster>`, e.g.:
 

--- a/mobile/asa-go/README.md
+++ b/mobile/asa-go/README.md
@@ -44,7 +44,7 @@ yarn build
    - Set `$ANDROID_HOME` to the path of the Android SDK
 3. Go to `mobile/asa-go`
 4. Run `APP_ENV=dev yarn cap:sync:android:dev` or `APP_ENV=prod yarn cap:sync:android:prod`
-5. If you are building from Android Studio, open the [`android`](/Users/breedwar/projects/other/wps/mobile/asa-go/android) project and choose the matching build variant in the `Build Variants` tool window:
+5. If you are building from Android Studio, open the [`android`](android) project and choose the matching build variant in the `Build Variants` tool window:
    - `devDebug` or `devRelease` after a dev sync
    - `prodDebug` or `prodRelease` after a prod sync
 6. Build and run with live reload: `APP_ENV=dev ionic capacitor run android -l --external` or `APP_ENV=prod ionic capacitor run android -l --external`

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -14,7 +14,7 @@ Needed if you want to test the nats service from the cli
 
 See: https://github.com/nats-io/natscli
 
-#####Homebrew install:
+##### Homebrew install:
 
 ```bash
 brew tap nats-io/nats-tools

--- a/sfms/README.md
+++ b/sfms/README.md
@@ -31,7 +31,7 @@ e.g.:
 ```config.ini
 secret=secret
 source=/home/user/sfms
-destination=https://psu.nrs.gov.bc.ca/api/sfms/upload
+url=https://psu.nrs.gov.bc.ca/api/sfms/upload
 ```
 
 ## Developer notes


### PR DESCRIPTION
While reading through the documentation to get oriented in the project, I ran into a number of links and commands that no longer work. This PR fixes the ones I could verify.

Everything below was checked against the repository or the referenced source rather than assumed. Happy to split this up, trim it, or close it if any of it is unwelcome or already in progress.

## Broken links

| Fix | How it was verified |
| --- | --- |
| README linked `LICENSE.md` | No such file; the file is `LICENSE` |
| README linked `CONDUCT.md` at `/blob/master/` | `git ls-remote --heads origin master` returns nothing, so there is no `master` branch and this 404s |
| README PEP8 and PEP20 links | `python/peps/blob/master/pep-0008.txt` and `pep-0020.txt` both return HTTP 404. `python/peps` moved off `master` and away from `.txt`. Replaced with the canonical `peps.python.org` URLs |
| `CONVENTIONS.md` linked `scripts/lint.sh` | No such file anywhere in the repo |
| `CONVENTIONS.md` linked `.githooks/pre-push` | Relative from `docs/`, this resolves to `docs/.githooks/pre-push`. The file is at the repo root |
| `model_data.md` image | `../../../docs/images/Grid_wx_station.png` needs six `../` from `backend/packages/wps-api/src/app/jobs/`. Looks like it was missed when the backend moved to `packages/` |
| `asa-go/README.md` android link | Pointed at `/Users/breedwar/projects/other/wps/mobile/asa-go/android`, a local absolute path |

After this change, every relative Markdown link in the repository resolves. Before it, the four repo-relative ones above did not.

## Commands that do not work as written

**`CONVENTIONS.md`** documents `make lint`, but the Makefile has no `lint` target. Replaced with the ruff invocation the `lint-api` job in `integration.yml` actually runs, and pointed at that workflow so the two stay visibly linked.

**`NATS.md`** says to run the API with `cd {path_to_repo}/wps/api` and `make run`. There is no `api` directory and no `run` target. Updated to the command documented in `backend/packages/wps-api/README.md`.

**`CLUSTER_DB.MD`** manual backup example reads `--overwritepostgres-operator.crunchydata.com/...`. The missing space makes the annotation part of the flag, so the command fails.

**`sfms/README.md`** config example sets `destination=`, but `sfms.py` reads `config.get('url')` at lines 164 and 175, and the prose above the example correctly lists `url`. Following the example produces a config the script cannot use.

`NATS.md` also had its step numbering run 1, 4, 5, 6, which I have renumbered.

## Rendering and metadata

`openshift/README.md` had `#####Homebrew install:` with no space after the hashes, so it rendered as literal text instead of a heading.

The README licence badge's alt text read `MIT License`, while `LICENSE` is Apache 2.0 and the badge itself renders "Apache-2.0". Anyone using a screen reader was told the wrong licence.

## Notes for review

Documentation only. No code, configuration, or generated files are touched.

This overlaps with #5683 (spelling and grammar) in five files, but on non-adjacent lines, so the two merge cleanly in either order.

I left the `docs/architecture/sfms.md` and `docs/ARCH.md` prose alone here, since the mermaid diagrams are marked work in progress and I did not want to touch diagram content in a fix-up PR.
