### PR TITLE
SFMS: Add ROS FBP processor

### DIFF
--- a/backend/packages/wps-api/src/app/jobs/sfms_run_pipeline.py
+++ b/backend/packages/wps-api/src/app/jobs/sfms_run_pipeline.py
@@ -26,6 +26,7 @@ from wps_sfms.processors.fwi import (
     ISICalculator,
 )
 from wps_sfms.processors.idw import Interpolator, RasterProcessor
+from wps_sfms.processors.rate_of_spread import RateOfSpreadProcessor
 from wps_sfms.processors.relative_humidity import RHInterpolator
 from wps_sfms.processors.surface_fuel_consumption import SurfaceFuelConsumptionProcessor
 from wps_sfms.processors.temperature import TemperatureInterpolator
@@ -123,6 +124,22 @@ async def _resolve_percent_conifer_path(
     )
 
 
+async def _resolve_percent_dead_conifer_path(
+    fuel_raster_year: int,
+    raster_addresser: SFMSNGRasterAddresser,
+    s3_client: S3Client,
+) -> GDALPath:
+    """Resolve the percent-dead-conifer raster matching the selected fuel-grid year."""
+    key = raster_addresser.get_percent_dead_conifer_key(fuel_raster_year)
+    if await s3_client.object_exists(key):
+        logger.info("Using percent-dead-conifer raster: %s", key)
+        return raster_addresser.gdal_path(key)
+
+    raise RuntimeError(
+        f"No percent-dead-conifer raster found for fuel-grid year {fuel_raster_year}: {key}"
+    )
+
+
 async def run_fbp_calculations(
     datetime_to_process: datetime,
     raster_addresser: SFMSNGRasterAddresser,
@@ -137,18 +154,32 @@ async def run_fbp_calculations(
     percent_conifer_path = await _resolve_percent_conifer_path(
         fuel_raster_year, raster_addresser, s3_client
     )
-    inputs = raster_addresser.get_surface_fuel_consumption_inputs(
+    sfc_inputs = raster_addresser.get_surface_fuel_consumption_inputs(
         datetime_to_process,
         run_type,
         fuel_raster_path,
         percent_conifer_path,
     )
-    processor = SurfaceFuelConsumptionProcessor(datetime_to_process)
+    sfc_processor = SurfaceFuelConsumptionProcessor(datetime_to_process)
 
-    async def _run() -> None:
-        await processor.process(s3_client, multi_wps_dataset_context, inputs)
+    async def _run_sfc() -> None:
+        await sfc_processor.process(s3_client, multi_wps_dataset_context, sfc_inputs)
 
-    await _run_tracked_job(SFMSRunLogJobName.SFC_CALCULATION, sfms_run_id, session, _run)
+    await _run_tracked_job(SFMSRunLogJobName.SFC_CALCULATION, sfms_run_id, session, _run_sfc)
+
+    ros_inputs = raster_addresser.get_rate_of_spread_inputs(
+        datetime_to_process,
+        run_type,
+        fuel_raster_path,
+        percent_conifer_path,
+        raster_addresser.gdal_path(sfc_inputs.output_key),
+    )
+    ros_processor = RateOfSpreadProcessor(datetime_to_process)
+
+    async def _run_ros() -> None:
+        await ros_processor.process(s3_client, multi_wps_dataset_context, ros_inputs)
+
+    await _run_tracked_job(SFMSRunLogJobName.ROS_CALCULATION, sfms_run_id, session, _run_ros)
 
 
 async def run_weather_interpolation(

--- a/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_actuals.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_actuals.py
@@ -67,6 +67,7 @@ class MockDailyActualsDeps(NamedTuple):
     interpolation_processor: MagicMock
     fwi_processor: MagicMock
     sfc_processor: MagicMock
+    ros_processor: MagicMock
     fmc_processor: MagicMock
     fmc_processor_class: MagicMock
     fmc_inputs: MagicMock
@@ -173,6 +174,14 @@ def mock_dependencies(mocker: MockerFixture, mock_s3_client, mock_wfwx_api) -> M
         f"{PIPELINE_PATH}.SurfaceFuelConsumptionProcessor", return_value=mock_sfc_processor
     )
 
+    mock_ros_inputs = MagicMock()
+    mock_addresser.get_surface_fuel_consumption_inputs.return_value = MagicMock()
+    mock_addresser.get_rate_of_spread_inputs.return_value = mock_ros_inputs
+
+    mock_ros_processor = MagicMock()
+    mock_ros_processor.process = AsyncMock(return_value=None)
+    mocker.patch(f"{PIPELINE_PATH}.RateOfSpreadProcessor", return_value=mock_ros_processor)
+
     # Keep the session root as a normal mock and only make the async methods AsyncMocks.
     # The session itself is used in async code, but some things it returns are still sync,
     # like `result.scalar()`. An AsyncMock root makes those look awaitable and causes noisy warnings.
@@ -198,6 +207,7 @@ def mock_dependencies(mocker: MockerFixture, mock_s3_client, mock_wfwx_api) -> M
         interpolation_processor=mock_interpolation_processor,
         fwi_processor=mock_fwi_processor,
         sfc_processor=mock_sfc_processor,
+        ros_processor=mock_ros_processor,
         fmc_processor=mock_fmc_processor,
         fmc_processor_class=mock_fmc_processor_class,
         fmc_inputs=mock_fmc_inputs,
@@ -330,19 +340,19 @@ class TestRunSfmsDailyActuals:
 
         await run_sfms_daily_actuals(target_date)
 
-        # twelve tracked runs: 5 weather + 6 FWI + 1 SFC calculation.
-        assert mock_dependencies.db_session.execute.call_count == 12
+        # thirteen tracked runs: 5 weather + 6 FWI + 2 FBP calculations (SFC + ROS).
+        assert mock_dependencies.db_session.execute.call_count == 13
 
     @pytest.mark.anyio
     async def test_logs_success_status(self, mock_dependencies: MockDailyActualsDeps):
         """Test that successful jobs are updated to success status."""
-        records = [MagicMock() for _ in range(12)]
+        records = [MagicMock() for _ in range(13)]
         mock_dependencies.db_session.get = AsyncMock(side_effect=records)
 
         target_date = datetime(2024, 7, 4, tzinfo=timezone.utc)
         await run_sfms_daily_actuals(target_date)
 
-        assert mock_dependencies.db_session.get.call_count == 12
+        assert mock_dependencies.db_session.get.call_count == 13
         for record in records:
             assert record.status == SFMSRunLogStatus.SUCCESS
             assert record.completed_at is not None
@@ -472,8 +482,8 @@ class TestMondayFWIInterpolation:
 
         await run_sfms_daily_actuals(target_date)
 
-        # twelve tracked runs: 5 weather + 3 interpolated FWI + 3 derived FWI + 1 SFC.
-        assert mock_dependencies.db_session.execute.call_count == 12
+        # thirteen tracked runs: 5 weather + 3 interpolated FWI + 3 derived FWI + 2 FBP calculations (SFC + ROS).
+        assert mock_dependencies.db_session.execute.call_count == 13
 
 
 class TestFWICalculationVsInterpolation:
@@ -606,6 +616,7 @@ class TestFWICalculationVsInterpolation:
             SFMSRunLogJobName.BUI_CALCULATION,
             SFMSRunLogJobName.FWI_CALCULATION,
             SFMSRunLogJobName.SFC_CALCULATION,
+            SFMSRunLogJobName.ROS_CALCULATION,
         ]
 
     @pytest.mark.anyio
@@ -637,6 +648,7 @@ class TestFWICalculationVsInterpolation:
             SFMSRunLogJobName.BUI_CALCULATION,
             SFMSRunLogJobName.FWI_CALCULATION,
             SFMSRunLogJobName.SFC_CALCULATION,
+            SFMSRunLogJobName.ROS_CALCULATION,
         ]
 
 

--- a/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_forecasts.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_sfms_daily_forecasts.py
@@ -47,6 +47,7 @@ class MockDailyForecastsDeps(NamedTuple):
     interpolation_processor: MagicMock
     fwi_processor: MagicMock
     sfc_processor: MagicMock
+    ros_processor: MagicMock
     fmc_processor: MagicMock
     fmc_processor_class: MagicMock
     fmc_inputs: MagicMock
@@ -139,6 +140,12 @@ def mock_dependencies(
         f"{PIPELINE_PATH}.SurfaceFuelConsumptionProcessor", return_value=mock_sfc_processor
     )
 
+    mock_ros_inputs = MagicMock()
+    mock_addresser.get_rate_of_spread_inputs.return_value = mock_ros_inputs
+    mock_ros_processor = MagicMock()
+    mock_ros_processor.process = AsyncMock(return_value=None)
+    mocker.patch(f"{PIPELINE_PATH}.RateOfSpreadProcessor", return_value=mock_ros_processor)
+
     db_session = MagicMock(spec=AsyncSession)
     db_execute_result = MagicMock()
     db_execute_result.scalar = MagicMock(return_value=1)
@@ -161,6 +168,7 @@ def mock_dependencies(
         interpolation_processor=mock_interpolation_processor,
         fwi_processor=mock_fwi_processor,
         sfc_processor=mock_sfc_processor,
+        ros_processor=mock_ros_processor,
         fmc_processor=mock_fmc_processor,
         fmc_processor_class=mock_fmc_processor_class,
         fmc_inputs=mock_fmc_inputs,

--- a/backend/packages/wps-api/src/app/tests/jobs/test_sfms_run_pipeline.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_sfms_run_pipeline.py
@@ -6,7 +6,11 @@ from pytest_mock import MockerFixture
 from wps_shared.db.models.sfms_run import SFMSRunLogJobName
 from wps_shared.run_type import RunType
 
-from app.jobs.sfms_run_pipeline import _resolve_percent_conifer_path, run_fbp_calculations
+from app.jobs.sfms_run_pipeline import (
+    _resolve_percent_conifer_path,
+    _resolve_percent_dead_conifer_path,
+    run_fbp_calculations,
+)
 
 PIPELINE_PATH = "app.jobs.sfms_run_pipeline"
 
@@ -40,6 +44,38 @@ async def test_resolve_percent_conifer_path_does_not_fall_back_one_year():
 
     addresser.get_percent_conifer_key.assert_called_once_with(2025)
     s3_client.object_exists.assert_awaited_once_with("sfms/static/m12_2025.tif")
+    addresser.gdal_path.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_resolve_percent_dead_conifer_path_uses_fuel_raster_year():
+    addresser = MagicMock()
+    addresser.get_percent_dead_conifer_key.side_effect = lambda year: f"sfms/static/m34_{year}.tif"
+    addresser.gdal_path.side_effect = lambda key: f"/vsis3/test/{key}"
+    s3_client = MagicMock()
+    s3_client.object_exists = AsyncMock(return_value=True)
+
+    result = await _resolve_percent_dead_conifer_path(2025, addresser, s3_client)
+
+    assert result == "/vsis3/test/sfms/static/m34_2025.tif"
+    s3_client.object_exists.assert_awaited_once_with("sfms/static/m34_2025.tif")
+
+
+@pytest.mark.anyio
+async def test_resolve_percent_dead_conifer_path_raises_when_missing():
+    addresser = MagicMock()
+    addresser.get_percent_dead_conifer_key.side_effect = lambda year: f"sfms/static/m34_{year}.tif"
+    s3_client = MagicMock()
+    s3_client.object_exists = AsyncMock(return_value=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="fuel-grid year 2025: sfms/static/m34_2025.tif",
+    ):
+        await _resolve_percent_dead_conifer_path(2025, addresser, s3_client)
+
+    addresser.get_percent_dead_conifer_key.assert_called_once_with(2025)
+    s3_client.object_exists.assert_awaited_once_with("sfms/static/m34_2025.tif")
     addresser.gdal_path.assert_not_called()
 
 
@@ -90,4 +126,7 @@ async def test_run_fbp_calculations_resolves_inputs_and_tracks_sfc(mocker: Mocke
     processor.process.assert_awaited_once()
     assert processor.process.await_args.args[0] is s3_client
     assert processor.process.await_args.args[2] is sfc_inputs
-    assert tracked_jobs == [SFMSRunLogJobName.SFC_CALCULATION]
+    assert tracked_jobs == [
+        SFMSRunLogJobName.SFC_CALCULATION,
+        SFMSRunLogJobName.ROS_CALCULATION,
+    ]

--- a/backend/packages/wps-api/src/app/tests/jobs/test_sfms_run_pipeline.py
+++ b/backend/packages/wps-api/src/app/tests/jobs/test_sfms_run_pipeline.py
@@ -86,7 +86,12 @@ async def test_run_fbp_calculations_resolves_inputs_and_tracks_sfc(mocker: Mocke
     s3_client = MagicMock()
     session = MagicMock()
     sfc_inputs = MagicMock()
+    sfc_inputs.output_key = "sfms_ng/actual/2025/07/04/sfc_20250704.tif"
+    ros_inputs = MagicMock()
     addresser.get_surface_fuel_consumption_inputs.return_value = sfc_inputs
+    addresser.get_rate_of_spread_inputs.return_value = ros_inputs
+    addresser.gdal_path.side_effect = lambda key: f"/vsis3/test/{key}"
+    s3_client.all_objects_exist = AsyncMock(return_value=True)
     resolve_percent_conifer = mocker.patch(
         f"{PIPELINE_PATH}._resolve_percent_conifer_path",
         new=AsyncMock(return_value="/vsis3/test/sfms/static/m12_2025.tif"),
@@ -95,6 +100,11 @@ async def test_run_fbp_calculations_resolves_inputs_and_tracks_sfc(mocker: Mocke
     processor.process = AsyncMock()
     processor_class = mocker.patch(
         f"{PIPELINE_PATH}.SurfaceFuelConsumptionProcessor", return_value=processor
+    )
+    ros_processor = MagicMock()
+    ros_processor.process = AsyncMock()
+    ros_processor_class = mocker.patch(
+        f"{PIPELINE_PATH}.RateOfSpreadProcessor", return_value=ros_processor
     )
     tracked_jobs = []
 
@@ -126,6 +136,10 @@ async def test_run_fbp_calculations_resolves_inputs_and_tracks_sfc(mocker: Mocke
     processor.process.assert_awaited_once()
     assert processor.process.await_args.args[0] is s3_client
     assert processor.process.await_args.args[2] is sfc_inputs
+    ros_processor_class.assert_called_once_with(datetime_to_process)
+    ros_processor.process.assert_awaited_once()
+    assert ros_processor.process.await_args.args[0] is s3_client
+    assert ros_processor.process.await_args.args[2] is ros_inputs
     assert tracked_jobs == [
         SFMSRunLogJobName.SFC_CALCULATION,
         SFMSRunLogJobName.ROS_CALCULATION,

--- a/backend/packages/wps-sfms/src/wps_sfms/processors/rate_of_spread.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/processors/rate_of_spread.py
@@ -1,0 +1,187 @@
+"""Raster processor for Fire Behaviour Prediction rate of spread."""
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from time import perf_counter
+from typing import Generator
+
+import numpy as np
+from cffdrs_vec.fbp import vectorized_rate_of_spread
+from wps_shared.geospatial.wps_dataset import WPSDataset
+from wps_shared.sfms.raster_addresser import GDALPath
+from wps_shared.utils.s3 import gdal_s3_context
+from wps_shared.utils.s3_client import S3Client
+
+from wps_sfms.fbp_fuel_types import (
+    NODATA_FUEL_TYPE_CODE,
+    NON_COMBUSTIBLE_FUEL_VALUES,
+    fuel_type_codes_from_grid,
+)
+from wps_sfms.fbp_input_validation import validate_percent_conifer
+from wps_sfms.interpolation.common import SFMS_NO_DATA
+from wps_sfms.publish import publish_dataset
+from wps_sfms.raster_dependencies import GriddedRasterDependencies, MultiDatasetContext
+from wps_sfms.raster_inputs import RateOfSpreadInputs
+from wps_sfms.raster_output import create_masked_output_dataset, open_bc_mask_dataset
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RateOfSpreadResult:
+    values: np.ndarray
+    nodata_value: float = SFMS_NO_DATA
+
+
+@dataclass(frozen=True)
+class RateOfSpreadDatasets:
+    fuel: WPSDataset
+    isi: WPSDataset
+    bui: WPSDataset
+    fmc: WPSDataset
+    sfc: WPSDataset
+    percent_conifer: WPSDataset
+
+
+def calculate_rate_of_spread(datasets: RateOfSpreadDatasets) -> RateOfSpreadResult:
+    """Calculate ROS using the same mixedwood validation rules as SFC."""
+    fuel, _ = datasets.fuel.replace_nodata_with(np.nan)
+    isi, _ = datasets.isi.replace_nodata_with(np.nan)
+    bui, _ = datasets.bui.replace_nodata_with(np.nan)
+    fmc, _ = datasets.fmc.replace_nodata_with(np.nan)
+    sfc, _ = datasets.sfc.replace_nodata_with(np.nan)
+    percent_conifer, _ = datasets.percent_conifer.replace_nodata_with(np.nan)
+
+    fuel_type_codes = fuel_type_codes_from_grid(fuel)
+    validate_percent_conifer(fuel, percent_conifer)
+
+    non_combustible_mask = np.isin(fuel, tuple(NON_COMBUSTIBLE_FUEL_VALUES))
+    calculation_mask = (
+        ~non_combustible_mask
+        & (fuel_type_codes != NODATA_FUEL_TYPE_CODE)
+        & np.isfinite(isi)
+        & np.isfinite(bui)
+        & np.isfinite(fmc)
+        & np.isfinite(sfc)
+    )
+
+    output = np.full(fuel.shape, SFMS_NO_DATA, dtype=np.float32)
+    if np.any(calculation_mask):
+        start = perf_counter()
+        pdf = np.zeros_like(isi[calculation_mask], dtype=np.float32)
+        cc = np.zeros_like(isi[calculation_mask], dtype=np.float32)
+        cbh = np.zeros_like(isi[calculation_mask], dtype=np.float32)
+        calculated = vectorized_rate_of_spread(
+            fuel_type_codes[calculation_mask],
+            isi[calculation_mask],
+            bui[calculation_mask],
+            fmc[calculation_mask],
+            sfc[calculation_mask],
+            percent_conifer[calculation_mask],
+            pdf,
+            cc,
+            cbh,
+        )
+        logger.info("%f seconds to calculate vectorized ROS", perf_counter() - start)
+        output[calculation_mask] = np.where(np.isfinite(calculated), calculated, SFMS_NO_DATA)
+
+    output[non_combustible_mask] = 0
+    return RateOfSpreadResult(output)
+
+
+class RateOfSpreadProcessor:
+    """Load, validate, calculate, and publish one daily ROS raster."""
+
+    def __init__(self, datetime_to_process: datetime):
+        self.datetime_to_process = datetime_to_process
+        self._raster_dependencies = GriddedRasterDependencies()
+
+    @staticmethod
+    def _dependency_keys(inputs: RateOfSpreadInputs) -> tuple[GDALPath, ...]:
+        return (
+            inputs.fuel_key,
+            inputs.isi_key,
+            inputs.bui_key,
+            inputs.fmc_key,
+            inputs.sfc_key,
+            inputs.percent_conifer_key,
+        )
+
+    @contextmanager
+    def _open_datasets(
+        self,
+        input_dataset_context: MultiDatasetContext,
+        inputs: RateOfSpreadInputs,
+    ) -> Generator[RateOfSpreadDatasets, None, None]:
+        with self._raster_dependencies.open_by_key(
+            input_dataset_context, self._dependency_keys(inputs)
+        ) as datasets_by_key:
+            yield RateOfSpreadDatasets(
+                fuel=datasets_by_key[inputs.fuel_key],
+                isi=datasets_by_key[inputs.isi_key],
+                bui=datasets_by_key[inputs.bui_key],
+                fmc=datasets_by_key[inputs.fmc_key],
+                sfc=datasets_by_key[inputs.sfc_key],
+                percent_conifer=datasets_by_key[inputs.percent_conifer_key],
+            )
+
+    def _validate_grids(self, datasets: RateOfSpreadDatasets) -> None:
+        self._raster_dependencies.validate_grids(
+            datasets.fuel,
+            {
+                "isi": datasets.isi,
+                "bui": datasets.bui,
+                "fmc": datasets.fmc,
+                "sfc": datasets.sfc,
+                "percent_conifer": datasets.percent_conifer,
+            },
+        )
+
+    async def process(
+        self,
+        s3_client: S3Client,
+        input_dataset_context: MultiDatasetContext,
+        inputs: RateOfSpreadInputs,
+    ) -> None:
+        """Calculate and publish ROS from the declared raster dependencies."""
+        with gdal_s3_context():
+            await self._raster_dependencies.assert_keys_exist(
+                s3_client,
+                self._dependency_keys(inputs),
+            )
+            logger.info(
+                "Calculating ROS %s for %s",
+                inputs.run_type.value,
+                self.datetime_to_process.date(),
+            )
+
+            with self._open_datasets(input_dataset_context, inputs) as datasets:
+                self._validate_grids(datasets)
+                result = calculate_rate_of_spread(datasets)
+
+                with (
+                    open_bc_mask_dataset() as mask,
+                    create_masked_output_dataset(
+                        result.values,
+                        datasets.fuel,
+                        mask,
+                        result.nodata_value,
+                    ) as output_ds,
+                ):
+                    output_band = output_ds.as_gdal_ds().GetRasterBand(1)
+                    output_band.SetDescription("rate_of_spread")
+                    output_band.SetUnitType("m/min")
+                    published = await publish_dataset(
+                        s3_client=s3_client,
+                        dataset=output_ds,
+                        output_key=inputs.output_key,
+                    )
+
+            logger.info(
+                "Stored ROS %s: %s (COG: %s)",
+                inputs.run_type.value,
+                published.output_key,
+                published.cog_key,
+            )

--- a/backend/packages/wps-sfms/src/wps_sfms/raster_inputs.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/raster_inputs.py
@@ -40,6 +40,20 @@ class SurfaceFuelConsumptionInputs:
 
 
 @dataclass(frozen=True)
+class RateOfSpreadInputs:
+    """Raster locations and metadata needed for one ROS calculation."""
+
+    fuel_key: GDALPath
+    isi_key: GDALPath
+    bui_key: GDALPath
+    fmc_key: GDALPath
+    sfc_key: GDALPath
+    percent_conifer_key: GDALPath
+    output_key: S3Key
+    run_type: RunType
+
+
+@dataclass(frozen=True)
 class FoliarMoistureContentInputs:
     """Static dependencies and date-specific outputs for shared daily FMC calculations."""
 

--- a/backend/packages/wps-sfms/src/wps_sfms/sfmsng_raster_addresser.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/sfmsng_raster_addresser.py
@@ -22,6 +22,7 @@ from wps_shared.utils.time import assert_all_utc
 from wps_sfms.raster_inputs import (
     FWIInputs,
     FoliarMoistureContentInputs,
+    RateOfSpreadInputs,
     SurfaceFuelConsumptionInputs,
 )
 
@@ -148,6 +149,31 @@ class SFMSNGRasterAddresser(BaseRasterAddresser):
             ),
             percent_conifer_key=percent_conifer_key,
             output_key=self.get_fbp_key(datetime_to_process, FBPParameter.SFC, run_type),
+            run_type=run_type,
+        )
+
+    def get_rate_of_spread_inputs(
+        self,
+        datetime_to_process: datetime,
+        run_type: RunType,
+        fuel_key: GDALPath,
+        percent_conifer_key: GDALPath,
+        sfc_key: GDALPath,
+    ) -> RateOfSpreadInputs:
+        """Build the raster dependencies for same-day ROS from completed FBP inputs."""
+        assert_all_utc(datetime_to_process)
+        return RateOfSpreadInputs(
+            fuel_key=fuel_key,
+            isi_key=self.gdal_path(
+                self.get_index_key(datetime_to_process, FWIParameter.ISI, run_type)
+            ),
+            bui_key=self.gdal_path(
+                self.get_index_key(datetime_to_process, FWIParameter.BUI, run_type)
+            ),
+            fmc_key=self.gdal_path(self.get_fmc_key(datetime_to_process.date())),
+            sfc_key=sfc_key,
+            percent_conifer_key=percent_conifer_key,
+            output_key=self.get_fbp_key(datetime_to_process, FBPParameter.ROS, run_type),
             run_type=run_type,
         )
 

--- a/backend/packages/wps-sfms/src/wps_sfms/tests/test_sfmsng_raster_addresser.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/tests/test_sfmsng_raster_addresser.py
@@ -212,6 +212,31 @@ class TestSurfaceFuelConsumptionInputs:
     def test_percent_conifer_key_uses_year(self, addresser: SFMSNGRasterAddresser):
         assert addresser.get_percent_conifer_key(2024) == "sfms/static/m12_2024.tif"
 
+    def test_percent_dead_conifer_key_uses_year(self, addresser: SFMSNGRasterAddresser):
+        assert addresser.get_percent_dead_conifer_key(2024) == "sfms/static/m34_2024.tif"
+
+    def test_get_rate_of_spread_inputs_uses_ros_output_key(self, addresser: SFMSNGRasterAddresser):
+        fuel_key = addresser.gdal_path(addresser.get_fuel_raster_key(TEST_DATETIME, 3))
+        percent_conifer_key = addresser.gdal_path(addresser.get_percent_conifer_key(2024))
+        sfc_key = addresser.gdal_path("sfms_ng/actual/2024/04/15/sfc_20240415.tif")
+
+        result = addresser.get_rate_of_spread_inputs(
+            TEST_DATETIME,
+            RunType.ACTUAL,
+            fuel_key,
+            percent_conifer_key,
+            sfc_key,
+        )
+
+        assert result.fuel_key == fuel_key
+        assert result.isi_key.endswith("sfms_ng/actual/2024/04/15/isi_20240415.tif")
+        assert result.bui_key.endswith("sfms_ng/actual/2024/04/15/bui_20240415.tif")
+        assert result.fmc_key.endswith("sfms_ng/static/fmc/2024/04/15/fmc_20240415.tif")
+        assert result.sfc_key == sfc_key
+        assert result.percent_conifer_key == percent_conifer_key
+        assert result.output_key == "sfms_ng/actual/2024/04/15/ros_20240415.tif"
+        assert result.run_type == RunType.ACTUAL
+
     def test_non_utc_raises(self, addresser: SFMSNGRasterAddresser):
         fuel_key = addresser.gdal_path(addresser.get_fuel_raster_key(TEST_DATETIME, 3))
         percent_conifer_key = addresser.gdal_path(addresser.get_percent_conifer_key(2024))

--- a/backend/packages/wps-shared/src/wps_shared/db/models/sfms_run.py
+++ b/backend/packages/wps-shared/src/wps_shared/db/models/sfms_run.py
@@ -32,6 +32,7 @@ class SFMSRunLogJobName(str, enum.Enum):
 
     # FBP
     SFC_CALCULATION = "sfc_calculation"
+    ROS_CALCULATION = "ros_calculation"
 
 
 class SFMSRunLogStatus(str, enum.Enum):

--- a/backend/packages/wps-shared/src/wps_shared/sfms/raster_addresser.py
+++ b/backend/packages/wps-shared/src/wps_shared/sfms/raster_addresser.py
@@ -32,6 +32,7 @@ class FWIParameter(enum.Enum):
 
 class FBPParameter(enum.Enum):
     SFC = "sfc"
+    ROS = "ros"
 
 
 class BaseRasterAddresser:
@@ -65,6 +66,10 @@ class BaseRasterAddresser:
     def get_percent_conifer_key(self, year: int) -> S3Key:
         """S3 key for a yearly mixedwood percent-conifer raster."""
         return S3Key(f"sfms/static/m12_{year}.tif")
+
+    def get_percent_dead_conifer_key(self, year: int) -> S3Key:
+        """S3 key for a yearly dead-balsam-fir mixedwood percent raster."""
+        return S3Key(f"sfms/static/m34_{year}.tif")
 
     def get_fuel_raster_key(self, datetime_utc: datetime, version: int) -> S3Key:
         """S3 key for a versioned fuel type raster."""

--- a/backend/packages/wps-shared/src/wps_shared/tests/test_raster_addresser.py
+++ b/backend/packages/wps-shared/src/wps_shared/tests/test_raster_addresser.py
@@ -46,3 +46,13 @@ def test_get_fuel_raster_key(addresser: BaseRasterAddresser):
 def test_get_unprocessed_raster_key(addresser: BaseRasterAddresser):
     result = addresser.get_unprocessed_fuel_raster_key("test.tif")
     assert result == "sfms/static/test.tif"
+
+
+def test_get_percent_conifer_key(addresser: BaseRasterAddresser):
+    result = addresser.get_percent_conifer_key(2024)
+    assert result == "sfms/static/m12_2024.tif"
+
+
+def test_get_percent_dead_conifer_key(addresser: BaseRasterAddresser):
+    result = addresser.get_percent_dead_conifer_key(2024)
+    assert result == "sfms/static/m34_2024.tif"


### PR DESCRIPTION
- Add year-paired percent-dead conifer raster lookup (m34_{year}.tif) alongside the existing percent-conifer raster lookup.
- Resolve and validate the matching raster before use in FBP pipelines.
- Extend the SFMS addresser and FBP pipeline to generate a rate-of-spread (ROS) raster after SFC.
- Add processor and test coverage for the new ROS input/output contract.
# Test Links:
[Landing Page](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5787-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
