### PR TITLE
Dev: Use 'fire centre' spelling in FBA table instructions

### DIFF
--- a/web/apps/wps-web/src/features/fbaCalculator/components/FBATableInstructions.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/FBATableInstructions.tsx
@@ -19,7 +19,7 @@ const FBATableInstructions = () => {
     <Root data-testid={'fba-instructions'} className={classes.content}>
       <p>Add a row to get started.</p>
       <p>
-        Build custom lists of weather stations by fire center, zone or fuel type. Bookmark the URL to save your custom
+        Build custom lists of weather stations by fire centre, zone or fuel type. Bookmark the URL to save your custom
         list.
       </p>
     </Root>


### PR DESCRIPTION
The Fire Behaviour Advisory Calculator's empty state instructions currently read:

> Build custom lists of weather stations by fire **center**, zone or fuel type.

Every other user-facing string in the application uses "fire **centre**", including the `FireCentreDropdown` label, the HFI Calculator's select-a-fire-centre instructions, the advisory text, and the Playwright specs. It also matches BC Wildfire Service terminology and the actual organisational names, such as Coastal Fire Centre and Cariboo Fire Centre.

This is the only remaining instance of the American spelling in a string a user actually sees.

## What this does not touch

The `fire_center_id` field name and the related identifiers in `hfiCalculatorSlice.ts` and `HfiCalculatorPage.tsx` are left exactly as they are. Those are part of the API wire format, and renaming them would be a breaking change for no user-visible benefit.

There are also two test fixtures using "Fire Center", in `advisoryReport.test.tsx` and a test description in `advisoryText.test.tsx`. I left those alone to keep this diff to a single line, but I am glad to tidy them up here if you would prefer.

## Verification

No test asserts on this copy. The two Playwright specs covering this component select it by the `fba-instructions` test id, not by text.

The reflowed line is 118 characters, within the `lineWidth` of 120 configured in `biome.json`, so the formatter leaves it as is.
