### PR TITLE
SFMS: Default grass curing to 65% in gridded rate of spread

### DIFF
--- a/backend/packages/wps-sfms/src/wps_sfms/processors/rate_of_spread.py
+++ b/backend/packages/wps-sfms/src/wps_sfms/processors/rate_of_spread.py
@@ -71,7 +71,7 @@ def calculate_rate_of_spread(datasets: RateOfSpreadDatasets) -> RateOfSpreadResu
     if np.any(calculation_mask):
         start = perf_counter()
         pdf = np.zeros_like(isi[calculation_mask], dtype=np.float32)
-        cc = np.zeros_like(isi[calculation_mask], dtype=np.float32)
+        cc = np.full(isi[calculation_mask].shape, 65.0, dtype=np.float32)
         cbh = np.zeros_like(isi[calculation_mask], dtype=np.float32)
         calculated = vectorized_rate_of_spread(
             fuel_type_codes[calculation_mask],


### PR DESCRIPTION
The gridded `RateOfSpreadProcessor` hardcoded percent cured grass (`cc`) to `0` for every pixel. `cffdrs` has no fallback logic for `cc` so every O1A/O1B pixel was silently computing rate of spread as 0% cured grass regardless of actual conditions. `65%` is used here as a fixed default until per-pixel grass curing input is wired into the gridded pipeline.
# Test Links:
[Landing Page](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5801-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
