### PR TITLE
Dev: Add actions:write permission to Cleanup jobs for oc cache

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,8 +1,5 @@
 name: Cleanup
 
-permissions:
-  contents: read
-
 on:
   pull_request:
     types: [closed]
@@ -22,6 +19,9 @@ env:
 jobs:
   cleanup-non-db:
     name: Delete non-DB resources associated with pr
+    permissions:
+      contents: read
+      actions: write
     runs-on:
       group: Larger Runners - OpenShift Static-IP
     steps:
@@ -136,6 +136,9 @@ jobs:
   cleanup-db:
     name: Delete DB resources associated with PR
     needs: cleanup-non-db
+    permissions:
+      contents: read
+      actions: write
     runs-on:
       group: Larger Runners - OpenShift Static-IP
     steps:


### PR DESCRIPTION
The `Cleanup` workflow was logging `Failed to save: Unable to reserve cache with key oc_4.18.54_linux_amd64 ... cache write denied: token has no writable scopes` from the `redhat-actions/openshift-tools-installer` step in `oc-setup`.

`cleanup.yml` declares an explicit `permissions` block (`contents: read`), which zeroes out every unlisted scope on the `GITHUB_TOKEN`, which the installer needs to save its CLI-binary cache. Moved `permissions: contents: read` / `actions: write` onto the `cleanup-non-db` and `cleanup-db` jobs individually, since both call `oc-setup` and neither should get it implicitly from a workflow-level default.

e.g. https://github.com/bcgov/wps/actions/runs/32887493931/job/97932446393#step:3:63
# Test Links:
[Landing Page](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5757-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
