### PR TITLE
ASA Go: Add horizontal and vertical autoscaling for the API

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Deploy ASA Go API to Dev
         shell: bash
         run: |
-          DEPLOY_VERSION="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" REPLICAS="1" MEMORY_REQUEST=1GMi MEMORY_LIMIT=1.5Gi ENVIRONMENT="development" bash openshift/scripts/oc_deploy_asa_go_api.sh ${SUFFIX} apply
+          DEPLOY_VERSION="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" REPLICAS="1" MEMORY_REQUEST=1Gi MEMORY_LIMIT=1.5Gi ENVIRONMENT="development" bash openshift/scripts/oc_deploy_asa_go_api.sh ${SUFFIX} apply
 
       - name: Allow APS to reach ASA Go API
         shell: bash

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Deploy ASA Go API to Dev
         shell: bash
         run: |
-          DEPLOY_VERSION="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" REPLICAS="1" MEMORY_REQUEST=700Mi MEMORY_LIMIT=1Gi ENVIRONMENT="development" bash openshift/scripts/oc_deploy_asa_go_api.sh ${SUFFIX} apply
+          DEPLOY_VERSION="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" REPLICAS="1" MEMORY_REQUEST=1GMi MEMORY_LIMIT=1.5Gi ENVIRONMENT="development" bash openshift/scripts/oc_deploy_asa_go_api.sh ${SUFFIX} apply
 
       - name: Allow APS to reach ASA Go API
         shell: bash

--- a/openshift/scripts/oc_cleanup.sh
+++ b/openshift/scripts/oc_cleanup.sh
@@ -32,7 +32,7 @@ else
 	DELETE_OR_GET="get"
 fi
 OC_CLEAN_DEPLOY="oc -n ${PROJ_TARGET} ${DELETE_OR_GET} all,cm,pvc,cronjob,job,networkpolicy -o name -l app=${APP_LABEL}"
-OC_CLEAN_ASA_GO_DEPLOY="oc -n ${PROJ_TARGET} ${DELETE_OR_GET} all,cm,pvc,cronjob,job,networkpolicy -o name -l app=${ASA_GO_APP_LABEL}"
+OC_CLEAN_ASA_GO_DEPLOY="oc -n ${PROJ_TARGET} ${DELETE_OR_GET} all,cm,pvc,cronjob,job,networkpolicy,hpa,vpa -o name -l app=${ASA_GO_APP_LABEL}"
 OC_CLEAN_SFMS_FWI_DEPLOY="oc -n ${PROJ_TARGET} ${DELETE_OR_GET} all,cm,pvc,cronjob,job,networkpolicy -o name -l app=${SFMS_FWI_APP_LABEL}"
 
 # Execute commands

--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -49,7 +49,7 @@ parameters:
     value: "70"
   - name: HPA_MEMORY_TARGET_PERCENTAGE
     description: Target average memory utilization (% of requested memory) the HPA scales around
-    value: "85"
+    value: "90"
   - name: ALLOWED_ORIGINS
     value: wps-*.apps.silver.devops.gov.bc.ca
   - name: PROJECT_NAMESPACE

--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -39,8 +39,17 @@ parameters:
     description: Memory upper limit
     value: 3Gi
   - name: REPLICAS
-    description: Number of replicas
+    description: Number of replicas (also used as the HPA's minimum)
     value: "2"
+  - name: HPA_MAX_REPLICAS
+    description: Upper bound for horizontal autoscaling
+    value: "10"
+  - name: HPA_CPU_TARGET_PERCENTAGE
+    description: Target average CPU utilization (% of requested CPU) the HPA scales around
+    value: "70"
+  - name: HPA_MEMORY_TARGET_PERCENTAGE
+    description: Target average memory utilization (% of requested memory) the HPA scales around
+    value: "70"
   - name: ALLOWED_ORIGINS
     value: wps-*.apps.silver.devops.gov.bc.ca
   - name: PROJECT_NAMESPACE
@@ -217,3 +226,46 @@ objects:
           targetPort: 8080
       selector:
         name: ${APP_NAME}-${SUFFIX}-asa-go
+  - apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      labels:
+        app: ${APP_NAME}-${SUFFIX}-asa-go
+      name: ${APP_NAME}-${SUFFIX}-asa-go
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: ${APP_NAME}-${SUFFIX}-asa-go
+      minReplicas: ${{REPLICAS}}
+      maxReplicas: ${{HPA_MAX_REPLICAS}}
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: ${{HPA_CPU_TARGET_PERCENTAGE}}
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: ${{HPA_MEMORY_TARGET_PERCENTAGE}}
+  - apiVersion: autoscaling.k8s.io/v1
+    kind: VerticalPodAutoscaler
+    metadata:
+      labels:
+        app: ${APP_NAME}-${SUFFIX}-asa-go
+      name: ${APP_NAME}-${SUFFIX}-asa-go
+    spec:
+      targetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: ${APP_NAME}-${SUFFIX}-asa-go
+      # Recommendation-only: "Auto" would fight the HPA over CPU, and would get
+      # clobbered on every deploy anyway since DEPLOY_VERSION forces a rollout with this
+      # template's static CPU_REQUEST/MEMORY_REQUEST every time. Use the recommendations
+      # this produces (`oc describe vpa`) to tune those params by hand.
+      updatePolicy:
+        updateMode: "Off"

--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -31,7 +31,7 @@ parameters:
     value: e1e498-tools
   - name: CPU_REQUEST
     description: Requested CPU
-    value: 250m
+    value: 100m
   - name: MEMORY_REQUEST
     description: Requested memory
     value: 2Gi

--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -49,7 +49,7 @@ parameters:
     value: "70"
   - name: HPA_MEMORY_TARGET_PERCENTAGE
     description: Target average memory utilization (% of requested memory) the HPA scales around
-    value: "70"
+    value: "85"
   - name: ALLOWED_ORIGINS
     value: wps-*.apps.silver.devops.gov.bc.ca
   - name: PROJECT_NAMESPACE
@@ -239,6 +239,9 @@ objects:
         name: ${APP_NAME}-${SUFFIX}-asa-go
       minReplicas: ${{REPLICAS}}
       maxReplicas: ${{HPA_MAX_REPLICAS}}
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 60
       metrics:
         - type: Resource
           resource:

--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -31,7 +31,7 @@ parameters:
     value: e1e498-tools
   - name: CPU_REQUEST
     description: Requested CPU
-    value: 100m
+    value: 250m
   - name: MEMORY_REQUEST
     description: Requested memory
     value: 2Gi


### PR DESCRIPTION
A load test against `e1e498-prod` (k6-on-Lambda, distributing requests across many IPs to bypass the gateway's per-IP rate limit) surfaced that `wps-prod-asa-go` pods failed their readiness/liveness probes and were `OOMKilled` under burst concurrency. `asa_go_api.yaml` had `replicas` fixed at `2`, this adds autoscaling to handle further load.
# Test Links:
[Landing Page](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5760-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
