### PR TITLE
Dev: Harden frontend CSP and fix dropped security headers

### DIFF
--- a/.github/actions/zap-baseline-scan/action.yml
+++ b/.github/actions/zap-baseline-scan/action.yml
@@ -1,0 +1,21 @@
+name: ZAP Baseline Scan
+description: Run a ZAP baseline scan against a target URL. Caller must checkout the repo first.
+
+inputs:
+  target:
+    description: URL to scan
+    required: true
+  cmd-options:
+    description: Additional zap-baseline.py command line options
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: ZAP Scan
+      uses: zaproxy/action-baseline@v0.15.0
+      with:
+        target: ${{ inputs.target }}
+        rules_file_name: ".zap/rules.tsv"
+        cmd_options: ${{ inputs.cmd-options }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -299,9 +299,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - name: ZAP Scan
-        uses: zaproxy/action-baseline@v0.15.0
+      - uses: ./.github/actions/zap-baseline-scan
         with:
           target: "https://wps-pr-${{ github.event.number }}-e1e498-dev.apps.silver.devops.gov.bc.ca"
-          rules_file_name: ".zap/rules.tsv"
-          cmd_options: "-I"
+          cmd-options: "-I"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -298,6 +298,7 @@ jobs:
     needs: [deploy-dev]
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v7
       - name: ZAP Scan
         uses: zaproxy/action-baseline@v0.15.0
         with:

--- a/.github/workflows/zap_scan.yml
+++ b/.github/workflows/zap_scan.yml
@@ -18,9 +18,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: main
-      - name: ZAP Scan
-        # f.y.i.: ZAP Scan must be able to log an issue or it will fail.
-        uses: zaproxy/action-baseline@v0.15.0
+      # f.y.i.: ZAP Scan must be able to log an issue or it will fail.
+      - uses: ./.github/actions/zap-baseline-scan
         with:
           target: "https://wps-prod.apps.silver.devops.gov.bc.ca/"
-          rules_file_name: ".zap/rules.tsv"

--- a/.github/workflows/zap_scan.yml
+++ b/.github/workflows/zap_scan.yml
@@ -1,4 +1,4 @@
-name: Every Sunday at 02:00
+name: ZAP Baseline Scan Prod
 
 permissions:
   contents: read

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,3 +1,0 @@
-# We intentionally load keycloak from our SSO provider to ensure we always have the correct version.
-10017   OUTOFSCOPE  .*(.apps.silver.devops.gov.bc.ca/)/?
-10017	WARN	(Cross-Domain JavaScript Source File Inclusion)

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -36,6 +36,7 @@ FROM docker.io/library/nginx:stable-alpine
 
 # Copy application sources
 COPY ./openshift/nginx.conf /etc/nginx/nginx.conf
+COPY ./openshift/security-headers.conf /etc/nginx/security-headers.conf
 
 # Copy the static content:
 COPY --from=static /app/apps/wps-web/build .

--- a/openshift/nginx.conf
+++ b/openshift/nginx.conf
@@ -23,14 +23,14 @@ http {
         root /;
         index index.html
 
+        # Hide the nginx version from the Server response header.
+        # https://www.zaproxy.org/docs/alerts/10036/
+        server_tokens off;
+
         gzip on;
         # By default, NGINX compresses responses only with MIME type text/html.
         gzip_types application/javascript application/json text/css;
 
-        # force https.
-        add_header Content-Security-Policy upgrade-insecure-requests;
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-        add_header X-Frame-Options DENY;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
         add_header X-Content-Type-Options nosniff;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
@@ -41,10 +41,23 @@ http {
         # # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma
         add_header Pragma no-cache;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-        # unpkg.com; - leaflet
-        add_header Content-Security-Policy "default-src 'unsafe-inline' *.googleapis.com *.gov.bc.ca *.gstatic.com unpkg.com; img-src *.gov.bc.ca blob: data: https:; script-src 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; frame-ancestors 'none'";
+        # default-src: self + Google Fonts, BC gov subdomains
+        # img-src: same, plus blob/data URIs
+        # connect-src: self, plus (Keycloak, ArcGIS, object storage)
+        # script-src/style-src/font-src: self + CDNs
+        # frame-ancestors 'none': equivalent of X-Frame-Options DENY
+        add_header Content-Security-Policy "default-src 'self' *.googleapis.com *.gov.bc.ca *.gstatic.com; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; style-src 'self' 'unsafe-inline' *.googleapis.com; font-src 'self' *.gstatic.com data:; frame-ancestors 'none'; upgrade-insecure-requests" always;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-        add_header X-Frame-Options DENY;
+        add_header X-Frame-Options DENY always;
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+        # https://www.zaproxy.org/docs/alerts/10035/
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy
+        # https://www.zaproxy.org/docs/alerts/10063/
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        # https://www.zaproxy.org/docs/alerts/90004/
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
 
         location / {
             # First attempt to serve request as file, then
@@ -62,17 +75,11 @@ http {
             return 200 "ready\n";
         }
 
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
-        location ~* \.(?:css|js|png|xml|svg|json|txt|html|htm)$ {            
-          add_header X-Content-Type-Options "nosniff";
-        }
-
-        # It's useful to cache some things - so let's create some exceptions.
+        # It's useful to cache some things.
         location ~* \.(?:woff2|png|js|css|svg)$ {
             expires 30d;
             etag off;
             if_modified_since off;
-            add_header Cache-Control "public, no-transform";
         }
 
     }

--- a/openshift/nginx.conf
+++ b/openshift/nginx.conf
@@ -41,6 +41,13 @@ http {
             # First attempt to serve request as file, then
             # as directory, then fall back to redirecting to index.html
             try_files $uri $uri/ $uri.html /index.html;
+
+            # Substitute a fresh per-request nonce into index.html's meta tag, matching
+            # the style-src nonce in the CSP header for this same response (both use
+            # $request_id). sub_filter_once off in case the placeholder appears more
+            # than once (e.g. an un-minified build).
+            sub_filter_once off;
+            sub_filter '__CSP_NONCE__' $request_id;
         }
 
         # We don't publish either of these.

--- a/openshift/nginx.conf
+++ b/openshift/nginx.conf
@@ -64,7 +64,7 @@ http {
 
         # It's useful to cache some things - so let's create some exceptions.
         # NOTE: an add_header here means this location does NOT inherit the server
-        # block's add_headers above (nginx quirk) - so security-headers.conf is
+        # block's add_headers above (nginx quirk) so security-headers.conf is
         # re-included here too, alongside a cacheable Cache-Control instead of
         # the no-store one set at the server level.
         location ~* \.(?:woff2|png|js|css|svg)$ {

--- a/openshift/nginx.conf
+++ b/openshift/nginx.conf
@@ -21,7 +21,7 @@ http {
         # listen on port 3000
         listen 3000;
         root /;
-        index index.html
+        index index.html;
 
         # Hide the nginx version from the Server response header.
         # https://www.zaproxy.org/docs/alerts/10036/

--- a/openshift/nginx.conf
+++ b/openshift/nginx.conf
@@ -31,31 +31,11 @@ http {
         # By default, NGINX compresses responses only with MIME type text/html.
         gzip_types application/javascript application/json text/css;
 
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
-        add_header X-Content-Type-Options nosniff;
+        include /etc/nginx/security-headers.conf;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
         # https://www.zaproxy.org/docs/alerts/10015/
         # By default - cache nothing.
         add_header Cache-Control "no-cache, no-store, must-revalidate";
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-        # default-src: self + BC gov subdomains
-        # img-src: same, plus blob/data URIs
-        # connect-src: self, plus (Keycloak, ArcGIS, object storage)
-        # script-src/style-src: self + CDNs
-        # frame-ancestors 'none': equivalent of X-Frame-Options DENY
-        # report-uri: sends a JSON report to Sentry on every violation
-        add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-        add_header X-Frame-Options DENY always;
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
-        # https://www.zaproxy.org/docs/alerts/10035/
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy
-        # https://www.zaproxy.org/docs/alerts/10063/
-        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-        # https://www.zaproxy.org/docs/alerts/90004/
-        add_header Cross-Origin-Opener-Policy "same-origin" always;
-        add_header Cross-Origin-Resource-Policy "same-origin" always;
 
         location / {
             # First attempt to serve request as file, then
@@ -82,11 +62,17 @@ http {
             return 200 "ready\n";
         }
 
-        # It's useful to cache some things.
+        # It's useful to cache some things - so let's create some exceptions.
+        # NOTE: an add_header here means this location does NOT inherit the server
+        # block's add_headers above (nginx quirk) - so security-headers.conf is
+        # re-included here too, alongside a cacheable Cache-Control instead of
+        # the no-store one set at the server level.
         location ~* \.(?:woff2|png|js|css|svg)$ {
-            expires 30d;
             etag off;
             if_modified_since off;
+
+            include /etc/nginx/security-headers.conf;
+            add_header Cache-Control "public, max-age=2592000, no-transform";
         }
 
     }

--- a/openshift/nginx.conf
+++ b/openshift/nginx.conf
@@ -41,12 +41,12 @@ http {
         # # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma
         add_header Pragma no-cache;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-        # default-src: self + Google Fonts, BC gov subdomains
+        # default-src: self + BC gov subdomains
         # img-src: same, plus blob/data URIs
         # connect-src: self, plus (Keycloak, ArcGIS, object storage)
-        # script-src/style-src/font-src: self + CDNs
+        # script-src/style-src: self + CDNs
         # frame-ancestors 'none': equivalent of X-Frame-Options DENY
-        add_header Content-Security-Policy "default-src 'self' *.googleapis.com *.gov.bc.ca *.gstatic.com; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; style-src 'self' 'unsafe-inline' *.googleapis.com; font-src 'self' *.gstatic.com data:; frame-ancestors 'none'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
         add_header X-Frame-Options DENY always;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

--- a/openshift/nginx.conf
+++ b/openshift/nginx.conf
@@ -37,9 +37,6 @@ http {
         # https://www.zaproxy.org/docs/alerts/10015/
         # By default - cache nothing.
         add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache;";
-        # # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma
-        add_header Pragma no-cache;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
         # default-src: self + BC gov subdomains
         # img-src: same, plus blob/data URIs
@@ -47,7 +44,7 @@ http {
         # script-src/style-src: self + CDNs
         # frame-ancestors 'none': equivalent of X-Frame-Options DENY
         # report-uri: sends a JSON report to Sentry on every violation
-        add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+        add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
         add_header X-Frame-Options DENY always;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
@@ -64,6 +61,15 @@ http {
             # First attempt to serve request as file, then
             # as directory, then fall back to redirecting to index.html
             try_files $uri $uri/ $uri.html /index.html;
+        }
+
+        # We don't publish either of these.
+        location = /robots.txt {
+            return 404;
+        }
+
+        location = /sitemap.xml {
+            return 404;
         }
 
         location /health {

--- a/openshift/nginx.conf
+++ b/openshift/nginx.conf
@@ -46,7 +46,8 @@ http {
         # connect-src: self, plus (Keycloak, ArcGIS, object storage)
         # script-src/style-src: self + CDNs
         # frame-ancestors 'none': equivalent of X-Frame-Options DENY
-        add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
+        # report-uri: sends a JSON report to Sentry on every violation
+        add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
         add_header X-Frame-Options DENY always;
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

--- a/openshift/security-headers.conf
+++ b/openshift/security-headers.conf
@@ -3,7 +3,7 @@
 # location drops all add_headers inherited from its parent (nginx quirk).
 # Cache-Control is NOT here since it differs between those two contexts.
 add_header X-Content-Type-Options nosniff;
-add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
 add_header X-Frame-Options DENY always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;

--- a/openshift/security-headers.conf
+++ b/openshift/security-headers.conf
@@ -3,7 +3,7 @@
 # location drops all add_headers inherited from its parent (nginx quirk).
 # Cache-Control is NOT here since it differs between those two contexts.
 add_header X-Content-Type-Options nosniff;
-add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
 add_header X-Frame-Options DENY always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;

--- a/openshift/security-headers.conf
+++ b/openshift/security-headers.conf
@@ -4,9 +4,14 @@
 # Cache-Control is NOT here since it differs between those two contexts.
 #
 # style-src carries a nonce (matched to sub_filter's substitution into index.html, see
-# nginx.conf) so Emotion's injected <style> tags satisfy CSP without 'unsafe-inline'.
+# nginx.conf) so Emotion's injected <style> tags satisfy CSP without 'unsafe-inline'. A
+# nonce can't attach to inline style="..." attribute mutations though (confirmed live on
+# FireBehaviourAdvisoryPage - OpenLayers positions map elements via direct style attribute
+# writes, e.g. transform, with values that change on every pan/zoom - not hashable), so
+# style-src-attr allows 'unsafe-inline' narrowly for just that sub-case. style-src-elem
+# still governs <style> tags via the nonce, unaffected by this.
 add_header X-Content-Type-Options nosniff;
-add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'nonce-$request_id' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'nonce-$request_id' cdn.jsdelivr.net; style-src-attr 'unsafe-inline'; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
 add_header X-Frame-Options DENY always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;

--- a/openshift/security-headers.conf
+++ b/openshift/security-headers.conf
@@ -3,7 +3,7 @@
 # location drops all add_headers inherited from its parent (nginx quirk).
 # Cache-Control is NOT here since it differs between those two contexts.
 add_header X-Content-Type-Options nosniff;
-add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'nonce-$request_id' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
 add_header X-Frame-Options DENY always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;

--- a/openshift/security-headers.conf
+++ b/openshift/security-headers.conf
@@ -3,7 +3,7 @@
 # location drops all add_headers inherited from its parent (nginx quirk).
 # Cache-Control is NOT here since it differs between those two contexts.
 add_header X-Content-Type-Options nosniff;
-add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
 add_header X-Frame-Options DENY always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;

--- a/openshift/security-headers.conf
+++ b/openshift/security-headers.conf
@@ -4,12 +4,9 @@
 # Cache-Control is NOT here since it differs between those two contexts.
 #
 # style-src carries a nonce (matched to sub_filter's substitution into index.html, see
-# nginx.conf) so Emotion's injected <style> tags satisfy CSP without 'unsafe-inline'. A
-# nonce can't attach to inline style="..." attribute mutations though (e.g. OpenLayers
-# positioning DOM elements directly), so style-src-attr allows 'unsafe-inline' narrowly
-# for just that sub-case - style-src-elem still governs <style> tags via the nonce.
+# nginx.conf) so Emotion's injected <style> tags satisfy CSP without 'unsafe-inline'.
 add_header X-Content-Type-Options nosniff;
-add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'nonce-$request_id' cdn.jsdelivr.net; style-src-attr 'unsafe-inline'; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'nonce-$request_id' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
 add_header X-Frame-Options DENY always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;

--- a/openshift/security-headers.conf
+++ b/openshift/security-headers.conf
@@ -1,0 +1,11 @@
+# Shared security headers used in both the server block and the
+# static-asset caching location in nginx.conf, since an add_header in a
+# location drops all add_headers inherited from its parent (nginx quirk).
+# Cache-Control is NOT here since it differs between those two contexts.
+add_header X-Content-Type-Options nosniff;
+add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: https:; connect-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+add_header X-Frame-Options DENY always;
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;

--- a/openshift/security-headers.conf
+++ b/openshift/security-headers.conf
@@ -2,8 +2,14 @@
 # static-asset caching location in nginx.conf, since an add_header in a
 # location drops all add_headers inherited from its parent (nginx quirk).
 # Cache-Control is NOT here since it differs between those two contexts.
+#
+# style-src carries a nonce (matched to sub_filter's substitution into index.html, see
+# nginx.conf) so Emotion's injected <style> tags satisfy CSP without 'unsafe-inline'. A
+# nonce can't attach to inline style="..." attribute mutations though (e.g. OpenLayers
+# positioning DOM elements directly), so style-src-attr allows 'unsafe-inline' narrowly
+# for just that sub-case - style-src-elem still governs <style> tags via the nonce.
 add_header X-Content-Type-Options nosniff;
-add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'nonce-$request_id' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
+add_header Content-Security-Policy "default-src 'self' *.gov.bc.ca; img-src *.gov.bc.ca blob: data: *.arcgis.com; connect-src 'self' *.gov.bc.ca *.arcgis.com o4507136969932800.ingest.us.sentry.io; script-src 'self' *.gov.bc.ca; worker-src 'self' blob:; style-src 'self' 'nonce-$request_id' cdn.jsdelivr.net; style-src-attr 'unsafe-inline'; font-src 'self' cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; report-uri https://o4507136969932800.ingest.us.sentry.io/api/4507138123890688/security/?sentry_key=1c1a6c9201d925e952231833bc0f3823" always;
 add_header X-Frame-Options DENY always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;

--- a/web/apps/wps-web/index.html
+++ b/web/apps/wps-web/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="csp-nonce" content="__CSP_NONCE__" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/images/bcid-apple-touch-icon.png" sizes="180x180" />
     <link rel="mask-icon" href="/images/bcid-apple-icon.svg" color="#036" />

--- a/web/apps/wps-web/index.html
+++ b/web/apps/wps-web/index.html
@@ -11,7 +11,6 @@
     <link rel="mask-icon" href="/images/bcid-apple-icon.svg" color="#036" />
     <link rel="icon" href="/images/bcid-favicon-32x32.png" sizes="32x32" type="image/png" />
     <link rel="icon" href="/images/bcid-favicon-16x16.png" sizes="16x16" type="image/png" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <title>BC Wildfire Predictive Services</title>
   </head>
   <body>

--- a/web/apps/wps-web/index.html
+++ b/web/apps/wps-web/index.html
@@ -2,10 +2,6 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/images/bcid-apple-touch-icon.png" sizes="180x180" />
     <link rel="mask-icon" href="/images/bcid-apple-icon.svg" color="#036" />

--- a/web/apps/wps-web/package.json
+++ b/web/apps/wps-web/package.json
@@ -14,6 +14,7 @@
     }
   ],
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "@mui/icons-material": "^9.0.0",

--- a/web/apps/wps-web/src/app/App.tsx
+++ b/web/apps/wps-web/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { CssBaseline } from '@mui/material'
-import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles'
+import { ThemeProvider } from '@mui/material/styles'
 import { LicenseInfo } from '@mui/x-license'
 import { theme } from '@wps/ui/theme'
 import { MUI_LICENSE } from '@wps/utils/env'
@@ -10,12 +10,12 @@ LicenseInfo.setLicenseKey(MUI_LICENSE)
 
 const App: React.FunctionComponent = () => {
   return (
-    <StyledEngineProvider injectFirst>
+    <>
       <CssBaseline />
       <ThemeProvider theme={theme}>
         <WPSRoutes />
       </ThemeProvider>
-    </StyledEngineProvider>
+    </>
   )
 }
 

--- a/web/apps/wps-web/src/features/fba/components/viz/FuelSummary.tsx
+++ b/web/apps/wps-web/src/features/fba/components/viz/FuelSummary.tsx
@@ -7,6 +7,7 @@ import {
   type GridRenderCellParams
 } from '@mui/x-data-grid-pro'
 import type { FireShape, FireZoneFuelStats } from '@wps/api/fbaAPI'
+import { CSP_NONCE } from '@wps/utils/env'
 import CriticalHours from 'features/fba/components/viz/CriticalHours'
 import FuelDistribution from 'features/fba/components/viz/FuelDistribution'
 import { groupBy, isUndefined } from 'lodash'
@@ -125,6 +126,7 @@ const FuelSummary = ({ fireZoneFuelStats, selectedFireZoneUnit }: FuelSummaryPro
         <Typography>No fuel type information available.</Typography>
       ) : (
         <DataGridPro
+          nonce={CSP_NONCE}
           columns={columns}
           density="compact"
           disableColumnMenu

--- a/web/apps/wps-web/src/features/fbaCalculator/components/FBAProgressRow.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/FBAProgressRow.tsx
@@ -1,4 +1,4 @@
-import { createTheme, LinearProgress, StyledEngineProvider, TableCell, TableRow, ThemeProvider } from '@mui/material'
+import { createTheme, LinearProgress, TableCell, TableRow, ThemeProvider } from '@mui/material'
 import { theme } from '@wps/ui/theme'
 
 import React from 'react'
@@ -26,15 +26,13 @@ const FBAProgressRow = (props: FBAProgressRowProps) => {
   return (
     <React.Fragment>
       {props.loading && (
-        <StyledEngineProvider injectFirst>
-          <ThemeProvider theme={adjustedTheme}>
-            <TableRow data-testid="progress-row-fba">
-              <TableCell colSpan={21} padding="none" data-testid="progress-row-cell-fba">
-                <LinearProgress />
-              </TableCell>
-            </TableRow>
-          </ThemeProvider>
-        </StyledEngineProvider>
+        <ThemeProvider theme={adjustedTheme}>
+          <TableRow data-testid="progress-row-fba">
+            <TableCell colSpan={21} padding="none" data-testid="progress-row-cell-fba">
+              <LinearProgress />
+            </TableCell>
+          </TableRow>
+        </ThemeProvider>
       )}
     </React.Fragment>
   )

--- a/web/apps/wps-web/src/features/fbaCalculator/components/WindSpeedCell.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/WindSpeedCell.tsx
@@ -1,23 +1,11 @@
 import { TextField, Tooltip } from '@mui/material'
-import { styled, ThemeProvider } from '@mui/material/styles'
+import { ThemeProvider } from '@mui/material/styles'
 import { adjustedTheme } from '@wps/ui/theme'
 import type { FBATableRow } from 'features/fbaCalculator/RowManager'
 import { buildUpdatedNumberRow, updateFBARow } from 'features/fbaCalculator/tableState'
 import { isWindSpeedInvalid } from 'features/fbaCalculator/validation'
 import { isEqual, isNil, isUndefined } from 'lodash'
 import React, { type ChangeEvent, useEffect, useState } from 'react'
-
-const PREFIX = 'WindSpeedCell'
-
-const classes = {
-  windSpeed: `${PREFIX}-windSpeed`
-}
-
-const StyledThemeProvider = styled(ThemeProvider)({
-  [`& .${classes.windSpeed}`]: {
-    width: 80
-  }
-})
 
 export interface WindSpeedCellProps {
   inputRows: FBATableRow[]
@@ -75,7 +63,7 @@ const WindSpeedCell = (props: WindSpeedCellProps) => {
         data-testid={`windSpeedInput-fba-${props.rowId}`}
         type="number"
         inputMode="numeric"
-        className={classes.windSpeed}
+        sx={{ width: 80 }}
         size="small"
         variant="outlined"
         onChange={changeHandler}
@@ -95,7 +83,7 @@ const WindSpeedCell = (props: WindSpeedCellProps) => {
     return buildTextField()
   }
 
-  return <StyledThemeProvider theme={adjustedTheme}>{buildTextField()}</StyledThemeProvider>
+  return <ThemeProvider theme={adjustedTheme}>{buildTextField()}</ThemeProvider>
 }
 
 export default React.memo(WindSpeedCell)

--- a/web/apps/wps-web/src/features/fbaCalculator/components/WindSpeedCell.tsx
+++ b/web/apps/wps-web/src/features/fbaCalculator/components/WindSpeedCell.tsx
@@ -1,5 +1,5 @@
 import { TextField, Tooltip } from '@mui/material'
-import { StyledEngineProvider, styled, ThemeProvider } from '@mui/material/styles'
+import { styled, ThemeProvider } from '@mui/material/styles'
 import { adjustedTheme } from '@wps/ui/theme'
 import type { FBATableRow } from 'features/fbaCalculator/RowManager'
 import { buildUpdatedNumberRow, updateFBARow } from 'features/fbaCalculator/tableState'
@@ -13,7 +13,7 @@ const classes = {
   windSpeed: `${PREFIX}-windSpeed`
 }
 
-const StyledStyledEngineProvider = styled(StyledEngineProvider)({
+const StyledThemeProvider = styled(ThemeProvider)({
   [`& .${classes.windSpeed}`]: {
     width: 80
   }
@@ -95,11 +95,7 @@ const WindSpeedCell = (props: WindSpeedCellProps) => {
     return buildTextField()
   }
 
-  return (
-    <StyledStyledEngineProvider injectFirst>
-      <ThemeProvider theme={adjustedTheme}>{buildTextField()}</ThemeProvider>
-    </StyledStyledEngineProvider>
-  )
+  return <StyledThemeProvider theme={adjustedTheme}>{buildTextField()}</StyledThemeProvider>
 }
 
 export default React.memo(WindSpeedCell)

--- a/web/apps/wps-web/src/features/fireWatch/components/DetailPanelContent.tsx
+++ b/web/apps/wps-web/src/features/fireWatch/components/DetailPanelContent.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography } from '@mui/material'
 import { DataGridPro, type GridColDef, type GridRenderCellParams } from '@mui/x-data-grid-pro'
 import { theme } from '@wps/ui/theme'
+import { CSP_NONCE } from '@wps/utils/env'
 import { isNull } from 'lodash'
 import type { DateTime } from 'luxon'
 import type { BurnForecast, BurnWatchRow } from '@/features/fireWatch/interfaces'
@@ -109,6 +110,7 @@ const DetailPanelContent = ({ row }: DetailPanelContentProps) => {
       {row.burnForecasts.length > 0 && (
         <Box data-testid={`detail-panel-content-${row.id}`}>
           <DataGridPro
+            nonce={CSP_NONCE}
             disableVirtualization
             density="compact"
             disableRowSelectionOnClick

--- a/web/apps/wps-web/src/features/fireWatch/components/FireWatchDashboard.tsx
+++ b/web/apps/wps-web/src/features/fireWatch/components/FireWatchDashboard.tsx
@@ -8,6 +8,7 @@ import PlayCircleIcon from '@mui/icons-material/PlayCircle'
 import { Alert, Backdrop, Box, CircularProgress, Snackbar, Tooltip, Typography, useTheme } from '@mui/material'
 import { DataGridPro, type DataGridProProps, GridActionsCellItem, type GridColDef } from '@mui/x-data-grid-pro'
 import { FireWatchPrescriptionColors } from '@wps/ui/theme'
+import { CSP_NONCE } from '@wps/utils/env'
 import { upperFirst } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -193,6 +194,7 @@ const FireWatchDashboard = () => {
       </Backdrop>
       <Box sx={{ padding: theme.spacing(2) }}>
         <DataGridPro
+          nonce={CSP_NONCE}
           density="compact"
           getRowId={row => row.id}
           processRowUpdate={processRowUpdate}

--- a/web/apps/wps-web/src/features/hfiCalculator/components/ErrorIconWithTooltip.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/ErrorIconWithTooltip.tsx
@@ -1,5 +1,5 @@
 import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined'
-import { createTheme, StyledEngineProvider, ThemeProvider, Tooltip } from '@mui/material'
+import { createTheme, ThemeProvider, Tooltip } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { BACKGROUND_COLOR, PLANNING_AREA } from '@wps/ui/theme'
 import { isUndefined } from 'lodash'
@@ -55,13 +55,11 @@ const ErrorIconWithTooltip = (props: ErrorIconWithTooltipProps) => {
       </DataCellIcon>
     )
   return (
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={errorIconTheme}>
-        <Tooltip title={props.tooltipElement} aria-label={`${props.tooltipAriaText.join('\n')}`}>
-          {icon}
-        </Tooltip>
-      </ThemeProvider>
-    </StyledEngineProvider>
+    <ThemeProvider theme={errorIconTheme}>
+      <Tooltip title={props.tooltipElement} aria-label={`${props.tooltipAriaText.join('\n')}`}>
+        {icon}
+      </Tooltip>
+    </ThemeProvider>
   )
 }
 

--- a/web/apps/wps-web/src/features/hfiCalculator/components/LastUpdatedHeader.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/LastUpdatedHeader.tsx
@@ -1,5 +1,5 @@
 import UpdateIcon from '@mui/icons-material/Update'
-import { createTheme, StyledEngineProvider, ThemeProvider } from '@mui/material'
+import { createTheme, ThemeProvider } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import type { StationDaily } from '@wps/api/hfiCalculatorAPI'
 import { theme } from '@wps/ui/theme'
@@ -60,14 +60,12 @@ const LastUpdatedHeader = (props: LastUpdatedHeaderProps) => {
     const dateString = `${lastUpdate.toFormat('MMMM d, HH:mm')} PST`
 
     return (
-      <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={lastUpdatedTheme}>
-          <Container>
-            <UpdateIcon></UpdateIcon>
-            <HeaderText>Forecast last updated {dateString}</HeaderText>
-          </Container>
-        </ThemeProvider>
-      </StyledEngineProvider>
+      <ThemeProvider theme={lastUpdatedTheme}>
+        <Container>
+          <UpdateIcon></UpdateIcon>
+          <HeaderText>Forecast last updated {dateString}</HeaderText>
+        </Container>
+      </ThemeProvider>
     )
   } else {
     return <div></div>

--- a/web/apps/wps-web/src/features/hfiCalculator/components/PlanningAreaReadyToggle.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/PlanningAreaReadyToggle.tsx
@@ -1,6 +1,6 @@
 import ToggleOffOutlinedIcon from '@mui/icons-material/ToggleOffOutlined'
 import ToggleOnOutlinedIcon from '@mui/icons-material/ToggleOnOutlined'
-import { createTheme, IconButton, StyledEngineProvider, ThemeProvider, Tooltip } from '@mui/material'
+import { createTheme, IconButton, ThemeProvider, Tooltip } from '@mui/material'
 import type { ReadyPlanningAreaDetails } from '@wps/api/hfiCalculatorAPI'
 import { isUndefined } from 'lodash'
 import React from 'react'
@@ -28,30 +28,28 @@ const PlanningAreaReadyToggle = ({ enabled, loading, readyDetails, toggleReady }
     ? `Marked ready by ${readyDetails?.update_user} at ${readyDetails?.update_timestamp.toISO()}`
     : ''
   return (
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={toggleReadyTheme}>
-        <Tooltip data-testid="hfi-ready-tooltip" title={toolTipText} aria-label={toolTipText}>
-          <span>
-            <IconButton
-              aria-label="hfi-toggle-ready"
-              data-testid="hfi-toggle-ready"
-              disabled={!enabled || loading || isUndefined(readyDetails)}
-              onClick={() => {
-                if (!isUndefined(readyDetails)) {
-                  toggleReady(readyDetails.planning_area_id)
-                }
-              }}
-            >
-              {readyDetails?.ready ? (
-                <ToggleOnOutlinedIcon fontSize="large" color="success" />
-              ) : (
-                <ToggleOffOutlinedIcon fontSize="large" />
-              )}
-            </IconButton>
-          </span>
-        </Tooltip>
-      </ThemeProvider>
-    </StyledEngineProvider>
+    <ThemeProvider theme={toggleReadyTheme}>
+      <Tooltip data-testid="hfi-ready-tooltip" title={toolTipText} aria-label={toolTipText}>
+        <span>
+          <IconButton
+            aria-label="hfi-toggle-ready"
+            data-testid="hfi-toggle-ready"
+            disabled={!enabled || loading || isUndefined(readyDetails)}
+            onClick={() => {
+              if (!isUndefined(readyDetails)) {
+                toggleReady(readyDetails.planning_area_id)
+              }
+            }}
+          >
+            {readyDetails?.ready ? (
+              <ToggleOnOutlinedIcon fontSize="large" color="success" />
+            ) : (
+              <ToggleOffOutlinedIcon fontSize="large" />
+            )}
+          </IconButton>
+        </span>
+      </Tooltip>
+    </ThemeProvider>
   )
 }
 

--- a/web/apps/wps-web/src/features/hfiCalculator/components/PrepDateRangeSelector.tsx
+++ b/web/apps/wps-web/src/features/hfiCalculator/components/PrepDateRangeSelector.tsx
@@ -1,14 +1,5 @@
 import * as materialIcons from '@mui/icons-material'
-import {
-  Button,
-  createTheme,
-  Dialog,
-  Icon,
-  InputAdornment,
-  StyledEngineProvider,
-  TextField,
-  ThemeProvider
-} from '@mui/material'
+import { Button, createTheme, Dialog, Icon, InputAdornment, TextField, ThemeProvider } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import type { PrepDateRange } from '@wps/api/hfiCalculatorAPI'
 import DateRangePickerWrapper from '@wps/ui/dateRangePicker/DateRangePickerWrapper'
@@ -92,46 +83,44 @@ const PrepDateRangeSelector = ({ dateRange, setDateRange }: PrepDateRangeSelecto
 
   return (
     <div>
-      <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={dateRangePickerTheme}>
-          <Button
-            sx={{ textTransform: 'capitalize' }}
-            data-testid="date-range-picker-button"
-            onClick={() => setDateRangePickerOpen(!dateRangePickerOpen)}
-          >
-            <DateRangePickerTextField
-              data-testid="date-range-picker-text-field"
-              size="small"
-              id="outlined-basic"
-              variant="outlined"
-              disabled={true}
-              label={'Set prep period'}
-              sx={{ pointerEvents: 'none' }}
-              value={
-                isUndefined(dateRange) || isUndefined(dateRange.start_date) || isUndefined(dateRange.end_date)
-                  ? ''
-                  : `${DateTime.fromISO(dateRange.start_date).toFormat(dateDisplayFormat).trim()} - ${DateTime.fromISO(
-                      dateRange.end_date
-                    )
-                      .toFormat(dateDisplayFormat)
-                      .trim()}
-                            `
-              }
-              slotProps={{
-                input: {
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <Icon>
-                        <materialIcons.DateRange />
-                      </Icon>
-                    </InputAdornment>
+      <ThemeProvider theme={dateRangePickerTheme}>
+        <Button
+          sx={{ textTransform: 'capitalize' }}
+          data-testid="date-range-picker-button"
+          onClick={() => setDateRangePickerOpen(!dateRangePickerOpen)}
+        >
+          <DateRangePickerTextField
+            data-testid="date-range-picker-text-field"
+            size="small"
+            id="outlined-basic"
+            variant="outlined"
+            disabled={true}
+            label={'Set prep period'}
+            sx={{ pointerEvents: 'none' }}
+            value={
+              isUndefined(dateRange) || isUndefined(dateRange.start_date) || isUndefined(dateRange.end_date)
+                ? ''
+                : `${DateTime.fromISO(dateRange.start_date).toFormat(dateDisplayFormat).trim()} - ${DateTime.fromISO(
+                    dateRange.end_date
                   )
-                }
-              }}
-            />
-          </Button>
-        </ThemeProvider>
-      </StyledEngineProvider>
+                    .toFormat(dateDisplayFormat)
+                    .trim()}
+                            `
+            }
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Icon>
+                      <materialIcons.DateRange />
+                    </Icon>
+                  </InputAdornment>
+                )
+              }
+            }}
+          />
+        </Button>
+      </ThemeProvider>
       <Dialog open={dateRangePickerOpen} onClose={toggleDateRangePicker}>
         <DateRangePickerWrapper
           initialDateRange={{ startDate, endDate }}

--- a/web/apps/wps-web/src/features/moreCast2/components/ForecastDataGrid.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/ForecastDataGrid.tsx
@@ -16,6 +16,7 @@ import {
   type MoreCastModelColors,
   type MoreCastParams
 } from '@wps/ui/theme'
+import { CSP_NONCE } from '@wps/utils/env'
 import { PINNED_COLUMNS } from 'features/moreCast2/components/ColumnDefBuilder'
 import { DataGridColumns } from 'features/moreCast2/components/DataGridColumns'
 import type { ColumnClickHandlerProps } from 'features/moreCast2/components/TabbedDataGrid'
@@ -102,6 +103,7 @@ const ForecastDataGrid = ({
   return (
     <Root className={classes.root} data-testid={`morecast2-data-grid`}>
       <DataGridPro
+        nonce={CSP_NONCE}
         getCellClassName={params => {
           return params.field.endsWith('Forecast') || params.field.endsWith('Actual') ? 'forecastCell' : ''
         }}

--- a/web/apps/wps-web/src/features/moreCast2/components/ForecastSummaryDataGrid.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/ForecastSummaryDataGrid.tsx
@@ -3,6 +3,7 @@ import { styled } from '@mui/material/styles'
 import { DataGridPro, type GridCellParams, type GridEventListener } from '@mui/x-data-grid-pro'
 import { ModelChoice } from '@wps/api/moreCast2API'
 import { MORECAST_WEATHER_PARAMS, type MoreCastParams, theme } from '@wps/ui/theme'
+import { CSP_NONCE } from '@wps/utils/env'
 import { PINNED_COLUMNS } from 'features/moreCast2/components/ColumnDefBuilder'
 import { DataGridColumns, getSummaryColumnGroupModel } from 'features/moreCast2/components/DataGridColumns'
 import { MORECAST2_INDEX_FIELDS } from 'features/moreCast2/components/MoreCast2Column'
@@ -71,6 +72,7 @@ const ForecastSummaryDataGrid = ({
   return (
     <Root className={classes.root} data-testid={`morecast2-data-grid`}>
       <DataGridPro
+        nonce={CSP_NONCE}
         getCellClassName={params => {
           return params.field.endsWith('Forecast') || params.field.endsWith('Actual') ? 'forecastCell' : ''
         }}

--- a/web/apps/wps-web/src/features/moreCast2/components/MoreCast2DateRangePicker.tsx
+++ b/web/apps/wps-web/src/features/moreCast2/components/MoreCast2DateRangePicker.tsx
@@ -1,4 +1,4 @@
-import { Box, createTheme, StyledEngineProvider, ThemeProvider } from '@mui/material'
+import { Box, createTheme, ThemeProvider } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import DateRangeSelector from '@wps/ui/DateRangeSelector'
 import type { DateRange } from '@wps/ui/dateRangePicker/types'
@@ -56,20 +56,18 @@ export const dateRangePickerTheme = createTheme({
 const MoreCase2DateRangePicker = ({ dateRange, setDateRange }: MoreCase2DateRangePickerProps) => {
   return (
     <StyledBox className={classes.container}>
-      <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={dateRangePickerTheme}>
-          <DateRangeSelector
-            dateRange={dateRange}
-            minDate={DateTime.now().toJSDate()}
-            maxDate={DateTime.now().plus({ days: 10 }).toJSDate()}
-            maxDayOffset={11}
-            dateDisplayFormat={'yyyy/MM/dd'}
-            setDateRange={setDateRange}
-            size="medium"
-            label={'Date Range'}
-          />
-        </ThemeProvider>
-      </StyledEngineProvider>
+      <ThemeProvider theme={dateRangePickerTheme}>
+        <DateRangeSelector
+          dateRange={dateRange}
+          minDate={DateTime.now().toJSDate()}
+          maxDate={DateTime.now().plus({ days: 10 }).toJSDate()}
+          maxDayOffset={11}
+          dateDisplayFormat={'yyyy/MM/dd'}
+          setDateRange={setDateRange}
+          size="medium"
+          label={'Date Range'}
+        />
+      </ThemeProvider>
     </StyledBox>
   )
 }

--- a/web/apps/wps-web/src/index.tsx
+++ b/web/apps/wps-web/src/index.tsx
@@ -15,7 +15,11 @@ import store from 'app/store'
 // response (see the __CSP_NONCE__ substitution in index.html and openshift/nginx.conf),
 // so Emotion's injected <style> tags satisfy CSP without needing 'unsafe-inline'.
 const cspNonce = document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content') ?? undefined
-const emotionCache = createCache({ key: 'css', nonce: cspNonce })
+// prepend: true replicates <StyledEngineProvider injectFirst> (MUI styles load first, so
+// app-level overrides win) - MUI's own CSP guide says to use this instead of
+// StyledEngineProvider once a custom/nonce-carrying cache is in play, since
+// StyledEngineProvider's injectFirst otherwise creates its own cache with no nonce.
+const emotionCache = createCache({ key: 'css', nonce: cspNonce, prepend: true })
 
 const render = () => {
   Sentry.init({

--- a/web/apps/wps-web/src/index.tsx
+++ b/web/apps/wps-web/src/index.tsx
@@ -1,6 +1,6 @@
 import createCache from '@emotion/cache'
 import { CacheProvider } from '@emotion/react'
-import { API_BASE_URL, SENTRY_DSN, SENTRY_ENV } from '@wps/utils/env'
+import { API_BASE_URL, CSP_NONCE, SENTRY_DSN, SENTRY_ENV } from '@wps/utils/env'
 import App from 'app/App'
 import * as ReactDOMClient from 'react-dom/client'
 import { Provider } from 'react-redux'
@@ -11,15 +11,11 @@ import { feedbackIntegration } from '@sentry/react'
 import { theme } from '@wps/ui/theme'
 import store from 'app/store'
 
-// Matches the style-src nonce nginx sets on the Content-Security-Policy header for this
-// response (see the __CSP_NONCE__ substitution in index.html and openshift/nginx.conf),
-// so Emotion's injected <style> tags satisfy CSP without needing 'unsafe-inline'.
-const cspNonce = document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content') ?? undefined
 // prepend: true replicates <StyledEngineProvider injectFirst> (MUI styles load first, so
 // app-level overrides win) - MUI's own CSP guide says to use this instead of
 // StyledEngineProvider once a custom/nonce-carrying cache is in play, since
 // StyledEngineProvider's injectFirst otherwise creates its own cache with no nonce.
-const emotionCache = createCache({ key: 'css', nonce: cspNonce, prepend: true })
+const emotionCache = createCache({ key: 'css', nonce: CSP_NONCE, prepend: true })
 
 const render = () => {
   Sentry.init({

--- a/web/apps/wps-web/src/index.tsx
+++ b/web/apps/wps-web/src/index.tsx
@@ -1,3 +1,5 @@
+import createCache from '@emotion/cache'
+import { CacheProvider } from '@emotion/react'
 import { API_BASE_URL, SENTRY_DSN, SENTRY_ENV } from '@wps/utils/env'
 import App from 'app/App'
 import * as ReactDOMClient from 'react-dom/client'
@@ -8,6 +10,12 @@ import * as Sentry from '@sentry/react'
 import { feedbackIntegration } from '@sentry/react'
 import { theme } from '@wps/ui/theme'
 import store from 'app/store'
+
+// Matches the style-src nonce nginx sets on the Content-Security-Policy header for this
+// response (see the __CSP_NONCE__ substitution in index.html and openshift/nginx.conf),
+// so Emotion's injected <style> tags satisfy CSP without needing 'unsafe-inline'.
+const cspNonce = document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content') ?? undefined
+const emotionCache = createCache({ key: 'css', nonce: cspNonce })
 
 const render = () => {
   Sentry.init({
@@ -44,9 +52,11 @@ const render = () => {
   }
   const root = ReactDOMClient.createRoot(container)
   root.render(
-    <Provider store={store}>
-      <App />
-    </Provider>
+    <CacheProvider value={emotionCache}>
+      <Provider store={store}>
+        <App />
+      </Provider>
+    </CacheProvider>
   )
 }
 

--- a/web/apps/wps-web/vite.config.ts
+++ b/web/apps/wps-web/vite.config.ts
@@ -25,9 +25,6 @@ export default defineConfig({
           /<meta name="viewport" content="width=device-width, initial-scale=1.0">/,
           `<meta name="viewport" content="width=device-width, initial-scale=1.0">
          <script src="config.js"></script>
-    <script type="text/javascript">
-      window.env = config
-    </script>
         `
         )
       }

--- a/web/packages/types/src/window.d.ts
+++ b/web/packages/types/src/window.d.ts
@@ -18,9 +18,9 @@ interface RuntimeEnv {
   REACT_APP_HILLSHADE_STYLE_URL: string
 }
 
-declare var env: RuntimeEnv
+declare var config: RuntimeEnv
 
 interface Window {
-  env: RuntimeEnv
+  config: RuntimeEnv
   Playwright: Record<string, unknown> | undefined
 }

--- a/web/packages/ui/src/FireTable.tsx
+++ b/web/packages/ui/src/FireTable.tsx
@@ -1,4 +1,4 @@
-import { Paper, StyledEngineProvider, Table, TableContainer, ThemeProvider } from '@mui/material'
+import { Paper, Table, TableContainer, ThemeProvider } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import React from 'react'
 import { fireTableTheme } from './theme'
@@ -26,15 +26,13 @@ interface FireTableProps {
 const FireTable = (props: FireTableProps) => {
   return (
     <StyledPaper elevation={1}>
-      <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={fireTableTheme}>
-          <TableContainer data-testid={'fire-table'} className={classes.tableContainer}>
-            <Table data-testid={props.testId} stickyHeader>
-              {props.children}
-            </Table>
-          </TableContainer>
-        </ThemeProvider>
-      </StyledEngineProvider>
+      <ThemeProvider theme={fireTableTheme}>
+        <TableContainer data-testid={'fire-table'} className={classes.tableContainer}>
+          <Table data-testid={props.testId} stickyHeader>
+            {props.children}
+          </Table>
+        </TableContainer>
+      </ThemeProvider>
     </StyledPaper>
   )
 }

--- a/web/packages/utils/src/env.ts
+++ b/web/packages/utils/src/env.ts
@@ -21,28 +21,28 @@ let ENV = {
 }
 // If the app is built using 'npm run build'
 if (import.meta.env.MODE === 'production') {
-  // globalThis.env is set in index.html, populated by env variables.
+  // globalThis.config is set by config.js, loaded in index.html.
   ENV = {
     // TODO: Figure out why axios goes to http on gets!
-    API_BASE_URL: env.API_BASE_URL ?? `${location.protocol}//${location.host}/api`,
-    RASTER_SERVER_BASE_URL: env.RASTER_SERVER_BASE_URL ?? `${location.protocol}//${location.host}`,
+    API_BASE_URL: config.API_BASE_URL ?? `${location.protocol}//${location.host}/api`,
+    RASTER_SERVER_BASE_URL: config.RASTER_SERVER_BASE_URL ?? `${location.protocol}//${location.host}`,
     HIDE_DISCLAIMER: undefined,
-    SM_LOGOUT_URL: env.REACT_APP_SM_LOGOUT_URL,
-    KC_AUTH_URL: env.REACT_APP_KEYCLOAK_AUTH_URL,
-    KC_REALM: env.REACT_APP_KEYCLOAK_REALM,
-    KC_CLIENT: env.REACT_APP_KEYCLOAK_CLIENT,
+    SM_LOGOUT_URL: config.REACT_APP_SM_LOGOUT_URL,
+    KC_AUTH_URL: config.REACT_APP_KEYCLOAK_AUTH_URL,
+    KC_REALM: config.REACT_APP_KEYCLOAK_REALM,
+    KC_CLIENT: config.REACT_APP_KEYCLOAK_CLIENT,
     TEST_AUTH: undefined,
-    MS_TEAMS_SPRINT_REVIEW_URL: env.REACT_APP_MS_TEAMS_SPRINT_REVIEW_URL,
-    SPRINT_REVIEW_BOARD_URL: env.REACT_APP_SPRINT_REVIEW_BOARD_URL,
-    PMTILES_BUCKET: env.REACT_APP_PMTILES_BUCKET,
-    MUI_LICENSE: env.REACT_APP_MUI_LICENSE_KEY,
-    SENTRY_DSN: env.REACT_APP_SENTRY_DSN,
-    SENTRY_ENV: env.REACT_APP_SENTRY_ENV,
-    PSU_BUCKET: env.REACT_APP_PSU_BUCKET,
-    BASEMAP_TILE_URL: env.REACT_APP_BASEMAP_TILE_URL,
-    BASEMAP_STYLE_URL: env.REACT_APP_BASEMAP_STYLE_URL,
-    HILLSHADE_TILE_URL: env.REACT_APP_HILLSHADE_TILE_URL,
-    HILLSHADE_STYLE_URL: env.REACT_APP_HILLSHADE_STYLE_URL
+    MS_TEAMS_SPRINT_REVIEW_URL: config.REACT_APP_MS_TEAMS_SPRINT_REVIEW_URL,
+    SPRINT_REVIEW_BOARD_URL: config.REACT_APP_SPRINT_REVIEW_BOARD_URL,
+    PMTILES_BUCKET: config.REACT_APP_PMTILES_BUCKET,
+    MUI_LICENSE: config.REACT_APP_MUI_LICENSE_KEY,
+    SENTRY_DSN: config.REACT_APP_SENTRY_DSN,
+    SENTRY_ENV: config.REACT_APP_SENTRY_ENV,
+    PSU_BUCKET: config.REACT_APP_PSU_BUCKET,
+    BASEMAP_TILE_URL: config.REACT_APP_BASEMAP_TILE_URL,
+    BASEMAP_STYLE_URL: config.REACT_APP_BASEMAP_STYLE_URL,
+    HILLSHADE_TILE_URL: config.REACT_APP_HILLSHADE_TILE_URL,
+    HILLSHADE_STYLE_URL: config.REACT_APP_HILLSHADE_STYLE_URL
   }
 }
 

--- a/web/packages/utils/src/env.ts
+++ b/web/packages/utils/src/env.ts
@@ -1,3 +1,10 @@
+// Set by nginx's sub_filter substituting a fresh value into index.html's meta tag on
+// every request, matching the style-src nonce on the Content-Security-Policy header for
+// that same response (see openshift/nginx.conf). Shared here since several components
+// (e.g. DataGridPro, which injects its own <style> tags outside Emotion's cache) need
+// this same nonce value passed to them directly, not just the root Emotion cache.
+export const CSP_NONCE = document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content') ?? undefined
+
 let ENV = {
   API_BASE_URL: import.meta.env.VITE_API_BASE_URL as string,
   RASTER_SERVER_BASE_URL: import.meta.env.VITE_RASTER_SERVER_BASE_URL as string,

--- a/web/packages/utils/src/env.ts
+++ b/web/packages/utils/src/env.ts
@@ -3,7 +3,10 @@
 // that same response (see openshift/nginx.conf). Shared here since several components
 // (e.g. DataGridPro, which injects its own <style> tags outside Emotion's cache) need
 // this same nonce value passed to them directly, not just the root Emotion cache.
-export const CSP_NONCE = document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content') ?? undefined
+export const CSP_NONCE =
+  typeof document === 'undefined'
+    ? undefined
+    : (document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content') ?? undefined)
 
 let ENV = {
   API_BASE_URL: import.meta.env.VITE_API_BASE_URL as string,

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4149,6 +4149,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^8.0.0"
     "@babel/preset-env": "npm:^8.0.0"
+    "@emotion/cache": "npm:^11.14.0"
     "@emotion/react": "npm:^11.8.2"
     "@emotion/styled": "npm:^11.8.1"
     "@mui/icons-material": "npm:^9.0.0"


### PR DESCRIPTION
- ZAP baseline scan (#5704) flagged `Content-Security-Policy`, `Strict-Transport-Security`, and `Permissions-Policy` as missing on most of the frontend. Root cause: two `location` blocks in `openshift/nginx.conf` each declared their own `add_header`, and nginx drops all inherited `add_header`s from a location that defines even one of its own.
- Removing those two blocks surfaced a second bug: `index index.html` was missing a `;`, so nginx had been silently folding `server_tokens off` into `index`'s argument list instead of applying it
- Re-adding headers to the asset-caching location then caused a duplicate, contradictory `Cache-Control` on cached assets (and, as a symptom, an intermittently broken PWA manifest icon). Fixed by moving the shared headers into `openshift/security-headers.conf` and `include`-ing it from both places instead of hand-keeping duplicates.
- Added `server_tokens off`, `Permissions-Policy`, `Cross-Origin-Opener-Policy`/`Resource-Policy`, `worker-src`/`base-uri`/`form-action` (more ZAP gaps), and a Sentry `report-uri` so future CSP gaps surface as violation reports instead of console errors.
- Narrowed `connect-src`/`img-src` from a blanket `https:` down to the hosts actually used (`*.gov.bc.ca`, `*.arcgis.com`, the exact Sentry ingest host); dropped unused `unpkg.com`/`fonts.googleapis.com`; merged what had been two separate `CSP` headers into one.
- Removed `'unsafe-eval'`/`'unsafe-inline'` from `script-src` — dropped the inline `window.env = config` script injected by `vite.config.ts`'s `build-html` plugin in favor of reading the ConfigMap-provided `config` global directly (`window.d.ts`, `env.ts`), so no inline script is needed at all.
- Replaced `style-src`'s `'unsafe-inline'` with a real per-request nonce: nginx's `sub_filter` substitutes `$request_id` into an `index.html` meta tag matching the CSP header nonce, and the app reads it into an Emotion `createCache({ nonce, prepend: true })` wrapped in `CacheProvider`. Kept `style-src-attr 'unsafe-inline'` since CSP has no nonce/hash mechanism for inline `style="..."` attributes (confirmed live: OpenLayers writes these directly for map positioning).
- Removed `<StyledEngineProvider injectFirst>` from `App.tsx` and 7 other components — it creates its own nonce-less Emotion cache that shadowed the root one, which is what caused MUI's own `<style>` tags to keep violating CSP after the nonce was wired up. `prepend: true` on the root cache now replicates its ordering effect app-wide instead.
- Fixed a crash this surfaced in `WindSpeedCell.tsx` (`styled(ThemeProvider)` throws — Emotion's theme-attaching logic doesn't support wrappin`ThemeProvider` itself) and gave `DataGridPro` (5 usages)  `nonce` prop, since it injects `<style>` tags through aseparate mechanism that doesn't go through the ambient Emotion cache at all.
- Made `/robots.txt`/`/sitemap.xml` return a real `404` instead of leaking the SPA shell (was also inflating unrelated ZAP findings on those paths).
- Cleaned up a stale `.zap/rules.tsv` rule for a Keycloak-loading pattern no longer in use, and the missing `actions/checkout` step that made that file unreadable in CI.
- Renamed `zap_scan.yml`'s workflow name from `Every Sundane Scan Prod` (matching `deployment.yml`'s `ZAP BaselineScan Dev`) and extracted the duplicated `zaproxy/action-ba `.github/actions/zap-baseline-scan` composite action.

# Test Links:
[Landing Page](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5769-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
