### PR TITLE
Docs: Fix spelling and grammar in documentation

### DIFF
--- a/backend/packages/wps-api/HFI_spreadsheet.md
+++ b/backend/packages/wps-api/HFI_spreadsheet.md
@@ -8,7 +8,7 @@ This information was pulled from the sample HFI calculator spreadsheet "__20 HFI
 
 Information for fuel type layer C6 is missing from the sample workbook.
 
-These formulae are based on the formulae used in the sample workbook. The formulae listed in this document should be verified against other sources to confirm that formula interpolation has been performed correctly, and that the formula used in the reference workbook are correct. (Given the complex nature of some of the formulae, it is highly possible that mistakes have been made somewhere.)
+These formulae are based on the formulae used in the sample workbook. The formulae listed in this document should be verified against other sources to confirm that formula interpolation has been performed correctly, and that the formulae used in the reference workbook are correct. (Given the complex nature of some of the formulae, it is highly possible that mistakes have been made somewhere.)
 
 ## Missing Data (that we definitely need)
 

--- a/backend/packages/wps-api/src/app/jobs/model_data.md
+++ b/backend/packages/wps-api/src/app/jobs/model_data.md
@@ -33,7 +33,7 @@ Some of the core functionalities of Morecast (versions 1 and 2) require that we 
 
 ## GRIB Files
 
