### PR TITLE
Bump oc and cache client in workflow

### DIFF
--- a/.github/actions/oc-setup/action.yml
+++ b/.github/actions/oc-setup/action.yml
@@ -13,7 +13,7 @@ runs:
         curl -s https://api64.ipify.org
 
     - name: Install OpenShift CLI tools
-      uses: redhat-actions/openshift-tools-installer@v3
+      uses: redhat-actions/openshift-tools-installer@e3b32c2ab7b064b2ce189121c4a49f509a99a7b4 # v3
       with:
-        oc: "4.14"
-        skip_cache: true
+        oc: "4.18"
+        skip_cache: false

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -39,17 +39,12 @@ jobs:
             const pr = pulls.data.find( ({state}) => state === 'open')
             core.exportVariable('SUFFIX', `pr-${pr.number}`);
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Log public IP address
-        run: |
-          echo -e "Public IPv4:"
-          curl -s https://api.ipify.org
-          echo -e "\nPublic IPv4(v6):"
-          curl -s https://api64.ipify.org
-      - name: Install OpenShift CLI tools
-        uses: redhat-actions/openshift-tools-installer@e3b32c2ab7b064b2ce189121c4a49f509a99a7b4 # v3
+      - uses: ./.github/actions/oc-setup
+      - uses: ./.github/actions/oc-login
         with:
-          oc: "4.14"
-          skip_cache: true
+          oc-server: ${{ secrets.OPENSHIFT_CLUSTER }}
+          oc-token: ${{ secrets.OC4_PROD_TOKEN }}
+          oc-namespace: e1e498-prod
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
@@ -58,8 +53,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Provision to production
         run: |
-          echo Login
-          oc login "${{ secrets.OPENSHIFT_CLUSTER }}" --token="${{ secrets.OC4_PROD_TOKEN }}"
           DEPLOY_VERSION="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" PROJ_TARGET=e1e498-prod bash openshift/scripts/oc_deploy_to_production.sh ${SUFFIX} apply
 
       - uses: ./.github/actions/gwa-setup


### PR DESCRIPTION
The oc setup job was behaving more slow since updating the oc installer action to v3. This caches it and reuses the setup in production.
# Test Links:
[Landing Page](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5726-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
