### PR TITLE
SFMS: Filter invalid negative precipitation from SFMS interpolation

### DIFF
--- a/backend/packages/wps-sfms/src/wps_sfms/interpolation/field.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/interpolation/field.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from typing import List
 
 import numpy as np
@@ -74,7 +74,22 @@ def build_attribute_field(actuals: List[SFMSDaily], attribute: str) -> ScalarFie
             f"Unknown attribute {attribute!r} on SFMSDaily. Valid attributes: {sorted(_VALID_SFMS_ATTRIBUTES)}"
         )
 
-    valid = [s for s in actuals if getattr(s, attribute) is not None]
+    valid = []
+    for station in actuals:
+        value = getattr(station, attribute)
+        if value is None:
+            continue
+        if attribute == "precipitation" and value < 0:
+            logger.warning(
+                "Negative precipitation reported for station code %s at %s (%s). "
+                "Dropping this station from precipitation interpolation like a missing value.",
+                station.code,
+                station.for_datetime,
+                value,
+            )
+            continue
+        valid.append(station)
+
     return ScalarField(
         lats=np.array([s.lat for s in valid], dtype=np.float32),
         lons=np.array([s.lon for s in valid], dtype=np.float32),

--- a/backend/packages/wps-sfms/src/wps_sfms/tests/test_field.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/tests/test_field.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 import numpy as np
@@ -41,6 +42,35 @@ class TestScalarFieldBuilders:
         np.testing.assert_allclose(field.lats, np.array([49.0], dtype=np.float32))
         np.testing.assert_allclose(field.lons, np.array([-123.0], dtype=np.float32))
         np.testing.assert_allclose(field.values, np.array([1.5], dtype=np.float32))
+
+    def test_build_attribute_field_filters_negative_precipitation(self, caplog):
+        actuals = [
+            SFMSDaily(
+                code=1,
+                for_datetime=TEST_FOR_DATETIME,
+                run_type=RunTypeEnum.actual,
+                lat=49.0,
+                lon=-123.0,
+                precipitation=1.5,
+            ),
+            SFMSDaily(
+                code=2,
+                for_datetime=TEST_FOR_DATETIME,
+                run_type=RunTypeEnum.actual,
+                lat=49.1,
+                lon=-123.1,
+                precipitation=-1.0,
+            ),
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            field = build_attribute_field(actuals, "precipitation")
+
+        np.testing.assert_allclose(field.lats, np.array([49.0], dtype=np.float32))
+        np.testing.assert_allclose(field.lons, np.array([-123.0], dtype=np.float32))
+        np.testing.assert_allclose(field.values, np.array([1.5], dtype=np.float32))
+        assert "Negative precipitation reported for station code 2" in caplog.text
+        assert "Dropping this station from precipitation interpolation" in caplog.text
 
     def test_build_temperature_field_applies_sea_level_adjustment(self):
         actuals = [


### PR DESCRIPTION
- Exclude stations reporting negative precipitation from SFMS precipitation interpolation.
- Log a warning when a station reports a negative precipitation value so the bad source is visible in logs.
- Treat negative precipitation the same way the pipeline already treats missing values: omit it from interpolation instead of allowing it into the raster.
# Test Links:
[Landing Page](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5789-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
