### PR TITLE
Dev: Reduce ASA Go resource consumption with HPA and memory tuning

### DIFF
--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -31,7 +31,7 @@ parameters:
     value: e1e498-tools
   - name: CPU_REQUEST
     description: Requested CPU
-    value: 250m
+    value: 500m
   - name: MEMORY_REQUEST
     description: Requested memory
     value: 1Gi

--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -31,7 +31,7 @@ parameters:
     value: e1e498-tools
   - name: CPU_REQUEST
     description: Requested CPU
-    value: 100m
+    value: 250m
   - name: MEMORY_REQUEST
     description: Requested memory
     value: 1Gi

--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -34,10 +34,10 @@ parameters:
     value: 100m
   - name: MEMORY_REQUEST
     description: Requested memory
-    value: 2Gi
+    value: 1Gi
   - name: MEMORY_LIMIT
     description: Memory upper limit
-    value: 3Gi
+    value: 1.5Gi
   - name: REPLICAS
     description: Number of replicas (also used as the HPA's minimum)
     value: "2"


### PR DESCRIPTION
Improve ASA Go autoscaling behavior and reduce unnecessary resource consumption in PR and production environments.
Reduced ASA Go resource requests/limits based on observed usage:
- Memory request: 2Gi → 1Gi
- Memory limit: 3Gi → 1.5Gi
- Requested CPU: 100m -> 500m

CPU: typically under 20m per pod on dev, 227m on prod
Memory: approximately 700-750Mi per pod
# Test Links:
[Landing Page](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5765-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
