### PR TITLE
ASA: Cap ASA Go API dev HPA max replicas to 2

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Deploy ASA Go API to Dev
         shell: bash
         run: |
-          DEPLOY_VERSION="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" REPLICAS="1" MEMORY_REQUEST=1Gi MEMORY_LIMIT=1.5Gi ENVIRONMENT="development" bash openshift/scripts/oc_deploy_asa_go_api.sh ${SUFFIX} apply
+          DEPLOY_VERSION="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" REPLICAS="1" HPA_MAX_REPLICAS="2" MEMORY_REQUEST=1Gi MEMORY_LIMIT=1.5Gi ENVIRONMENT="development" bash openshift/scripts/oc_deploy_asa_go_api.sh ${SUFFIX} apply
 
       - name: Allow APS to reach ASA Go API
         shell: bash

--- a/openshift/scripts/oc_deploy_asa_go_api.sh
+++ b/openshift/scripts/oc_deploy_asa_go_api.sh
@@ -10,8 +10,8 @@ source "$(dirname ${0})/common/common"
 #% Usage:
 #%
 #%   [CPU_REQUEST=<>] [MEMORY_REQUEST=<>] [MEMORY_LIMIT=<>] [REPLICAS=<>] \
-#%   [ALLOWED_ORIGINS=<>] [POSTGRES_POOL_SIZE=<>] [POSTGRES_MAX_OVERFLOW=<>] \
-#%   ${THIS_FILE} [SUFFIX] [apply]
+#%   [HPA_MAX_REPLICAS=<>] [ALLOWED_ORIGINS=<>] [POSTGRES_POOL_SIZE=<>] \
+#%   [POSTGRES_MAX_OVERFLOW=<>] ${THIS_FILE} [SUFFIX] [apply]
 #%
 #% Examples:
 #%
@@ -40,8 +40,8 @@ OC_PROCESS="oc -n ${PROJ_TARGET} process -f ${TEMPLATE_PATH}/asa_go_api.yaml \
  ${ENVIRONMENT:+ "-p ENVIRONMENT=${ENVIRONMENT}"} \
  ${ALLOWED_ORIGINS:+ "-p ALLOWED_ORIGINS=${ALLOWED_ORIGINS}"} \
  ${REPLICAS:+ "-p REPLICAS=${REPLICAS}"} \
+ ${HPA_MAX_REPLICAS:+ "-p HPA_MAX_REPLICAS=${HPA_MAX_REPLICAS}"} \
  -p DEPLOY_VERSION=${DEPLOY_VERSION}"
-
 OC_APPLY="oc -n ${PROJ_TARGET} apply -f -"
 [ "${APPLY}" ] || OC_APPLY="${OC_APPLY} --dry-run=client"
 


### PR DESCRIPTION
This change reduces the ASA Go API autoscaling cap in the dev deployment environment to 2 replicas, without changing the shared template default.

- Added an explicit `HPA_MAX_REPLICAS` override in the dev deployment workflow for the ASA Go API to limit resource usage
- Set the dev value to 2
- Left the template default unchanged so production and other environments continue to use the standard value
# Test Links:
[Landing Page](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5790-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
