### PR TITLE
Dev: Disable Gunicorn control socket in API startup

### DIFF
--- a/backend/packages/wps-api/start.sh
+++ b/backend/packages/wps-api/start.sh
@@ -7,4 +7,4 @@ set -e
 GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
 APP_MODULE="${APP_MODULE:-app.main:app}"
 # start the server
-GUNICORN_CMD_ARGS="--max-requests 50 --max-requests-jitter 50" gunicorn "$APP_MODULE" --timeout 200 --workers $GUNICORN_WORKERS --worker-class uvicorn.workers.UvicornWorker --bind=0.0.0.0:8080
+GUNICORN_CMD_ARGS="--max-requests 50 --max-requests-jitter 50" gunicorn "$APP_MODULE" --timeout 200 --workers $GUNICORN_WORKERS --worker-class uvicorn.workers.UvicornWorker --bind=0.0.0.0:8080 --no-control-socket


### PR DESCRIPTION
This PR disables Gunicorn’s control socket in the API startup command to avoid permission issues caused by writing to the default .gunicorn control socket path in the container environment. We don't need this running in the container environment at the moment.

- Added the Gunicorn flag `--no-control-socket` to the existing startup command
# Test Links:
[Landing Page](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5791-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
