### PR TITLE
ASA: Adjust API memory request to reduce memory-driven HPA over-scaling

### DIFF
--- a/openshift/templates/asa_go_api.yaml
+++ b/openshift/templates/asa_go_api.yaml
@@ -34,10 +34,10 @@ parameters:
     value: 200m
   - name: MEMORY_REQUEST
     description: Requested memory
-    value: 1Gi
+    value: 2Gi
   - name: MEMORY_LIMIT
     description: Memory upper limit
-    value: 1.5Gi
+    value: 2.5Gi
   - name: REPLICAS
     description: Number of replicas (also used as the HPA's minimum)
     value: "2"


### PR DESCRIPTION
Given the scaling formula for horizontal pod scaling: `desiredReplicas = currentReplicas × (currentUtilization / targetUtilization)`

Where we were seeing: 725 MiB / 1024 MiB ≈ 70% memory utilization therefore: 
`desiredReplicas = 5 × (70 / 90) = 3.89` based on initial deploy.

This change should bring us down to 2 pods in the normal utilization state:
`desiredReplicas = 5 × (35 / 90) = 1.94`
# Test Links:
[Landing Page](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5786-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
