### PR TITLE
SFMS: FBP Primary and TODOs

### DIFF
--- a/backend/packages/cffdrs-vec/src/cffdrs_vec/fbp.py
+++ b/backend/packages/cffdrs-vec/src/cffdrs_vec/fbp.py
@@ -532,6 +532,19 @@ def _vectorized_fbp_secondary(
     raz0_out[0] = result.raz0
 
 
+class FBPPrimaryOutput(NamedTuple):
+    """The primary fields from one vectorized CFFDRS fire behaviour calculation."""
+
+    cfb: np.ndarray
+    cfc: np.ndarray
+    fd_code: np.ndarray
+    hfi: np.ndarray
+    raz: np.ndarray
+    ros: np.ndarray
+    sfc: np.ndarray
+    tfc: np.ndarray
+
+
 class FBPOutput(NamedTuple):
     """Every field cffdrs's own _fire_behaviour_prediction computes and returns - Primary (cfb
     through tfc) and Secondary (be through tti), plus wsv0/raz0 (the raw, pre-fallback
@@ -583,6 +596,79 @@ class FBPOutput(NamedTuple):
     tti: np.ndarray
     wsv0: np.ndarray
     raz0: np.ndarray
+
+
+def vectorized_primary_fire_behaviour_prediction(
+    fuel_type_code,
+    ffmc,
+    bui,
+    ws,
+    wd_rad,
+    gs,
+    aspect_rad,
+    pc,
+    pdf,
+    cc,
+    gfl,
+    cbh,
+    cfl,
+    fmc,
+    isi,
+    lat,
+    lon,
+    elv,
+    dj,
+    d0,
+    sd,
+    sh,
+    hr,
+    theta_rad,
+    accel,
+    buieff,
+) -> FBPPrimaryOutput:
+    """Calculate the eight primary FBP fields with one call per broadcast element.
+
+    Parameters have the same meaning as ``vectorized_fire_behaviour_prediction`` below. This
+    entry point avoids the second calculation needed by that all-output wrapper.
+    """
+    cfb, cfc, fd_code, hfi, raz, ros, sfc, tfc = _vectorized_fbp_primary(
+        fuel_type_code,
+        ffmc,
+        bui,
+        ws,
+        wd_rad,
+        gs,
+        aspect_rad,
+        pc,
+        pdf,
+        cc,
+        gfl,
+        cbh,
+        cfl,
+        fmc,
+        isi,
+        lat,
+        lon,
+        elv,
+        dj,
+        d0,
+        sd,
+        sh,
+        hr,
+        theta_rad,
+        accel,
+        buieff,
+    )
+    return FBPPrimaryOutput(
+        cfb=cfb,
+        cfc=cfc,
+        fd_code=fd_code,
+        hfi=hfi,
+        raz=raz,
+        ros=ros,
+        sfc=sfc,
+        tfc=tfc,
+    )
 
 
 def vectorized_fire_behaviour_prediction(
@@ -662,7 +748,7 @@ def vectorized_fire_behaviour_prediction(
     :param buieff: 1 to apply the Buildup Effect to rate of spread (using bui), any other value
         disables it
     """
-    cfb, cfc, fd_code, hfi, raz, ros, sfc, tfc = _vectorized_fbp_primary(
+    primary = vectorized_primary_fire_behaviour_prediction(
         fuel_type_code,
         ffmc,
         bui,
@@ -756,14 +842,14 @@ def vectorized_fire_behaviour_prediction(
         buieff,
     )
     return FBPOutput(
-        cfb=cfb,
-        cfc=cfc,
-        fd_code=fd_code,
-        hfi=hfi,
-        raz=raz,
-        ros=ros,
-        sfc=sfc,
-        tfc=tfc,
+        cfb=primary.cfb,
+        cfc=primary.cfc,
+        fd_code=primary.fd_code,
+        hfi=primary.hfi,
+        raz=primary.raz,
+        ros=primary.ros,
+        sfc=primary.sfc,
+        tfc=primary.tfc,
         be=be,
         sf=sf,
         isi=isi_out,

--- a/backend/packages/cffdrs-vec/src/cffdrs_vec/tests/test_fbp_matches_cffdrs.py
+++ b/backend/packages/cffdrs-vec/src/cffdrs_vec/tests/test_fbp_matches_cffdrs.py
@@ -21,7 +21,12 @@ import pytest
 from cffdrs.constants import FUEL_TYPE_CODES
 from cffdrs.fire_behaviour_prediction import fire_behaviour_prediction
 
-from cffdrs_vec.fbp import FBPOutput, vectorized_fire_behaviour_prediction
+from cffdrs_vec.fbp import (
+    FBPOutput,
+    FBPPrimaryOutput,
+    vectorized_fire_behaviour_prediction,
+    vectorized_primary_fire_behaviour_prediction,
+)
 from cffdrs_vec.tests._glc_x_10_data import GLC_X_10_SOURCES
 
 # fire_behaviour_prediction()'s public "All" output represents Fire Type as a string ("S"/"I"/"C"),
@@ -64,7 +69,7 @@ def test_vectorized_fire_behaviour_prediction_matches_fire_behaviour_prediction(
     accel = np.array([i.accel for i in fbp_inputs], dtype=np.int64)
     buieff = np.array([i.bui_eff for i in fbp_inputs], dtype=np.int64)
 
-    result = vectorized_fire_behaviour_prediction(
+    calculation_args = (
         fuel_type_codes,
         ffmc,
         bui,
@@ -92,6 +97,8 @@ def test_vectorized_fire_behaviour_prediction_matches_fire_behaviour_prediction(
         accel,
         buieff,
     )
+    result = vectorized_fire_behaviour_prediction(*calculation_args)
+    primary_result = vectorized_primary_fire_behaviour_prediction(*calculation_args)
 
     all_output = [fire_behaviour_prediction(i, output="All") for i in fbp_inputs]
     wsv0 = np.array([fire_behaviour_prediction(i, output="WSV0") for i in fbp_inputs])
@@ -109,3 +116,52 @@ def test_vectorized_fire_behaviour_prediction_matches_fire_behaviour_prediction(
         np.testing.assert_allclose(
             getattr(result, field), reference, rtol=1e-9, atol=1e-9, err_msg=field
         )
+        if field in FBPPrimaryOutput._fields:
+            np.testing.assert_allclose(
+                getattr(primary_result, field),
+                reference,
+                rtol=1e-9,
+                atol=1e-9,
+                err_msg=f"primary {field}",
+            )
+
+
+def test_vectorized_primary_fire_behaviour_prediction_accepts_scalar_inputs():
+    fbp_input = GLC_X_10_SOURCES[0].to_fbp_inputs()[0]
+    calculation_args = (
+        FUEL_TYPE_CODES[fbp_input.fuel_type],
+        fbp_input.ffmc,
+        fbp_input.bui,
+        fbp_input.ws,
+        fbp_input.wd,
+        fbp_input.gs,
+        fbp_input.aspect,
+        fbp_input.pc,
+        fbp_input.pdf,
+        fbp_input.cc,
+        fbp_input.gfl,
+        fbp_input.cbh,
+        fbp_input.cfl,
+        fbp_input.fmc,
+        fbp_input.isi,
+        fbp_input.lat,
+        fbp_input.lon,
+        fbp_input.elv,
+        fbp_input.dj,
+        fbp_input.d0,
+        fbp_input.sd,
+        fbp_input.sh,
+        fbp_input.hr,
+        fbp_input.theta,
+        fbp_input.accel,
+        fbp_input.bui_eff,
+    )
+
+    result = vectorized_primary_fire_behaviour_prediction(*calculation_args)
+    reference = fire_behaviour_prediction(fbp_input, output="Primary")
+
+    for field in FBPPrimaryOutput._fields:
+        expected = (
+            _FD_CODE_BY_STRING[reference.fd] if field == "fd_code" else getattr(reference, field)
+        )
+        np.testing.assert_allclose(getattr(result, field), expected, rtol=1e-9, atol=1e-9)

--- a/docs/architecture/fbp-todo.md
+++ b/docs/architecture/fbp-todo.md
@@ -1,0 +1,96 @@
+# SFMS Fire Behaviour Prediction TODO
+
+This document tracks the inputs and policy decisions needed to move SFMS from its standalone
+Surface Fuel Consumption (SFC) calculation to a shared Fire Behaviour Prediction (FBP)
+calculation. The intended primary outputs are SFC, Total Fuel Consumption, Rate of Spread, Crown
+Fraction Burned, and Head Fire Intensity.
+
+SFC should continue using `vectorized_surface_fuel_consumption` until the inputs below are ready.
+Once another primary output is added, the SFC-only processor should be replaced by a multi-output
+FBP processor that calls `vectorized_primary_fire_behaviour_prediction` once and publishes the
+required fields from its result.
+
+## Input TODOs
+
+- [ ] Bring the existing legacy SFMS ground-slope and aspect rasters into the new pipeline,
+  following the same approach used for the legacy DEM.
+  - Ground slope (`gs`) must be expressed as percent slope, not degrees.
+  - Aspect is the direction the slope faces. Convert it to radians before calling CFFDRS.
+  - Define nodata handling and the aspect value used for flat pixels.
+- [ ] Confirm whether production fuel grids contain the M3/M4 classification before sourcing
+  percent dead balsam fir (`pdf`).
+  - The temporary classification mapping reserves value `13` for M3/M4, but the temporary 2025
+    raster currently contains no value `13` pixels.
+  - If a selected fuel grid contains M3/M4 pixels, identify an appropriate PDF source and decide
+    whether it must be paired with the fuel-grid year.
+  - If M3/M4 is absent, use zero for PDF and defer acquiring a dedicated raster.
+  - If PDF is required, missing or out-of-range values on M3/M4 pixels should prevent calculation
+    rather than silently use a generic percentage.
+- [ ] Identify, retain, and align an initial percent-grass-curing (`cc`) raster source.
+  - It is only meaningful for O1A/O1B pixels.
+  - The initial source and update cadence still need to be determined.
+  - Define staleness and fallback rules once the source is selected.
+- [ ] Integrate the daily Foliar Moisture Content (FMC) raster.
+  - Treat valid daily FMC values as authoritative rather than asking CFFDRS to derive them.
+  - Require FMC to be finite and greater than `0` and at most `120` on pixels being calculated.
+  - Exclude missing or invalid FMC pixels with the common valid-pixel mask. Passing them into
+    CFFDRS would activate its location-and-date fallback and unintentionally fill missing data.
+- [ ] Decide the Initial Spread Index policy.
+  - The existing daily ISI raster is based on FFMC and interpolated wind without terrain effects.
+  - Passing the existing positive ISI makes CFFDRS use it for the final ROS calculation.
+  - Passing `isi=0` makes CFFDRS calculate ISI from FFMC and the slope-adjusted effective wind.
+- [ ] Define the seasonal fuel-type policy.
+  - Set the green-up/standing-period dates used to choose M1/M2, M3/M4, and O1A/O1B.
+  - Resolve D1/D2 handling: the SFMS seasonal mapping includes D2, but the installed `cffdrs`
+    package does not support D2 as an FBP fuel type.
+
+## Inputs Already Available or Derivable
+
+| CFFDRS argument | Source or policy | Units and notes |
+| --- | --- | --- |
+| `fuel_type_code` | Year-specific fuel raster and SFMS classification mapping | Apply seasonal variants before converting to CFFDRS codes. |
+| `ffmc` | Same-day FFMC raster | Existing FWI output. |
+| `bui` | Same-day BUI raster | Existing FWI output. |
+| `ws` | Same-day interpolated wind-speed raster | km/h. |
+| `wd_rad` | Same-day interpolated wind-direction raster | Existing raster is meteorological degrees; convert to radians. |
+| `gs` | Existing legacy SFMS slope raster | Percent slope; migrate and address it in the new pipeline. |
+| `aspect_rad` | Existing legacy SFMS aspect raster | Downslope aspect converted to radians; migrate and address it in the new pipeline. |
+| `pc` | Percent-conifer raster paired with the fuel-grid year | Required and validated on M1/M2 pixels. Use zero elsewhere. |
+| `pdf` | Conditional percent-dead-balsam-fir source | First confirm M3/M4 occurs in the selected fuel grid. If it does, require and validate PDF on those pixels; use zero elsewhere. |
+| `cc` | Grass-curing source to be determined | Required and validated on O1A/O1B pixels. Use zero elsewhere. |
+| `gfl` | Fixed value | `0.35 kg/m²`, matching the existing SFC calculation. |
+| `cbh` | CFFDRS fuel-type defaults | Pass `0`; a future stand-specific layer could override it. |
+| `cfl` | CFFDRS fuel-type defaults | Pass `0`; a future stand-specific layer could override it. |
+| `fmc` | Daily FMC raster | Require a finite value in `(0, 120]`; missing or invalid pixels become output nodata. |
+| `isi` | Policy to be decided | Pass a positive value to use the existing daily ISI, or `0` to have CFFDRS derive it from FFMC and effective wind. |
+| `lat` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
+| `lon` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
+| `elv` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
+| `dj` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
+| `d0` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
+| `sd` | No stand-density source planned | Pass `0`; C6 then uses its fuel-type CBH default. |
+| `sh` | No stand-height source planned | Pass `0`; C6 then uses its fuel-type CBH default. |
+| `hr` | Fixed primary-calculation control | Pass `0`; elapsed time is not used by the primary products. |
+| `theta_rad` | Fixed primary-calculation control | Pass `0`; directional secondary outputs are not being published. |
+| `accel` | Fixed primary-calculation control | Pass `0`; primary ROS is equilibrium ROS. |
+| `buieff` | Fixed calculation control | Pass `1` to apply the BUI effect. |
+
+## Pipeline Requirements
+
+- [ ] Define a shared `FBPInputs` raster contract once the unresolved data sources are known.
+- [ ] Require all input rasters to match the selected fuel grid's extent, resolution, projection,
+  and geotransform.
+- [ ] Validate fuel-specific inputs only where they are meaningful: PC on M1/M2, PDF on M3/M4,
+  and grass curing on O1A/O1B.
+- [ ] Apply one common valid-pixel mask to every primary output and publish nodata for non-fuel or
+  incomplete pixels.
+- [ ] Replace `SurfaceFuelConsumptionProcessor` rather than running both the standalone SFC and
+  shared primary FBP calculations.
+- [ ] During that transition, verify the shared primary calculation's SFC output matches the
+  standalone SFC calculation for every supported fuel type.
+
+## Deferred Outputs
+
+- Thirty-minute fire size requires secondary fire-geometry outputs and is intentionally deferred.
+- Wildfire Ignition Probability is a separate downstream model, not a CFFDRS primary or secondary
+  output.

--- a/docs/architecture/fbp-todo.md
+++ b/docs/architecture/fbp-todo.md
@@ -59,20 +59,20 @@ required fields from its result.
 | `pdf` | Conditional percent-dead-balsam-fir source | First confirm M3/M4 occurs in the selected fuel grid. If it does, require and validate PDF on those pixels; use zero elsewhere. |
 | `cc` | Grass-curing source to be determined | Required and validated on O1A/O1B pixels. Use zero elsewhere. |
 | `gfl` | Fixed value | `0.35 kg/m²`, matching the existing SFC calculation. |
-| `cbh` | CFFDRS fuel-type defaults | Pass `0`; a future stand-specific layer could override it. |
-| `cfl` | CFFDRS fuel-type defaults | Pass `0`; a future stand-specific layer could override it. |
+| `cbh` | Default policy to confirm | Candidate value: `0`, which selects the CFFDRS fuel-type default; confirm before implementation. |
+| `cfl` | Default policy to confirm | Candidate value: `0`, which selects the CFFDRS fuel-type default; confirm before implementation. |
 | `fmc` | Daily FMC raster | Require a finite value in `(0, 120]`; missing or invalid pixels become output nodata. |
 | `isi` | Policy to be decided | Pass a positive value to use the existing daily ISI, or `0` to have CFFDRS derive it from FFMC and effective wind. |
-| `lat` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
-| `lon` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
-| `elv` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
-| `dj` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
-| `d0` | Fixed unused placeholder | Pass `0`; valid FMC prevents CFFDRS from reading it. |
-| `sd` | No stand-density source planned | Pass `0`; C6 then uses its fuel-type CBH default. |
-| `sh` | No stand-height source planned | Pass `0`; C6 then uses its fuel-type CBH default. |
-| `hr` | Fixed primary-calculation control | Pass `0`; elapsed time is not used by the primary products. |
-| `theta_rad` | Fixed primary-calculation control | Pass `0`; directional secondary outputs are not being published. |
-| `accel` | Fixed primary-calculation control | Pass `0`; primary ROS is equilibrium ROS. |
+| `lat` | Unused-input policy to confirm | Candidate placeholder: `0`; valid FMC prevents CFFDRS from reading it. Confirm before implementation. |
+| `lon` | Unused-input policy to confirm | Candidate placeholder: `0`; valid FMC prevents CFFDRS from reading it. Confirm before implementation. |
+| `elv` | Unused-input policy to confirm | Candidate placeholder: `0`; valid FMC prevents CFFDRS from reading it. Confirm before implementation. |
+| `dj` | Unused-input policy to confirm | Candidate placeholder: `0`; valid FMC prevents CFFDRS from reading it. Confirm before implementation. |
+| `d0` | Unused-input policy to confirm | Candidate placeholder: `0`; valid FMC prevents CFFDRS from reading it. Confirm before implementation. |
+| `sd` | Default policy to confirm | Candidate value: `0`, which makes C6 use its fuel-type CBH default; confirm before implementation. |
+| `sh` | Default policy to confirm | Candidate value: `0`, which makes C6 use its fuel-type CBH default; confirm before implementation. |
+| `hr` | Primary-control policy to confirm | Candidate value: `0`; elapsed time is not used by the planned primary products. Confirm before implementation. |
+| `theta_rad` | Primary-control policy to confirm | Candidate value: `0`; directional secondary outputs are not planned. Confirm before implementation. |
+| `accel` | Primary-control policy to confirm | Candidate value: `0`, which produces equilibrium ROS; confirm before implementation. |
 | `buieff` | Fixed calculation control | Pass `1` to apply the BUI effect. |
 
 ## Pipeline Requirements

--- a/docs/architecture/fbp-todo.md
+++ b/docs/architecture/fbp-todo.md
@@ -82,8 +82,9 @@ required fields from its result.
   and geotransform.
 - [ ] Validate fuel-specific inputs only where they are meaningful: PC on M1/M2, PDF on M3/M4,
   and grass curing on O1A/O1B.
-- [ ] Apply one common valid-pixel mask to every primary output and publish nodata for non-fuel or
-  incomplete pixels.
+- [ ] Apply the BC mask as the final mask for every primary output. Publish nodata outside BC and
+  where required inputs are missing or invalid; publish `0` for recognized non-combustible fuel
+  pixels inside BC.
 - [ ] Replace `SurfaceFuelConsumptionProcessor` rather than running both the standalone SFC and
   shared primary FBP calculations.
 - [ ] During that transition, verify the shared primary calculation's SFC output matches the


### PR DESCRIPTION
  This PR prepares the next stage of SFMS FBP processing.

  It adds a vectorized primary FBP entry point that calculates the eight primary CFFDRS outputs without also running the secondary calculations. These are most of what the geospatial team needs SFMS to generate initially. I haven't quite figured out the rest yet.

  It adds an FBP TODO document outlining the remaining raster inputs, validation rules, and other decisions needed before replacing the standalone SFC processor with a shared multi-output FBP processor

# Test Links:
[Landing Page](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5697-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
