### PR TITLE
ASA Go: Right-size autoscaler CPU request and ceiling to free prod quota headroom

### DIFF
--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -31,7 +31,7 @@ parameters:
     value: e1e498-tools
   - name: CPU_REQUEST
     description: Requested CPU
-    value: 500m
+    value: 200m
   - name: MEMORY_REQUEST
     description: Requested memory
     value: 1Gi
@@ -46,7 +46,7 @@ parameters:
     value: "6"
   - name: HPA_CPU_TARGET_PERCENTAGE
     description: Target average CPU utilization (% of requested CPU) the HPA scales around
-    value: "70"
+    value: "90"
   - name: HPA_MEMORY_TARGET_PERCENTAGE
     description: Target average memory utilization (% of requested memory) the HPA scales around
     value: "90"

--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -43,7 +43,7 @@ parameters:
     value: "2"
   - name: HPA_MAX_REPLICAS
     description: Upper bound for horizontal autoscaling
-    value: "10"
+    value: "6"
   - name: HPA_CPU_TARGET_PERCENTAGE
     description: Target average CPU utilization (% of requested CPU) the HPA scales around
     value: "70"


### PR DESCRIPTION
A routine `wps-prod-nats-consumer` rollout failed with `exceeded quota: compute-long-running-quota, requested: requests.cpu=1500m, used: requests.cpu=15580m, limited: requests.cpu=16` — the `e1e498-prod` namespace was effectively out of CPU request headroom. `oc adm top pods` showed real usage nowhere near that: the busiest pod was `21m`, and `asa-go` pods were using `9-13m` against a `500m` `CPU_REQUEST` (under 3%). Most of the quota was static reservation rather than real load, and ASA Go's `HorizontalPodAutoscaler` (`minReplicas: 2`, `maxReplicas: 10`) could reserve up to `5` cores on its own at full scale-out.

`CPU_REQUEST` had been raised `100m` -> `500m` in `#5760` alongside the HPA/VPA addition, to fix pods getting low scheduling priority under node contention — that overcorrected relative to actual usage. This drops `CPU_REQUEST` to `200m` (still double the original `100m`), caps `HPA_MAX_REPLICAS` at `6`, and raises `HPA_CPU_TARGET_PERCENTAGE` `70` -> `90` so the smaller request doesn't make the autoscaler trigger noticeably earlier than before. Together this cuts ASA Go's worst-case CPU reservation from `5000m` to `1200m`.

# Test Links:
[Landing Page](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5779-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
