### PR TITLE
Dev: Pin @sentry/react to 10.69.0 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,20 @@
 {
-  "extends": ["github>bcgov/renovate-config#2026.8.18"],
+  "extends": [
+    "github>bcgov/renovate-config#2026.8.18"
+  ],
   "ignorePaths": [
     "openshift/s3-backup/docker/poetry.lock"
   ],
   "ignoreDeps": [
     "@psu/cffdrs_ts",
     "aiobotocore"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "@sentry/react"
+      ],
+      "allowedVersions": "10.69.0"
+    }
   ]
 }


### PR DESCRIPTION
Versions newer than 10.69.0 are not compatible with our current Capacitor version and result in build/runtime issues. This prevents Renovate from opening upgrade PRs until Capacitor can be upgraded.
# Test Links:
[Landing Page](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5763-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
