### PR TITLE
Task: Weather Toolkit ability to full screen individual plots

### DIFF
--- a/web/apps/wps-web/src/features/weatherToolkit/components/ChartPanel.tsx
+++ b/web/apps/wps-web/src/features/weatherToolkit/components/ChartPanel.tsx
@@ -1,5 +1,23 @@
 import { Fullscreen, FullscreenExit } from '@mui/icons-material'
-import { Box, CircularProgress, IconButton, Typography, useTheme } from '@mui/material'
+import { Box, ButtonBase, CircularProgress, IconButton, Typography, useTheme } from '@mui/material'
+import { useEffect, useState } from 'react'
+
+// The four plots tile the generated image edge to edge in a 2x2 grid
+// (see apply_4panel_frames in wps-weather), so each plot maps exactly to
+// one quadrant of the image.
+export enum PanelQuadrant {
+  TOP_LEFT = 'topLeft',
+  TOP_RIGHT = 'topRight',
+  BOTTOM_LEFT = 'bottomLeft',
+  BOTTOM_RIGHT = 'bottomRight'
+}
+
+export const panelRegistry: Record<PanelQuadrant, { label: string; row: 0 | 1; col: 0 | 1 }> = {
+  [PanelQuadrant.TOP_LEFT]: { label: '500 hPa Height + Abs Vorticity', row: 0, col: 0 },
+  [PanelQuadrant.TOP_RIGHT]: { label: 'MSLP + 1000-500 Thickness', row: 0, col: 1 },
+  [PanelQuadrant.BOTTOM_LEFT]: { label: '700 hPa Height + 850-500 Relative Humidity', row: 1, col: 0 },
+  [PanelQuadrant.BOTTOM_RIGHT]: { label: 'Precipitation', row: 1, col: 1 }
+}
 
 interface ChartPanelProps {
   imageSrc: string | null
@@ -11,13 +29,66 @@ interface ChartPanelProps {
 
 const ChartPanel = ({ imageSrc, chartKey, isFailed, isExpanded, onToggleExpand }: ChartPanelProps) => {
   const theme = useTheme()
+  const [focusedPanel, setFocusedPanel] = useState<PanelQuadrant | null>(null)
+
+  useEffect(() => {
+    if (!focusedPanel) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setFocusedPanel(null)
+      }
+    }
+    globalThis.addEventListener('keydown', handleKeyDown)
+    return () => globalThis.removeEventListener('keydown', handleKeyDown)
+  }, [focusedPanel])
+
+  const focused = focusedPanel ? panelRegistry[focusedPanel] : null
+
   return (
     <Box sx={{ flexGrow: 1, overflow: 'hidden', bgcolor: '#B9B9B9', position: 'relative' }}>
       {imageSrc && !isFailed && (
         <img
           src={imageSrc}
-          alt="4-panel chart"
-          style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', objectFit: 'contain' }}
+          alt={focused ? `${focused.label} panel` : '4-panel chart'}
+          style={
+            focused
+              ? {
+                  position: 'absolute',
+                  top: focused.row === 0 ? 0 : '-100%',
+                  left: focused.col === 0 ? 0 : '-100%',
+                  width: '200%',
+                  height: '200%',
+                  objectFit: 'contain'
+                }
+              : { position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', objectFit: 'contain' }
+          }
+        />
+      )}
+      {imageSrc && !isFailed && !focusedPanel && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gridTemplateRows: '1fr 1fr'
+          }}
+        >
+          {Object.values(PanelQuadrant).map(quadrant => (
+            <ButtonBase
+              key={quadrant}
+              onClick={() => setFocusedPanel(quadrant)}
+              aria-label={`View ${panelRegistry[quadrant].label} panel full screen`}
+              sx={{ '&:hover': { outline: '2px solid rgba(255,255,255,0.7)', outlineOffset: '-2px' } }}
+            />
+          ))}
+        </Box>
+      )}
+      {imageSrc && !isFailed && focusedPanel && (
+        <ButtonBase
+          onClick={() => setFocusedPanel(null)}
+          aria-label="Return to 4-panel view"
+          sx={{ position: 'absolute', inset: 0 }}
         />
       )}
       {!imageSrc && !isFailed && (

--- a/web/apps/wps-web/src/features/weatherToolkit/components/chartPanel.test.tsx
+++ b/web/apps/wps-web/src/features/weatherToolkit/components/chartPanel.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import ChartPanel from './ChartPanel'
+import ChartPanel, { PanelQuadrant, panelRegistry } from './ChartPanel'
 
 const defaultProps = {
   imageSrc: null,
@@ -67,6 +67,66 @@ describe('ChartPanel', () => {
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
     expect(screen.getByText('Image not available')).toBeInTheDocument()
     expect(screen.getByText('some/chart/key')).toBeInTheDocument()
+  })
+
+  describe('full screen individual panels', () => {
+    const withImage = { ...defaultProps, imageSrc: 'https://example.com/chart.png' }
+
+    it('renders a full screen button for each of the four panels', () => {
+      render(<ChartPanel {...withImage} />)
+      for (const { label } of Object.values(panelRegistry)) {
+        expect(screen.getByRole('button', { name: `View ${label} panel full screen` })).toBeInTheDocument()
+      }
+    })
+
+    it('does not render panel buttons when there is no image', () => {
+      render(<ChartPanel {...defaultProps} />)
+      const { label } = panelRegistry[PanelQuadrant.TOP_LEFT]
+      expect(screen.queryByRole('button', { name: `View ${label} panel full screen` })).not.toBeInTheDocument()
+    })
+
+    it('does not render panel buttons when the image failed to load', () => {
+      render(<ChartPanel {...withImage} isFailed={true} />)
+      const { label } = panelRegistry[PanelQuadrant.TOP_LEFT]
+      expect(screen.queryByRole('button', { name: `View ${label} panel full screen` })).not.toBeInTheDocument()
+    })
+
+    it.each(Object.values(PanelQuadrant))('zooms the image to the %s panel when clicked', async quadrant => {
+      render(<ChartPanel {...withImage} />)
+      const { label, row, col } = panelRegistry[quadrant]
+      await userEvent.click(screen.getByRole('button', { name: `View ${label} panel full screen` }))
+      const img = screen.getByRole('img', { name: `${label} panel` })
+      expect(img).toHaveStyle({
+        width: '200%',
+        height: '200%',
+        top: row === 0 ? '0px' : '-100%',
+        left: col === 0 ? '0px' : '-100%'
+      })
+    })
+
+    it('returns to the 4-panel view when the zoomed image is clicked', async () => {
+      render(<ChartPanel {...withImage} />)
+      const { label } = panelRegistry[PanelQuadrant.TOP_LEFT]
+      await userEvent.click(screen.getByRole('button', { name: `View ${label} panel full screen` }))
+      await userEvent.click(screen.getByRole('button', { name: 'Return to 4-panel view' }))
+      expect(screen.getByRole('img', { name: '4-panel chart' })).toHaveStyle({ width: '100%', height: '100%' })
+    })
+
+    it('returns to the 4-panel view on Escape', async () => {
+      render(<ChartPanel {...withImage} />)
+      const { label } = panelRegistry[PanelQuadrant.BOTTOM_RIGHT]
+      await userEvent.click(screen.getByRole('button', { name: `View ${label} panel full screen` }))
+      fireEvent.keyDown(window, { key: 'Escape' })
+      expect(screen.getByRole('img', { name: '4-panel chart' })).toBeInTheDocument()
+    })
+
+    it('keeps the focused panel when the image source changes', async () => {
+      const { rerender } = render(<ChartPanel {...withImage} />)
+      const { label } = panelRegistry[PanelQuadrant.TOP_RIGHT]
+      await userEvent.click(screen.getByRole('button', { name: `View ${label} panel full screen` }))
+      rerender(<ChartPanel {...withImage} imageSrc="https://example.com/next-hour.png" />)
+      expect(screen.getByRole('img', { name: `${label} panel` })).toBeInTheDocument()
+    })
   })
 
   describe('expand/collapse button', () => {


### PR DESCRIPTION
Closes #5359

Adds the ability to full screen each of the four plots in the Weather Toolkit chart.

Since the generated image tiles the four plots edge to edge in a 2x2 grid (`apply_4panel_frames` sets `subplots_adjust(0, 1, 0, 1)` with no spacing), each plot maps exactly to one quadrant of the PNG, so this is done client-side by zooming the image to the selected quadrant — no backend changes and no extra image requests.

Behaviour:
- Clicking a quadrant of the chart full screens that plot (each quadrant is a labelled button, e.g. "View MSLP + 1000-500 Thickness panel full screen", so it is keyboard and screen reader accessible)
- Clicking the zoomed plot, or pressing Escape, returns to the 4-panel view
- The focused plot is kept while stepping through forecast hours, so a forecaster can hold one panel full screen and animate through time
- Works alongside the existing hide header/footer expand button

Added 9 component tests covering the quadrant buttons, zoom styles for all four quadrants, exit via click and Escape, and persistence across image changes; all 22 ChartPanel tests pass locally, and biome check is clean.