### PR TITLE
PG Idle Timeout

### DIFF
--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -10,7 +10,7 @@ labels:
 parameters:
   - name: NAME
     description: |
-      The name of the application for labelling all artifacts.
+      The name  of the application for labelling all artifacts.
     displayName: Application Name
     required: true
   - description: Namespace in which database resides

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -76,11 +76,6 @@ objects:
       postgresVersion: 16
       postGISVersion: "3.3"
       openshift: true
-      patroni:
-        dynamicConfiguration:
-          postgresql:
-            parameters:
-              idle_in_transaction_session_timeout: "4h"
       metadata:
         name: ${CRUNCHY_NAME}-${SUFFIX}
         labels:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -10,7 +10,7 @@ labels:
 parameters:
   - name: NAME
     description: |
-      The name  of the application for labelling all artifacts.
+      The name of the application for labelling all artifacts.
     displayName: Application Name
     required: true
   - description: Namespace in which database resides
@@ -76,6 +76,11 @@ objects:
       postgresVersion: 16
       postGISVersion: "3.3"
       openshift: true
+      patroni:
+        dynamicConfiguration:
+          postgresql:
+            parameters:
+              idle_in_transaction_session_timeout: "4h"
       metadata:
         name: ${CRUNCHY_NAME}-${SUFFIX}
         labels:

--- a/openshift/templates/crunchy.yaml
+++ b/openshift/templates/crunchy.yaml
@@ -76,6 +76,11 @@ objects:
       postgresVersion: 16
       postGISVersion: "3.3"
       openshift: true
+      patroni:
+        dynamicConfiguration:
+          postgresql:
+            parameters:
+              idle_in_transaction_session_timeout: "4h"
       metadata:
         name: ${CRUNCHY_NAME}-${SUFFIX}
         labels:

--- a/openshift/templates/crunchy_standby.yaml
+++ b/openshift/templates/crunchy_standby.yaml
@@ -67,6 +67,11 @@ objects:
       postgresVersion: 16
       postGISVersion: "3.3"
       openshift: true
+      patroni:
+        dynamicConfiguration:
+          postgresql:
+            parameters:
+              idle_in_transaction_session_timeout: "4h"
       metadata:
         name: ${CRUNCHY_NAME}-${DATE}-${SUFFIX}
         labels:


### PR DESCRIPTION
  Configures PG to terminate sessions that remain continuously idle in transaction for more than 4 hrs (we can adjust this time if we think it's too long).

  This helps prevent abandoned transactions from retaining locks or interfering with database maintenance indefinitely.

  `idle_in_transaction_session_timeout` is enforced by PG. After 4 hours of continuous inactivity inside an open transaction, PG terminates the connection, rolls back the transaction, and releases its locks. The timer resets whenever the connection executes another statement.

Can confirm it's correctly set on the db pods by querying:
`SHOW idle_in_transaction_session_timeout;`

Refs
- https://access.crunchydata.com/documentation/postgres-operator/latest/references/crd/5.8.x/postgrescluster#postgresclusterspecpatroni
- https://patroni.readthedocs.io/en/latest/dynamic_configuration.html




# Test Links:
[Landing Page](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5694-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
