### PR TITLE
Dev: revert deploy workflows to standard GitHub-hosted runners

### DIFF
--- a/.github/workflows/build_openshift_manual.yml
+++ b/.github/workflows/build_openshift_manual.yml
@@ -41,8 +41,7 @@ env:
 jobs:
   build-image:
     name: Build ${{ inputs.module_name }} Image via OpenShift
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -22,8 +22,7 @@ env:
 jobs:
   cleanup-non-db:
     name: Delete non-DB resources associated with pr
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/oc-setup
@@ -136,8 +135,7 @@ jobs:
   cleanup-db:
     name: Delete DB resources associated with PR
     needs: cleanup-non-db
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/oc-setup

--- a/.github/workflows/deploy_wps_weather.yml
+++ b/.github/workflows/deploy_wps_weather.yml
@@ -34,8 +34,7 @@ jobs:
   deployments:
     name: Deployments
     needs: [build-image]
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,8 +19,7 @@ env:
 jobs:
   prepare-dev-database:
     name: Prepare Dev Database
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/oc-setup
@@ -38,8 +37,7 @@ jobs:
 
   build-image:
     name: Build ${{ matrix.name }} Image
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -80,8 +78,7 @@ jobs:
 
   configure-nats-server-name:
     name: Configure nats server name
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/oc-setup
@@ -99,8 +96,7 @@ jobs:
   deploy-dev-queue:
     name: Deploy Message Queue to Dev
     if: github.triggering_actor != 'renovate'
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     needs: [build-image, configure-nats-server-name]
     steps:
       - uses: actions/checkout@v7
@@ -127,8 +123,7 @@ jobs:
         deploy-dev-queue,
         configure-nats-server-name,
       ]
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/oc-setup
@@ -179,8 +174,7 @@ jobs:
     name: Deploy ASA Go API to Dev
     if: github.triggering_actor != 'renovate'
     needs: [build-image, prepare-dev-database]
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/oc-setup
@@ -205,8 +199,7 @@ jobs:
     name: Deploy SFMS FWI API to Dev
     if: github.triggering_actor != 'renovate'
     needs: [build-image, prepare-dev-database]
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/oc-setup

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -17,8 +17,7 @@ env:
 jobs:
   deploy_to_production:
     name: Deploy to production
-    runs-on:
-      group: Larger Runners - OpenShift Static-IP
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Every production/deploy run since switching to Larger Runners - OpenShift Static-IP has shown the same pattern: oc login succeeds, then a later oc call to the same API server stalls with dial tcp 142.34.194.119:6443: i/o timeout, consistently 5–10 minutes into a job — never at the start. That timing survived several other hypotheses (short-lived token, oc client version, the tools-installer action), all ruled out on evidence.

This PR reverts runs-on back to ubuntu-24.04 across all 5 workflows that talk to the OpenShift API server.
# Test Links:
[Landing Page](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5731-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
