### PR TITLE
Revert to oc 4.14

### DIFF
--- a/.github/actions/oc-setup/action.yml
+++ b/.github/actions/oc-setup/action.yml
@@ -15,5 +15,5 @@ runs:
     - name: Install OpenShift CLI tools
       uses: redhat-actions/openshift-tools-installer@e3b32c2ab7b064b2ce189121c4a49f509a99a7b4 # v3
       with:
-        oc: "4.18"
+        oc: "4.14"
         skip_cache: false


### PR DESCRIPTION
Since #5726 bumped oc from 4.14 → 4.18 (client-go v0.27.4 → v0.31.1) and switched to a cached client/reused login, production deploys have been intermittently dying mid-run with:

`error: ... dial tcp 142.34.194.119:6443: i/o timeout`

Traced through a live failing run: `oc login` succeeds fine and the deploy proceeds normally for several minutes, then a dial tcp call to the same API server stalls and eventually times out 

# Test Links:
[Landing Page](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5729-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