-All weather model produce outputs in GRIB file format. [Refer here for a description of what a GRIB file is](https://weather.gc.ca/grib/what_is_GRIB_e.html).
+All weather models produce outputs in GRIB file format. [Refer here for a description of what a GRIB file is](https://weather.gc.ca/grib/what_is_GRIB_e.html).
 
 A GRIB file contains one or more raster bands, in which weather data is presented in a grid format. Each raster band corresponds to one weather variable. (For example, temperature data points will be stored in a different raster band to wind speed data points.) When we fetch a specific raster band from a data grid (using gdal's `GetRasterBand(<band_id>)`), we get a 2-dimensional array of numeric values (usually floats) containing the values for the relevant weather variable. In order to coalesce the points on the data grid with geographic locations (such as lat/long coordinates), a geographic coordinate transformation must be applied. This coordinate transformation is performed in our backend, using metadata supplied by the source of the GRIB file.
 
@@ -103,7 +103,7 @@ NAM model data is published on a Polar Stereographic projection at a 32km resolu
 
 ##### Model Run Cycles
 
-The NAM model makes predictions for every hour for the first 36 hours, and then on a 3-hourly schedule to 84 hours [https://mag.ncep.noaa.gov/model-guidance-model-parameter.php?group=Model%20Guidance&model=NAM&area=NAMER&ps=area#]. As with the GFS model, we sometimes need to fetch data for 2 different hour offsets and then perform linear interpolation in order to have a weather prediction for 12:00 PST. The file naming convention that NAM uses indicates the model runtime as hours in UTC, and indexes that hour as 00. All subsequent hours in the model run are referenced as offsets of the 00 hour index. This means that for the 00:00 UTC model cycle, 20:00 UTC (or 12:00 PST) is referenced as hour 20; but for the 12:00 UTC model cycle, 20:00 UTC is referenced as hour 8 (20:00 - 12:00). Therefore, to fetch the noon PST data we need, the NAM cronjob pulls the following model hours. noon hours are equivalent to 20:00 UTC. before_noon hours are 18:00 UTC and used for linear interpolation along with after_noon hours which are 21:00 UTC. Accumulation hours represent the prediction hours required in oorder to calcaulte accumulative precipitation throughout the model run.
+The NAM model makes predictions for every hour for the first 36 hours, and then on a 3-hourly schedule to 84 hours [https://mag.ncep.noaa.gov/model-guidance-model-parameter.php?group=Model%20Guidance&model=NAM&area=NAMER&ps=area#]. As with the GFS model, we sometimes need to fetch data for 2 different hour offsets and then perform linear interpolation in order to have a weather prediction for 12:00 PST. The file naming convention that NAM uses indicates the model runtime as hours in UTC, and indexes that hour as 00. All subsequent hours in the model run are referenced as offsets of the 00 hour index. This means that for the 00:00 UTC model cycle, 20:00 UTC (or 12:00 PST) is referenced as hour 20; but for the 12:00 UTC model cycle, 20:00 UTC is referenced as hour 8 (20:00 - 12:00). Therefore, to fetch the noon PST data we need, the NAM cronjob pulls the following model hours. noon hours are equivalent to 20:00 UTC. before_noon hours are 18:00 UTC and used for linear interpolation along with after_noon hours which are 21:00 UTC. Accumulation hours represent the prediction hours required in order to calculate accumulative precipitation throughout the model run.
 
 - For the 00:00 UTC model run time:
   - accumulation_hours = 0, 12, 24, 36, 48, 60
@@ -130,7 +130,7 @@ Note that the accumulation hours are required in order for us to calculate the c
 
 #### Relevant Weather Variables
 
-To be consistent with the weather variables that we pull from the Environment Canada models, for GFS we use comparable weather variables. There is a slight exception for wind direction and speed: Env Canada models output the separate U and V components for wind, but they also output the calculated wind speed and direction using those U, V components. NOAA only outputs the U,V components for wind - we must do the wind direction and wind speed calculations ourselves. The NOAA grib files for GFS contain two layers related to cumulative precipitation. Both layers are named 'apcp_sfc_0' but accumulate precipitation differently. Raster band 6 accumulates precip in 3 hour increments for odd hours and six hour increments for even hours, but we actually ignore this band. We use band 7 which accumulats precipitation across the model run.
+To be consistent with the weather variables that we pull from the Environment Canada models, for GFS we use comparable weather variables. There is a slight exception for wind direction and speed: Env Canada models output the separate U and V components for wind, but they also output the calculated wind speed and direction using those U, V components. NOAA only outputs the U,V components for wind - we must do the wind direction and wind speed calculations ourselves. The NOAA grib files for GFS contain two layers related to cumulative precipitation. Both layers are named 'apcp_sfc_0' but accumulate precipitation differently. Raster band 6 accumulates precip in 3 hour increments for odd hours and six hour increments for even hours, but we actually ignore this band. We use band 7 which accumulates precipitation across the model run.
 
 The NAM grib file does not contain a band for cumulative precipitation since the start of the model. This requires us to use band 6 which accumulates precipitation slightly differently for model run hours 00 and 12 versus 06 and 18. The 00 and 12 hour model runs contain cumulative precipitation in 12 hour cycles.
 
@@ -157,7 +157,7 @@ For the 00 and 12 hour model runs:
 | 51 | 48 - 51 |
 | ... | ... - ... |
 
-For the 06 and 18 hour model runs precipitation accumlates in 3 hour intervals:
+For the 06 and 18 hour model runs precipitation accumulates in 3 hour intervals:
 
 | Hour from start | Cumulative precip hours |
 | --------------- | ----------------------- |

--- a/backend/packages/wps-shared/src/wps_shared/db/storage_assumptions.md
+++ b/backend/packages/wps-shared/src/wps_shared/db/storage_assumptions.md
@@ -7,7 +7,7 @@
 
 ## Assumptions
 
-- Optimization by a factor of 10 on env-canada job should be feasable.
+- Optimization by a factor of 10 on env-canada job should be feasible.
 - Compression ratio for backup will remain consistent.
 - Forecast data has very little room for optimization.
 

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -11,7 +11,7 @@ graph LR
 
     wso2["WSO2 API Gateway"]
 
-    sso["Red Hat SSO / Keycloak</br>[Idendity Provider]</br>https://oidc.gov.bc.ca"]
+    sso["Red Hat SSO / Keycloak</br>[Identity Provider]</br>https://oidc.gov.bc.ca"]
 
     subgraph Wildfire Predictive Services Unit Web Application
         FrontEnd["PSU Single Page Application</br>[Container: Javascript, React]"]

--- a/docs/NATS.md
+++ b/docs/NATS.md
@@ -14,7 +14,7 @@ The durable consumer we care about is `hfi_classify`.
 
 ### 1. Check existing config
 
-First, login to the openshift cli and start a temporary NATS toolbox pod
+First, log in to the openshift cli and start a temporary NATS toolbox pod
 
 ```bash
 oc -n <namespace> run nats-box --rm -it --restart=Never --image=natsio/nats-box -- sh

--- a/docs/architecture/sfms.md
+++ b/docs/architecture/sfms.md
@@ -25,7 +25,7 @@ subgraph Openshift
 
     APIPostGIS[("PostGIS for API<br/>Used for analysis")]
     Queue[("NATS Queue")]
-    TileServerPostGIS[("PostGIS for tile servers</br>Opimized for server data to tile servers. Not used for analysis.")]
+    TileServerPostGIS[("PostGIS for tile servers</br>Optimized for server data to tile servers. Not used for analysis.")]
     Workers["[Container: Pods, Python]</br>Workers. Pull jobs from queue and do work.</br>e.g. calculate area in zone that exceeds 4000 hectares."]
 
     API-."Put jobs on Queue".->Queue

--- a/docs/database/CLUSTER_DB.MD
+++ b/docs/database/CLUSTER_DB.MD
@@ -46,7 +46,7 @@ In the rare case where the multi-instance primary cluster is unrecoverable a rep
 ![Repo-based Standby Architecture](repo-standby-overview.png)
 Source: <https://access.crunchydata.com/documentation/postgres-operator/latest/architecture/disaster-recovery#repo-based-standby>
 
-When the repo-standby is spun, it reads and applies the WAL in order to replicate the state of the database and runs as it's own cluster, separate from the primary.
+When the repo-standby is spun up, it reads and applies the WAL in order to replicate the state of the database and runs as its own cluster, separate from the primary.
 
 Spin up the Repo-Standby Cluster with:
 `PROJ_TARGET=<namespace-license-plate> BUCKET=<s3-bucket> bash openshift/scripts/oc_provision_crunchy_standby.sh <suffix> apply`
@@ -56,9 +56,9 @@ Spin up the Repo-Standby Cluster with:
 ##### Promoting a Standby Cluster
 
 Once a standby is stood up, it can be promoted to be the primary cluster. **Note: only do this if the existing primary has been shut down first.**
-You can shutdown the primary cluster with this command:  
+You can shut down the primary cluster with this command:  
 `kubectl patch postgrescluster/<cluster-name> --type merge --patch '{"spec":{"shutdown": true}}'`  
-You can determine that the cluster is fully shutdown when there are no StatefulSet pods running for that cluster.
+You can determine that the cluster is fully shut down when there are no StatefulSet pods running for that cluster.
 
 Promote the standby cluster by editing the [crunchy_standby.yaml](../../openshift/templates/crunchy_standby.yaml) to set the `standby` field to `false`.
 You can determine that promotion has completed when the logs of the standby StatefulSet show a leader has been elected.
@@ -67,7 +67,7 @@ More details here: <https://access.crunchydata.com/documentation/postgres-operat
 
 ##### Database user privileges
 
-The promoted standby cluster created it's own secrets for connecting to pgbouncer and it has created a new user in the database with the same name as the cluster. Ex. if the standby cluster is named "wps-crunchy-16-20241210", the user will have the same name (this user won't be created until the standby is promoted).
+The promoted standby cluster created its own secrets for connecting to pgbouncer and it has created a new user in the database with the same name as the cluster. Ex. if the standby cluster is named "wps-crunchy-16-20241210", the user will have the same name (this user won't be created until the standby is promoted).
 Once the standby has been promoted, the easiest way to update user privileges is to reassign table ownership from the old user to the new user:  
 `REASSIGN OWNED BY "<old-user>" TO "<new-user>";`  
 Use `\du` in psql to see users in the database.
@@ -92,7 +92,7 @@ PROJ_TARGET=<namespace-license-plate> BUCKET=<s3-bucket> CPU_REQUEST=75m MEMORY_
 
 ##### Set superuser permissions in new cluster via OpenShift web GUI
 
-Login to the OpenShift UI and use `patronictl list` to identify the new cluster's leader pod. The role to update will be something like `wps-crunchydb-16-<suffix>`. You can confirm the role by exploring the pg_roles table with:
+Log in to the OpenShift UI and use `patronictl list` to identify the new cluster's leader pod. The role to update will be something like `wps-crunchydb-16-<suffix>`. You can confirm the role by exploring the pg_roles table with:
 `psql -c "SELECT * FROM pg_roles"`.
 Access the terminal of the leader pod and execute:
 `psql -c 'ALTER ROLE "<wps-crunchydb-username>" SUPERUSER'`
@@ -124,7 +124,7 @@ PGPASSWORD=$PGPASSWORD psql -U $PGUSER -d wps -h localhost < wps-crunchydb-sql-d
 ##### Remove superuser privileges from pguser
 
 This step is required as pgbouncer will not connect to the cluster/database with a superuser.
-Login to the OpenShift UI and use `patronictl list` to identify the new cluster's leader pod. Access the terminal of the leader pod and execute:
+Log in to the OpenShift UI and use `patronictl list` to identify the new cluster's leader pod. Access the terminal of the leader pod and execute:
 `psql -c 'ALTER ROLE "<wps-crunchydb-username>" NOSUPERUSER'`
 
 ##### Update the prod deployment to use the new crunchydb cluster and pguser secret

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -102,7 +102,7 @@ rules:
       - patch
 ```
 
-## Used token to create appropraite token in github
+## Used token to create appropriate token in github
 
 - Create service account in tools
 

--- a/sfms/README.md
+++ b/sfms/README.md
@@ -6,7 +6,7 @@ This project contains a script that is intended to be run on the SFMS windows se
 
 The python script in this project, `sfms.py` is targeted at python 2.7, since the SFMS server is running python 2.7.
 
-The python script, `sfms.py` does not require any external dependencies. [Python 2.7 is deprected](https://www.python.org/doc/sunset-python-2/) so we can't rely on pip being able to install any external dependencies.
+The python script, `sfms.py` does not require any external dependencies. [Python 2.7 is deprecated](https://www.python.org/doc/sunset-python-2/) so we can't rely on pip being able to install any external dependencies.
 
 ## Run
 
@@ -20,10 +20,10 @@ python sfms.py config.ini
 
 ## Configuration
 
-The `config.ini` must be specifed, and has three fields that need to be configured:
+The `config.ini` must be specified, and has three fields that need to be configured:
 
 - secret: This is a shared secret (password) between the SFMS server and the PSU API. If the secret does not match, then the PSU API will reject the request.
-- source: this the directory where the geotiffs are located. All *.tif and *.tiff files in this directory will be uploaded.
+- source: this is the directory where the geotiffs are located. All *.tif and *.tiff files in this directory will be uploaded.
 - url: this is the url of the PSU API endpoint to which the script will post the geotiffs.
 
 e.g.:
@@ -53,7 +53,7 @@ On M1, `pyenv install 2.7.18` fails, and will never pass (they're not going to b
 
 #### TODO: `pyenv install 2.7.18` and all subsequent commands above worked fine on my M1. Maybe it has been fixed after all?? Confirm with other devs
 
-You CAN however try run a universal binary in x86_64 mode, and get it to work that way!
+You CAN however try to run a universal binary in x86_64 mode, and get it to work that way!
 
 ```bash
 arch -x86_64 /bin/bash 


### PR DESCRIPTION
A set of spelling and grammar errors I noticed while reading the docs. This PR fixes those and nothing else.

Scope is deliberately narrow: Markdown prose only. No code, no configuration, no generated files, and no rewording beyond the errors themselves.

## Spelling

| File | Change |
| --- | --- |
| `sfms/README.md` | "deprected" to "deprecated", "specifed" to "specified" |
| `openshift/README.md` | "appropraite" to "appropriate" |
| `docs/ARCH.md` | "Idendity Provider" to "Identity Provider" |
| `docs/architecture/sfms.md` | "Opimized" to "Optimized" |
| `storage_assumptions.md` | "feasable" to "feasible" |
| `model_data.md` | "in oorder to calcaulte" to "in order to calculate"; "accumulats" and "accumlates" to "accumulates" |

## Grammar

| File | Change |
| --- | --- |
| `model_data.md` | "All weather model produce outputs" to "All weather models produce outputs" |
| `CLUSTER_DB.MD` | "runs as it's own cluster" and "created it's own secrets" to "its" |
| `CLUSTER_DB.MD` | "shutdown" to "shut down" in the two places it is used as a verb |
| `CLUSTER_DB.MD`, `NATS.md` | "Login to" to "Log in to" where used as a verb |
| `sfms/README.md` | "source: this the directory" to "this is the directory"; "try run" to "try to run" |
| `HFI_spreadsheet.md` | "the formula used in the reference workbook are correct" to "formulae", to agree with the verb |

## Two typos I found but deliberately did not fix

I would rather flag these than change them without your input.

`mobile/keycloak/README.md` contains "from a OAuth 2 provider". That file is generated by `@capacitor/docgen` (see `package.json` line 42, and the file carries the "rerun docgen" marker), so editing it directly would be overwritten by the next build. The real fix belongs in the plugin's JSDoc source, which felt out of scope for a docs PR.

`openshift/templates/global.config.yaml` has "Secret for SFMS process triger" in a parameter description. It is a template rather than documentation, so I left it for you to decide on.

I also left `PSU API's` in the `ARCH.md` mermaid diagram alone, since it is a `subgraph` identifier and I did not want to risk the diagram rendering for a possessive apostrophe.

## Notes for review

This overlaps with #5682 (broken links) in five files, but on non-adjacent lines, so the two merge cleanly in either order.
