### PR TITLE
Cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,7 +16,6 @@ on:
         type: number
 
 env:
-  PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
   APS_TEST_GATEWAY_ID: gw-11008
   SUFFIX: pr-${{ github.event.number || inputs.pr_number }}
 
@@ -34,7 +33,7 @@ jobs:
         id: asa_go_aps_config
         shell: bash
         run: |
-          echo "config_path=.github/tmp/asa-go-gw-config-pr-${{ env.PR_NUMBER }}.yaml" >> "${GITHUB_OUTPUT}"
+          echo "config_path=.github/tmp/asa-go-gw-config-${{ env.SUFFIX }}.yaml" >> "${GITHUB_OUTPUT}"
 
       - name: Render ASA Go APS gateway config for cleanup
         shell: bash
@@ -55,7 +54,7 @@ jobs:
       - name: Upload ASA Go APS cleanup config
         uses: actions/upload-artifact@v7
         with:
-          name: asa-go-aps-gateway-config-cleanup-pr-${{ env.PR_NUMBER }}
+          name: asa-go-aps-gateway-config-cleanup-${{ env.SUFFIX }}
           path: ${{ steps.asa_go_aps_config.outputs.config_path }}
 
       - name: Publish SFMS FWI APS cleanup config
@@ -71,7 +70,7 @@ jobs:
       - name: Upload SFMS FWI APS cleanup config
         uses: actions/upload-artifact@v7
         with:
-          name: sfms-fwi-aps-gateway-config-cleanup-pr-${{ env.PR_NUMBER }}
+          name: sfms-fwi-aps-gateway-config-cleanup-${{ env.SUFFIX }}
           path: ${{ steps.asa_go_aps_config.outputs.config_path }}
 
       - name: Delete SFMS FWI dataset and product from API Directory

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -8,10 +8,17 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to clean up
+        required: true
+        type: number
 
 env:
+  PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
   APS_TEST_GATEWAY_ID: gw-11008
-  SUFFIX: pr-${{ github.event.number }}
+  SUFFIX: pr-${{ github.event.number || inputs.pr_number }}
 
 jobs:
   cleanup-non-db:
@@ -27,7 +34,7 @@ jobs:
         id: asa_go_aps_config
         shell: bash
         run: |
-          echo "config_path=.github/tmp/asa-go-gw-config-pr-${{ github.event.number }}.yaml" >> "${GITHUB_OUTPUT}"
+          echo "config_path=.github/tmp/asa-go-gw-config-pr-${{ env.PR_NUMBER }}.yaml" >> "${GITHUB_OUTPUT}"
 
       - name: Render ASA Go APS gateway config for cleanup
         shell: bash
@@ -48,7 +55,7 @@ jobs:
       - name: Upload ASA Go APS cleanup config
         uses: actions/upload-artifact@v7
         with:
-          name: asa-go-aps-gateway-config-cleanup-pr-${{ github.event.number }}
+          name: asa-go-aps-gateway-config-cleanup-pr-${{ env.PR_NUMBER }}
           path: ${{ steps.asa_go_aps_config.outputs.config_path }}
 
       - name: Publish SFMS FWI APS cleanup config
@@ -64,7 +71,7 @@ jobs:
       - name: Upload SFMS FWI APS cleanup config
         uses: actions/upload-artifact@v7
         with:
-          name: sfms-fwi-aps-gateway-config-cleanup-pr-${{ github.event.number }}
+          name: sfms-fwi-aps-gateway-config-cleanup-pr-${{ env.PR_NUMBER }}
           path: ${{ steps.asa_go_aps_config.outputs.config_path }}
 
       - name: Delete SFMS FWI dataset and product from API Directory


### PR DESCRIPTION
Make `cleanup` action also work as a manually triggered `workflow_dispatch`

Tested by running: `gh workflow run cleanup.yml --ref task/cleanup-workflow -f pr_number=5666`

https://github.com/bcgov/wps/actions/runs/32164971868
# Test Links:
[Landing Page](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5710-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
