### PR TITLE
ASA Go: API Locks for stats cache access

### DIFF
--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/advisory_run_stats/cache.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/advisory_run_stats/cache.py
@@ -8,10 +8,13 @@ gets a new key rather than needing invalidation.
 
 import asyncio
 import logging
+from collections import defaultdict
+from collections.abc import Awaitable, Callable
 from typing import Optional, TypeVar
 
 from pydantic import TypeAdapter
 from redis import StrictRedis
+from redis.lock import Lock
 from wps_shared import config
 from wps_shared.schemas.fba import (
     FireCentreTPIResponse,
@@ -23,6 +26,10 @@ from wps_shared.schemas.fba import (
 
 logger = logging.getLogger(__name__)
 cache_expiry_seconds = 86400  # 1 day -- generous since a completed run's data never changes
+# keep the lease just beyond gunicorn's 200-second worker timeout so killed workers recover
+compute_lock_timeout_seconds = 210
+# keep interactive requests responsive when a writer or Redis stalls
+compute_lock_wait_seconds = 5
 
 T = TypeVar("T")
 
@@ -36,11 +43,11 @@ _FIRE_CENTRE_HFI_STATS_ADAPTER = TypeAdapter(dict[int, FireZoneHFIStats])
 _FIRE_CENTRE_TPI_STATS_ADAPTER = TypeAdapter(FireCentreTPIResponse)
 
 
-def _run_key(prefix: str, run_type: str, run_datetime, for_date) -> str:
+def run_cache_key(prefix: str, run_type: str, run_datetime, for_date) -> str:
     return f"{prefix}_{run_type}_{run_datetime}_{for_date}"
 
 
-def _fire_centre_run_key(
+def fire_centre_cache_key(
     prefix: str, fire_centre_name: str, run_type: str, run_datetime, for_date
 ) -> str:
     return f"{prefix}_{fire_centre_name}_{run_type}_{run_datetime}_{for_date}"
@@ -58,6 +65,7 @@ class ASARedisCache:
         # via asyncio.to_thread so this blocking redis-py call doesn't sit on the event loop.
         self._timeout_seconds = timeout_seconds
         self._client: Optional[StrictRedis] = None
+        self._compute_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     def connection_kwargs(self) -> dict:
         return {
@@ -76,6 +84,63 @@ class ASARedisCache:
         if self._client is None:
             self._client = StrictRedis(**self.connection_kwargs())
         return self._client
+
+    async def _acquire_compute_lock(self, cache_key: str) -> Lock | None:
+        try:
+            lock = self.client().lock(
+                f"{cache_key}:compute-lock",
+                timeout=compute_lock_timeout_seconds,
+                blocking_timeout=compute_lock_wait_seconds,
+                thread_local=False,
+            )
+            acquired = await asyncio.wait_for(
+                asyncio.to_thread(lock.acquire),
+                timeout=compute_lock_wait_seconds + self._timeout_seconds,
+            )
+            if acquired:
+                return lock
+            logger.warning("timed out waiting for redis compute lock %s", cache_key)
+        except Exception as error:
+            logger.error("unable to acquire redis compute lock %s", cache_key, exc_info=error)
+        return None
+
+    async def _release_compute_lock(self, cache_key: str, lock: Lock | None) -> None:
+        if lock is None:
+            return
+        try:
+            await asyncio.wait_for(asyncio.to_thread(lock.release), timeout=self._timeout_seconds)
+        except Exception as error:
+            # keep a successful response independent from best-effort cache coordination
+            logger.error("unable to release redis compute lock %s", cache_key, exc_info=error)
+
+    async def get_or_compute(
+        self,
+        cache_key: str,
+        get_cached: Callable[[], Awaitable[T | None]],
+        compute: Callable[[], Awaitable[T]],
+        put_cached: Callable[[T], Awaitable[None]],
+    ) -> T:
+        cached = await get_cached()
+        if cached is not None:
+            return cached
+
+        async with self._compute_locks[cache_key]:
+            # re-check before sending this worker's one contender to the distributed lock
+            cached = await get_cached()
+            if cached is not None:
+                return cached
+
+            lock = await self._acquire_compute_lock(cache_key)
+            try:
+                # another worker may have populated the cache while this worker waited
+                cached = await get_cached()
+                if cached is not None:
+                    return cached
+                result = await compute()
+                await put_cached(result)
+                return result
+            finally:
+                await self._release_compute_lock(cache_key, lock)
 
     async def _get(self, key: str, adapter: TypeAdapter) -> Optional[T]:
         try:
@@ -106,7 +171,7 @@ class ASARedisCache:
         self, run_type: str, run_datetime, for_date
     ) -> Optional[ProvincialSummaryResponse]:
         return await self._get(
-            _run_key("provincial_summary", run_type, run_datetime, for_date),
+            run_cache_key("provincial_summary", run_type, run_datetime, for_date),
             _PROVINCIAL_SUMMARY_ADAPTER,
         )
 
@@ -114,7 +179,7 @@ class ASARedisCache:
         self, run_type: str, run_datetime, for_date, response: ProvincialSummaryResponse
     ):
         await self._put(
-            _run_key("provincial_summary", run_type, run_datetime, for_date),
+            run_cache_key("provincial_summary", run_type, run_datetime, for_date),
             response,
             _PROVINCIAL_SUMMARY_ADAPTER,
         )
@@ -123,35 +188,39 @@ class ASARedisCache:
         self, run_type: str, run_datetime, for_date
     ) -> Optional[HFIStatsResponse]:
         return await self._get(
-            _run_key("hfi_stats", run_type, run_datetime, for_date), _HFI_STATS_ADAPTER
+            run_cache_key("hfi_stats", run_type, run_datetime, for_date), _HFI_STATS_ADAPTER
         )
 
     async def put_cached_hfi_stats(
         self, run_type: str, run_datetime, for_date, response: HFIStatsResponse
     ):
         await self._put(
-            _run_key("hfi_stats", run_type, run_datetime, for_date), response, _HFI_STATS_ADAPTER
+            run_cache_key("hfi_stats", run_type, run_datetime, for_date),
+            response,
+            _HFI_STATS_ADAPTER,
         )
 
     async def get_cached_tpi_stats(
         self, run_type: str, run_datetime, for_date
     ) -> Optional[TPIResponse]:
         return await self._get(
-            _run_key("tpi_stats", run_type, run_datetime, for_date), _TPI_STATS_ADAPTER
+            run_cache_key("tpi_stats", run_type, run_datetime, for_date), _TPI_STATS_ADAPTER
         )
 
     async def put_cached_tpi_stats(
         self, run_type: str, run_datetime, for_date, response: TPIResponse
     ):
         await self._put(
-            _run_key("tpi_stats", run_type, run_datetime, for_date), response, _TPI_STATS_ADAPTER
+            run_cache_key("tpi_stats", run_type, run_datetime, for_date),
+            response,
+            _TPI_STATS_ADAPTER,
         )
 
     async def get_cached_fire_centre_hfi_stats(
         self, fire_centre_name: str, run_type: str, run_datetime, for_date
     ) -> Optional[dict[int, FireZoneHFIStats]]:
         return await self._get(
-            _fire_centre_run_key(
+            fire_centre_cache_key(
                 "fire_centre_hfi_stats", fire_centre_name, run_type, run_datetime, for_date
             ),
             _FIRE_CENTRE_HFI_STATS_ADAPTER,
@@ -166,7 +235,7 @@ class ASARedisCache:
         value: dict[int, FireZoneHFIStats],
     ):
         await self._put(
-            _fire_centre_run_key(
+            fire_centre_cache_key(
                 "fire_centre_hfi_stats", fire_centre_name, run_type, run_datetime, for_date
             ),
             value,
@@ -177,7 +246,7 @@ class ASARedisCache:
         self, fire_centre_name: str, run_type: str, run_datetime, for_date
     ) -> Optional[FireCentreTPIResponse]:
         return await self._get(
-            _fire_centre_run_key(
+            fire_centre_cache_key(
                 "fire_centre_tpi_stats", fire_centre_name, run_type, run_datetime, for_date
             ),
             _FIRE_CENTRE_TPI_STATS_ADAPTER,
@@ -192,7 +261,7 @@ class ASARedisCache:
         response: FireCentreTPIResponse,
     ):
         await self._put(
-            _fire_centre_run_key(
+            fire_centre_cache_key(
                 "fire_centre_tpi_stats", fire_centre_name, run_type, run_datetime, for_date
             ),
             response,

--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/advisory_run_stats/stats.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/advisory_run_stats/stats.py
@@ -2,10 +2,12 @@
 fire shape status rollup, per-zone HFI stats, per-zone elevation TPI stats) and shapes it into
 API responses, caching in Redis since this data never changes once a run completes."""
 
+import asyncio
 import logging
 import math
+from collections import defaultdict
 from datetime import date, datetime
-from typing import List
+from typing import Awaitable, Callable, List, TypeVar
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from wps_shared.db.crud.auto_spatial_advisory import (
@@ -18,8 +20,10 @@ from wps_shared.db.crud.auto_spatial_advisory import (
     get_precomputed_stats_for_shape,
     get_provincial_rollup,
     get_tpi_fuel_areas,
-    get_tpi_stats as fetch_tpi_stats_rows,
     get_zone_source_ids_in_centre,
+)
+from wps_shared.db.crud.auto_spatial_advisory import (
+    get_tpi_stats as fetch_tpi_stats_rows,
 )
 from wps_shared.db.crud.fuel_layer import get_fuel_type_raster_by_year
 from wps_shared.db.database import get_async_read_session_scope
@@ -41,6 +45,35 @@ from app.auto_spatial_advisory.zone_stats import (
 )
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# A completed run's data is the same for every caller (today/tomorrow), so a burst of
+# concurrent requests all miss the cache at once and would otherwise all recompute in
+# parallel instead of one caller computing it and the rest reading the cache. Keyed by the
+# same (kind, run_type, run_datetime, for_date[, fire_centre_name]) tuple each call site
+# already has this is unbounded but low-cardinality (one entry per run/day) and gunicorn recycles
+# workers every ~50 requests anyway, so it never grows indefinitely.
+_compute_locks: dict[tuple, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+
+async def _get_or_compute(
+    key: tuple,
+    get_cached: Callable[[], Awaitable[T | None]],
+    compute: Callable[[], Awaitable[T]],
+    put_cached: Callable[[T], Awaitable[None]],
+) -> T:
+    cached = await get_cached()
+    if cached is not None:
+        return cached
+    async with _compute_locks[key]:
+        # Re-check: another caller may have computed and cached this while we waited on the lock.
+        cached = await get_cached()
+        if cached is not None:
+            return cached
+        result = await compute()
+        await put_cached(result)
+        return result
 
 
 async def get_all_zone_data_for_source_ids(
@@ -126,53 +159,71 @@ async def get_provincial_summary(
     run_type: RunType, run_datetime: datetime, for_date: date
 ) -> ProvincialSummaryResponse:
     """Return all Fire Centres with their fire shapes and the HFI status of those shapes."""
-    cached = await asa_stats_cache.get_cached_provincial_summary(run_type.value, run_datetime, for_date)
-    if cached is not None:
-        return cached
 
-    async with get_async_read_session_scope() as session:
-        fire_shape_status_details = await get_provincial_rollup(
-            session, RunTypeEnum(run_type.value), run_datetime, for_date
-        )
+    async def compute() -> ProvincialSummaryResponse:
+        async with get_async_read_session_scope() as session:
+            fire_shape_status_details = await get_provincial_rollup(
+                session, RunTypeEnum(run_type.value), run_datetime, for_date
+            )
+        return ProvincialSummaryResponse(provincial_summary=fire_shape_status_details)
 
-    response = ProvincialSummaryResponse(provincial_summary=fire_shape_status_details)
-    await asa_stats_cache.put_cached_provincial_summary(run_type.value, run_datetime, for_date, response)
-    return response
+    return await _get_or_compute(
+        ("provincial_summary", run_type.value, run_datetime, for_date),
+        lambda: asa_stats_cache.get_cached_provincial_summary(
+            run_type.value, run_datetime, for_date
+        ),
+        compute,
+        lambda response: asa_stats_cache.put_cached_provincial_summary(
+            run_type.value, run_datetime, for_date, response
+        ),
+    )
 
 
-async def get_hfi_stats(run_type: RunType, run_datetime: datetime, for_date: date) -> HFIStatsResponse:
+async def get_hfi_stats(
+    run_type: RunType, run_datetime: datetime, for_date: date
+) -> HFIStatsResponse:
     """Fetch fuel type and critical hours data for all fire zone units."""
-    cached = await asa_stats_cache.get_cached_hfi_stats(run_type.value, run_datetime, for_date)
-    if cached is not None:
-        return cached
 
-    async with get_async_read_session_scope() as session:
-        zone_source_ids = await get_all_zone_source_ids(session)
-        all_zone_data = await get_all_zone_data_for_source_ids(
-            session, zone_source_ids, run_type, for_date, run_datetime
-        )
+    async def compute() -> HFIStatsResponse:
+        async with get_async_read_session_scope() as session:
+            zone_source_ids = await get_all_zone_source_ids(session)
+            all_zone_data = await get_all_zone_data_for_source_ids(
+                session, zone_source_ids, run_type, for_date, run_datetime
+            )
+        return HFIStatsResponse(zone_data=all_zone_data)
 
-    response = HFIStatsResponse(zone_data=all_zone_data)
-    await asa_stats_cache.put_cached_hfi_stats(run_type.value, run_datetime, for_date, response)
-    return response
+    return await _get_or_compute(
+        ("hfi_stats", run_type.value, run_datetime, for_date),
+        lambda: asa_stats_cache.get_cached_hfi_stats(run_type.value, run_datetime, for_date),
+        compute,
+        lambda response: asa_stats_cache.put_cached_hfi_stats(
+            run_type.value, run_datetime, for_date, response
+        ),
+    )
 
 
 async def get_fire_centre_hfi_stats(
     fire_centre_name: str, run_type: RunType, run_datetime: datetime, for_date: date
 ) -> dict[int, FireZoneHFIStats]:
     """Fetch fuel type and critical hours data for all fire zones in one fire centre."""
-    cached = await asa_stats_cache.get_cached_fire_centre_hfi_stats(fire_centre_name, run_type.value, run_datetime, for_date)
-    if cached is not None:
-        return cached
 
-    async with get_async_read_session_scope() as session:
-        zone_source_ids = await get_zone_source_ids_in_centre(session, fire_centre_name)
-        all_zone_data = await get_all_zone_data_for_source_ids(
-            session, zone_source_ids, run_type, for_date, run_datetime
-        )
+    async def compute() -> dict[int, FireZoneHFIStats]:
+        async with get_async_read_session_scope() as session:
+            zone_source_ids = await get_zone_source_ids_in_centre(session, fire_centre_name)
+            return await get_all_zone_data_for_source_ids(
+                session, zone_source_ids, run_type, for_date, run_datetime
+            )
 
-    await asa_stats_cache.put_cached_fire_centre_hfi_stats(fire_centre_name, run_type.value, run_datetime, for_date, all_zone_data)
-    return all_zone_data
+    return await _get_or_compute(
+        ("fire_centre_hfi_stats", fire_centre_name, run_type.value, run_datetime, for_date),
+        lambda: asa_stats_cache.get_cached_fire_centre_hfi_stats(
+            fire_centre_name, run_type.value, run_datetime, for_date
+        ),
+        compute,
+        lambda all_zone_data: asa_stats_cache.put_cached_fire_centre_hfi_stats(
+            fire_centre_name, run_type.value, run_datetime, for_date, all_zone_data
+        ),
+    )
 
 
 def build_firezone_tpi_stats(tpi_stats, tpi_fuel_stats) -> list[FireZoneTPIStats]:
@@ -213,37 +264,51 @@ def build_firezone_tpi_stats(tpi_stats, tpi_fuel_stats) -> list[FireZoneTPIStats
 
 async def get_tpi_stats(run_type: RunType, run_datetime: datetime, for_date: date) -> TPIResponse:
     """Return the elevation TPI statistics for each advisory threshold for all fire shapes."""
-    cached = await asa_stats_cache.get_cached_tpi_stats(run_type.value, run_datetime, for_date)
-    if cached is not None:
-        return cached
 
-    async with get_async_read_session_scope() as session:
-        tpi_stats = await fetch_tpi_stats_rows(session, run_type, run_datetime, for_date)
-        fuel_type_raster = await get_fuel_type_raster_by_year(session, for_date.year)
-        tpi_fuel_stats = await get_tpi_fuel_areas(session, fuel_type_raster.id)
-        hfi_tpi_areas_by_zone = build_firezone_tpi_stats(tpi_stats, tpi_fuel_stats)
+    async def compute() -> TPIResponse:
+        async with get_async_read_session_scope() as session:
+            tpi_stats = await fetch_tpi_stats_rows(session, run_type, run_datetime, for_date)
+            fuel_type_raster = await get_fuel_type_raster_by_year(session, for_date.year)
+            tpi_fuel_stats = await get_tpi_fuel_areas(session, fuel_type_raster.id)
+            hfi_tpi_areas_by_zone = build_firezone_tpi_stats(tpi_stats, tpi_fuel_stats)
+        return TPIResponse(firezone_tpi_stats=hfi_tpi_areas_by_zone)
 
-    response = TPIResponse(firezone_tpi_stats=hfi_tpi_areas_by_zone)
-    await asa_stats_cache.put_cached_tpi_stats(run_type.value, run_datetime, for_date, response)
-    return response
+    return await _get_or_compute(
+        ("tpi_stats", run_type.value, run_datetime, for_date),
+        lambda: asa_stats_cache.get_cached_tpi_stats(run_type.value, run_datetime, for_date),
+        compute,
+        lambda response: asa_stats_cache.put_cached_tpi_stats(
+            run_type.value, run_datetime, for_date, response
+        ),
+    )
 
 
 async def get_fire_centre_tpi_stats(
     fire_centre_name: str, run_type: RunType, run_datetime: datetime, for_date: date
 ) -> FireCentreTPIResponse:
     """Return the elevation TPI statistics for each advisory threshold for one fire centre."""
-    cached = await asa_stats_cache.get_cached_fire_centre_tpi_stats(fire_centre_name, run_type.value, run_datetime, for_date)
-    if cached is not None:
-        return cached
 
-    async with get_async_read_session_scope() as session:
-        tpi_stats_for_centre = await get_centre_tpi_stats(
-            session, fire_centre_name, run_type, run_datetime, for_date
+    async def compute() -> FireCentreTPIResponse:
+        async with get_async_read_session_scope() as session:
+            tpi_stats_for_centre = await get_centre_tpi_stats(
+                session, fire_centre_name, run_type, run_datetime, for_date
+            )
+            fuel_type_raster = await get_fuel_type_raster_by_year(session, for_date.year)
+            tpi_fuel_stats = await get_fire_centre_tpi_fuel_areas(
+                session, fire_centre_name, fuel_type_raster.id
+            )
+            hfi_tpi_areas_by_zone = build_firezone_tpi_stats(tpi_stats_for_centre, tpi_fuel_stats)
+        return FireCentreTPIResponse(
+            fire_centre_name=fire_centre_name, firezone_tpi_stats=hfi_tpi_areas_by_zone
         )
-        fuel_type_raster = await get_fuel_type_raster_by_year(session, for_date.year)
-        tpi_fuel_stats = await get_fire_centre_tpi_fuel_areas(session, fire_centre_name, fuel_type_raster.id)
-        hfi_tpi_areas_by_zone = build_firezone_tpi_stats(tpi_stats_for_centre, tpi_fuel_stats)
 
-    response = FireCentreTPIResponse(fire_centre_name=fire_centre_name, firezone_tpi_stats=hfi_tpi_areas_by_zone)
-    await asa_stats_cache.put_cached_fire_centre_tpi_stats(fire_centre_name, run_type.value, run_datetime, for_date, response)
-    return response
+    return await _get_or_compute(
+        ("fire_centre_tpi_stats", fire_centre_name, run_type.value, run_datetime, for_date),
+        lambda: asa_stats_cache.get_cached_fire_centre_tpi_stats(
+            fire_centre_name, run_type.value, run_datetime, for_date
+        ),
+        compute,
+        lambda response: asa_stats_cache.put_cached_fire_centre_tpi_stats(
+            fire_centre_name, run_type.value, run_datetime, for_date, response
+        ),
+    )

--- a/backend/packages/wps-api/src/app/auto_spatial_advisory/advisory_run_stats/stats.py
+++ b/backend/packages/wps-api/src/app/auto_spatial_advisory/advisory_run_stats/stats.py
@@ -2,12 +2,10 @@
 fire shape status rollup, per-zone HFI stats, per-zone elevation TPI stats) and shapes it into
 API responses, caching in Redis since this data never changes once a run completes."""
 
-import asyncio
 import logging
 import math
-from collections import defaultdict
 from datetime import date, datetime
-from typing import Awaitable, Callable, List, TypeVar
+from typing import List
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from wps_shared.db.crud.auto_spatial_advisory import (
@@ -37,7 +35,11 @@ from wps_shared.schemas.fba import (
     TPIResponse,
 )
 
-from app.auto_spatial_advisory.advisory_run_stats.cache import asa_stats_cache
+from app.auto_spatial_advisory.advisory_run_stats.cache import (
+    asa_stats_cache,
+    fire_centre_cache_key,
+    run_cache_key,
+)
 from app.auto_spatial_advisory.process_hfi import RunType
 from app.auto_spatial_advisory.zone_stats import (
     get_fuel_type_area_stats,
@@ -45,35 +47,6 @@ from app.auto_spatial_advisory.zone_stats import (
 )
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T")
-
-# A completed run's data is the same for every caller (today/tomorrow), so a burst of
-# concurrent requests all miss the cache at once and would otherwise all recompute in
-# parallel instead of one caller computing it and the rest reading the cache. Keyed by the
-# same (kind, run_type, run_datetime, for_date[, fire_centre_name]) tuple each call site
-# already has this is unbounded but low-cardinality (one entry per run/day) and gunicorn recycles
-# workers every ~50 requests anyway, so it never grows indefinitely.
-_compute_locks: dict[tuple, asyncio.Lock] = defaultdict(asyncio.Lock)
-
-
-async def _get_or_compute(
-    key: tuple,
-    get_cached: Callable[[], Awaitable[T | None]],
-    compute: Callable[[], Awaitable[T]],
-    put_cached: Callable[[T], Awaitable[None]],
-) -> T:
-    cached = await get_cached()
-    if cached is not None:
-        return cached
-    async with _compute_locks[key]:
-        # Re-check: another caller may have computed and cached this while we waited on the lock.
-        cached = await get_cached()
-        if cached is not None:
-            return cached
-        result = await compute()
-        await put_cached(result)
-        return result
 
 
 async def get_all_zone_data_for_source_ids(
@@ -167,8 +140,8 @@ async def get_provincial_summary(
             )
         return ProvincialSummaryResponse(provincial_summary=fire_shape_status_details)
 
-    return await _get_or_compute(
-        ("provincial_summary", run_type.value, run_datetime, for_date),
+    return await asa_stats_cache.get_or_compute(
+        run_cache_key("provincial_summary", run_type.value, run_datetime, for_date),
         lambda: asa_stats_cache.get_cached_provincial_summary(
             run_type.value, run_datetime, for_date
         ),
@@ -192,8 +165,8 @@ async def get_hfi_stats(
             )
         return HFIStatsResponse(zone_data=all_zone_data)
 
-    return await _get_or_compute(
-        ("hfi_stats", run_type.value, run_datetime, for_date),
+    return await asa_stats_cache.get_or_compute(
+        run_cache_key("hfi_stats", run_type.value, run_datetime, for_date),
         lambda: asa_stats_cache.get_cached_hfi_stats(run_type.value, run_datetime, for_date),
         compute,
         lambda response: asa_stats_cache.put_cached_hfi_stats(
@@ -214,8 +187,14 @@ async def get_fire_centre_hfi_stats(
                 session, zone_source_ids, run_type, for_date, run_datetime
             )
 
-    return await _get_or_compute(
-        ("fire_centre_hfi_stats", fire_centre_name, run_type.value, run_datetime, for_date),
+    return await asa_stats_cache.get_or_compute(
+        fire_centre_cache_key(
+            "fire_centre_hfi_stats",
+            fire_centre_name,
+            run_type.value,
+            run_datetime,
+            for_date,
+        ),
         lambda: asa_stats_cache.get_cached_fire_centre_hfi_stats(
             fire_centre_name, run_type.value, run_datetime, for_date
         ),
@@ -273,8 +252,8 @@ async def get_tpi_stats(run_type: RunType, run_datetime: datetime, for_date: dat
             hfi_tpi_areas_by_zone = build_firezone_tpi_stats(tpi_stats, tpi_fuel_stats)
         return TPIResponse(firezone_tpi_stats=hfi_tpi_areas_by_zone)
 
-    return await _get_or_compute(
-        ("tpi_stats", run_type.value, run_datetime, for_date),
+    return await asa_stats_cache.get_or_compute(
+        run_cache_key("tpi_stats", run_type.value, run_datetime, for_date),
         lambda: asa_stats_cache.get_cached_tpi_stats(run_type.value, run_datetime, for_date),
         compute,
         lambda response: asa_stats_cache.put_cached_tpi_stats(
@@ -302,8 +281,14 @@ async def get_fire_centre_tpi_stats(
             fire_centre_name=fire_centre_name, firezone_tpi_stats=hfi_tpi_areas_by_zone
         )
 
-    return await _get_or_compute(
-        ("fire_centre_tpi_stats", fire_centre_name, run_type.value, run_datetime, for_date),
+    return await asa_stats_cache.get_or_compute(
+        fire_centre_cache_key(
+            "fire_centre_tpi_stats",
+            fire_centre_name,
+            run_type.value,
+            run_datetime,
+            for_date,
+        ),
         lambda: asa_stats_cache.get_cached_fire_centre_tpi_stats(
             fire_centre_name, run_type.value, run_datetime, for_date
         ),

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_advisory_run_stats.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_advisory_run_stats.py
@@ -2,6 +2,7 @@
 and the cache-aware public functions (get_provincial_summary, get_hfi_stats, get_tpi_stats, and
 their fire-centre-scoped counterparts)."""
 
+import asyncio
 from collections import namedtuple
 from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -517,3 +518,49 @@ async def test_get_fire_centre_tpi_stats_cache_hit_skips_db(mocker):
 
     assert result is cached_response
     mock_centre_tpi_stats.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_get_provincial_summary_concurrent_callers_compute_once(mocker):
+    """A burst of concurrent callers for the same (run_type, run_datetime, for_date) must not
+    each recompute independently -- that's the cache-stampede this locking exists to prevent.
+    Only the first caller should reach get_provincial_rollup; everyone else should block on the
+    lock and then read back what the first caller cached."""
+    stored: dict = {}
+
+    async def fake_get_cached(*_args):
+        return stored.get("value")
+
+    async def fake_put_cached(*args):
+        stored["value"] = args[-1]
+
+    mocker.patch(
+        "app.auto_spatial_advisory.advisory_run_stats.stats.asa_stats_cache.get_cached_provincial_summary",
+        side_effect=fake_get_cached,
+    )
+    mocker.patch(
+        "app.auto_spatial_advisory.advisory_run_stats.stats.asa_stats_cache.put_cached_provincial_summary",
+        side_effect=fake_put_cached,
+    )
+    mocker.patch("app.auto_spatial_advisory.advisory_run_stats.stats.get_async_read_session_scope")
+
+    async def slow_rollup(*_args, **_kwargs):
+        # Holds the lock long enough for other concurrent callers to queue up behind it.
+        await asyncio.sleep(0.05)
+        return []
+
+    mock_rollup = mocker.patch(
+        "app.auto_spatial_advisory.advisory_run_stats.stats.get_provincial_rollup",
+        side_effect=slow_rollup,
+    )
+
+    concurrent_for_date = date(2099, 1, 1)  # unique key: isolates this test's lock from others
+    results = await asyncio.gather(
+        *(
+            get_provincial_summary(RunType.FORECAST, RUN_DATETIME, concurrent_for_date)
+            for _ in range(10)
+        )
+    )
+
+    assert mock_rollup.call_count == 1
+    assert all(result == ProvincialSummaryResponse(provincial_summary=[]) for result in results)

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_advisory_run_stats.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_advisory_run_stats.py
@@ -524,8 +524,7 @@ async def test_get_fire_centre_tpi_stats_cache_hit_skips_db(mocker):
 async def test_get_provincial_summary_concurrent_callers_compute_once(mocker):
     """A burst of concurrent callers for the same (run_type, run_datetime, for_date) must not
     each recompute independently -- that's the cache-stampede this locking exists to prevent.
-    Only the first caller should reach get_provincial_rollup; everyone else should block on the
-    lock and then read back what the first caller cached."""
+    The local lock must retain that protection when the distributed Redis lock is unavailable."""
     stored: dict = {}
 
     async def fake_get_cached(*_args):
@@ -542,10 +541,16 @@ async def test_get_provincial_summary_concurrent_callers_compute_once(mocker):
         "app.auto_spatial_advisory.advisory_run_stats.stats.asa_stats_cache.put_cached_provincial_summary",
         side_effect=fake_put_cached,
     )
+    mock_redis = MagicMock()
+    mock_redis.lock.return_value.acquire.side_effect = ConnectionError("redis unavailable")
+    mocker.patch(
+        "app.auto_spatial_advisory.advisory_run_stats.stats.asa_stats_cache.client",
+        return_value=mock_redis,
+    )
     mocker.patch("app.auto_spatial_advisory.advisory_run_stats.stats.get_async_read_session_scope")
 
     async def slow_rollup(*_args, **_kwargs):
-        # Holds the lock long enough for other concurrent callers to queue up behind it.
+        # hold the lock long enough for other concurrent callers to queue up behind it
         await asyncio.sleep(0.05)
         return []
 
@@ -554,7 +559,7 @@ async def test_get_provincial_summary_concurrent_callers_compute_once(mocker):
         side_effect=slow_rollup,
     )
 
-    concurrent_for_date = date(2099, 1, 1)  # unique key: isolates this test's lock from others
+    concurrent_for_date = date(2099, 1, 1)  # unique key isolates this test's lock from others
     results = await asyncio.gather(
         *(
             get_provincial_summary(RunType.FORECAST, RUN_DATETIME, concurrent_for_date)
@@ -563,4 +568,5 @@ async def test_get_provincial_summary_concurrent_callers_compute_once(mocker):
     )
 
     assert mock_rollup.call_count == 1
+    mock_redis.lock.return_value.acquire.assert_called_once_with()
     assert all(result == ProvincialSummaryResponse(provincial_summary=[]) for result in results)

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_cache.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_cache.py
@@ -140,9 +140,10 @@ async def test_get_or_compute_releases_lock_when_compute_raises(mocker):
     mocker.patch.object(redis_cache, "client", return_value=mock_client)
     get_cached = AsyncMock(side_effect=[None, None, None])
     compute = AsyncMock(side_effect=RuntimeError("compute failed"))
+    put_cached = AsyncMock()
 
     with pytest.raises(RuntimeError, match="compute failed"):
-        await redis_cache.get_or_compute("hfi_stats_run", get_cached, compute, AsyncMock())
+        await redis_cache.get_or_compute("hfi_stats_run", get_cached, compute, put_cached)
 
     mock_lock.release.assert_called_once_with()
 

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_cache.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_cache.py
@@ -3,12 +3,17 @@ ASARedisCache used by advisory_run_stats to avoid re-hitting Postgres for data t
 once an SFMS run completes."""
 
 import time
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from wps_shared.schemas.fba import HFIStatsResponse, ProvincialSummaryResponse, TPIResponse
 
-from app.auto_spatial_advisory.advisory_run_stats.cache import ASARedisCache, asa_stats_cache
+from app.auto_spatial_advisory.advisory_run_stats.cache import (
+    ASARedisCache,
+    asa_stats_cache,
+    compute_lock_timeout_seconds,
+    compute_lock_wait_seconds,
+)
 
 RUN_TYPE = "forecast"
 RUN_DATETIME = "2024-07-15T12:00:00+00:00"
@@ -66,6 +71,80 @@ async def test_put_cached_hfi_stats_redis_error_does_not_raise(mocker):
     await asa_stats_cache.put_cached_hfi_stats(
         RUN_TYPE, RUN_DATETIME, FOR_DATE, HFIStatsResponse(zone_data={})
     )  # does not raise
+
+
+@pytest.mark.anyio
+async def test_get_or_compute_uses_distributed_lease_and_releases(mocker):
+    redis_cache = ASARedisCache()
+    mock_client = MagicMock()
+    mock_lock = mock_client.lock.return_value
+    mock_lock.acquire.return_value = True
+    mocker.patch.object(redis_cache, "client", return_value=mock_client)
+    response = HFIStatsResponse(zone_data={})
+    get_cached = AsyncMock(side_effect=[None, None, None])
+    compute = AsyncMock(return_value=response)
+    put_cached = AsyncMock()
+
+    result = await redis_cache.get_or_compute("hfi_stats_run", get_cached, compute, put_cached)
+
+    assert result is response
+    mock_client.lock.assert_called_once_with(
+        "hfi_stats_run:compute-lock",
+        timeout=compute_lock_timeout_seconds,
+        blocking_timeout=compute_lock_wait_seconds,
+        thread_local=False,
+    )
+    mock_lock.acquire.assert_called_once_with()
+    mock_lock.release.assert_called_once_with()
+
+
+@pytest.mark.anyio
+async def test_get_or_compute_cache_hit_skips_locks_and_compute(mocker):
+    redis_cache = ASARedisCache()
+    mock_client = mocker.patch.object(redis_cache, "client")
+    response = HFIStatsResponse(zone_data={})
+    compute = AsyncMock()
+
+    result = await redis_cache.get_or_compute(
+        "hfi_stats_run", AsyncMock(return_value=response), compute, AsyncMock()
+    )
+
+    assert result is response
+    mock_client.assert_not_called()
+    compute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_get_or_compute_redis_error_falls_back_without_raising(mocker):
+    redis_cache = ASARedisCache()
+    mock_client = MagicMock()
+    mock_lock = mock_client.lock.return_value
+    mock_lock.acquire.side_effect = ConnectionError("redis unavailable")
+    mocker.patch.object(redis_cache, "client", return_value=mock_client)
+    response = HFIStatsResponse(zone_data={})
+    get_cached = AsyncMock(side_effect=[None, None, None])
+    compute = AsyncMock(return_value=response)
+
+    result = await redis_cache.get_or_compute("hfi_stats_run", get_cached, compute, AsyncMock())
+
+    assert result is response
+    mock_lock.release.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_get_or_compute_releases_lock_when_compute_raises(mocker):
+    redis_cache = ASARedisCache()
+    mock_client = MagicMock()
+    mock_lock = mock_client.lock.return_value
+    mock_lock.acquire.return_value = True
+    mocker.patch.object(redis_cache, "client", return_value=mock_client)
+    get_cached = AsyncMock(side_effect=[None, None, None])
+    compute = AsyncMock(side_effect=RuntimeError("compute failed"))
+
+    with pytest.raises(RuntimeError, match="compute failed"):
+        await redis_cache.get_or_compute("hfi_stats_run", get_cached, compute, AsyncMock())
+
+    mock_lock.release.assert_called_once_with()
 
 
 @pytest.mark.anyio

--- a/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_cache_integration.py
+++ b/backend/packages/wps-api/src/app/tests/auto_spatial_advisory/test_cache_integration.py
@@ -9,6 +9,7 @@ that socket_connect_timeout doesn't cover DNS resolution, only a real unreachabl
 (see the timeout test below, and the asyncio.wait_for fix in cache.py).
 """
 
+import asyncio
 import time
 
 import pytest
@@ -21,9 +22,11 @@ from wps_shared.schemas.fba import (
     TPIResponse,
 )
 
-from app.auto_spatial_advisory.advisory_run_stats.cache import ASARedisCache
+from app.auto_spatial_advisory.advisory_run_stats.cache import ASARedisCache, run_cache_key
 
-TESTCONTAINERS_REDIS_IMAGE = "redis:6-alpine"  # matches openshift/templates/redis.yaml's redis:6-el9
+TESTCONTAINERS_REDIS_IMAGE = (
+    "redis:6-alpine"  # matches openshift/templates/redis.yaml's redis:6-el9
+)
 
 RUN_TYPE = "forecast"
 RUN_DATETIME = "2025-01-01T12:00:00+00:00"
@@ -53,8 +56,13 @@ def real_cache(redis_container, monkeypatch):
 async def test_put_then_get_round_trips_through_real_redis(real_cache):
     """Every put_cached_*/get_cached_* pair, called directly against a real Redis."""
     provincial_summary = ProvincialSummaryResponse(provincial_summary=[])
-    await real_cache.put_cached_provincial_summary(RUN_TYPE, RUN_DATETIME, FOR_DATE, provincial_summary)
-    assert await real_cache.get_cached_provincial_summary(RUN_TYPE, RUN_DATETIME, FOR_DATE) == provincial_summary
+    await real_cache.put_cached_provincial_summary(
+        RUN_TYPE, RUN_DATETIME, FOR_DATE, provincial_summary
+    )
+    assert (
+        await real_cache.get_cached_provincial_summary(RUN_TYPE, RUN_DATETIME, FOR_DATE)
+        == provincial_summary
+    )
 
     hfi_stats = HFIStatsResponse(zone_data=SAMPLE_ZONE_DATA)
     await real_cache.put_cached_hfi_stats(RUN_TYPE, RUN_DATETIME, FOR_DATE, hfi_stats)
@@ -68,16 +76,22 @@ async def test_put_then_get_round_trips_through_real_redis(real_cache):
         FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE, SAMPLE_ZONE_DATA
     )
     assert (
-        await real_cache.get_cached_fire_centre_hfi_stats(FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE)
+        await real_cache.get_cached_fire_centre_hfi_stats(
+            FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE
+        )
         == SAMPLE_ZONE_DATA
     )
 
-    fire_centre_tpi_stats = FireCentreTPIResponse(fire_centre_name=FIRE_CENTRE_NAME, firezone_tpi_stats=[])
+    fire_centre_tpi_stats = FireCentreTPIResponse(
+        fire_centre_name=FIRE_CENTRE_NAME, firezone_tpi_stats=[]
+    )
     await real_cache.put_cached_fire_centre_tpi_stats(
         FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE, fire_centre_tpi_stats
     )
     assert (
-        await real_cache.get_cached_fire_centre_tpi_stats(FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE)
+        await real_cache.get_cached_fire_centre_tpi_stats(
+            FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE
+        )
         == fire_centre_tpi_stats
     )
 
@@ -89,11 +103,15 @@ async def test_get_miss_returns_none_against_real_redis(real_cache):
     assert await real_cache.get_cached_hfi_stats(RUN_TYPE, RUN_DATETIME, FOR_DATE) is None
     assert await real_cache.get_cached_tpi_stats(RUN_TYPE, RUN_DATETIME, FOR_DATE) is None
     assert (
-        await real_cache.get_cached_fire_centre_hfi_stats(FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE)
+        await real_cache.get_cached_fire_centre_hfi_stats(
+            FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE
+        )
         is None
     )
     assert (
-        await real_cache.get_cached_fire_centre_tpi_stats(FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE)
+        await real_cache.get_cached_fire_centre_tpi_stats(
+            FIRE_CENTRE_NAME, RUN_TYPE, RUN_DATETIME, FOR_DATE
+        )
         is None
     )
 
@@ -107,6 +125,37 @@ async def test_ttl_is_set_on_write(real_cache):
     key = f"provincial_summary_{RUN_TYPE}_{RUN_DATETIME}_{FOR_DATE}"
     ttl = real_cache.client().ttl(key)
     assert 0 < ttl <= 86400
+
+
+@pytest.mark.anyio
+async def test_get_or_compute_coordinates_independent_redis_clients(real_cache):
+    second_cache = ASARedisCache()
+    cache_key = run_cache_key("provincial_summary", RUN_TYPE, RUN_DATETIME, FOR_DATE)
+    compute_count = 0
+
+    async def compute() -> ProvincialSummaryResponse:
+        nonlocal compute_count
+        compute_count += 1
+        await asyncio.sleep(0.05)
+        return ProvincialSummaryResponse(provincial_summary=[])
+
+    async def get_or_compute(cache: ASARedisCache) -> ProvincialSummaryResponse:
+        return await cache.get_or_compute(
+            cache_key,
+            lambda: cache.get_cached_provincial_summary(RUN_TYPE, RUN_DATETIME, FOR_DATE),
+            compute,
+            lambda response: cache.put_cached_provincial_summary(
+                RUN_TYPE, RUN_DATETIME, FOR_DATE, response
+            ),
+        )
+
+    results = await asyncio.gather(get_or_compute(real_cache), get_or_compute(second_cache))
+
+    assert compute_count == 1
+    assert results == [
+        ProvincialSummaryResponse(provincial_summary=[]),
+        ProvincialSummaryResponse(provincial_summary=[]),
+    ]
 
 
 @pytest.mark.anyio

--- a/backend/packages/wps-api/src/app/tests/conftest.py
+++ b/backend/packages/wps-api/src/app/tests/conftest.py
@@ -37,6 +37,13 @@ def mock_advisory_run_stats_redis(monkeypatch):
     class. A test that wants to exercise ASARedisCache's own connection/client-building logic can
     just instantiate a fresh ASARedisCache(), unaffected by this."""
 
+    class MockLock:
+        def acquire(self):
+            return True
+
+        def release(self):
+            pass
+
     class MockRedis:
         def get(self, name):
             return None
@@ -46,6 +53,9 @@ def mock_advisory_run_stats_redis(monkeypatch):
 
         def delete(self, name):
             pass
+
+        def lock(self, *_args, **_kwargs):
+            return MockLock()
 
     monkeypatch.setattr(advisory_run_stats_cache.asa_stats_cache, "client", lambda: MockRedis())
 


### PR DESCRIPTION
Create a lock for each cache key so that only one writer sets the cached result to prevent a thundering heard from all attempting at once.

Updates:
  - Replaced process-only coordination with a Redis distributed lock, ensuring Gunicorn workers and pods don’t simultaneously compute the same cold cache key.
  - Retained a per-process `asyncio.Lock` to reduce Redis contention and provide fallback when Redis is unavailable.
  - Centralized cache lookup, locking, computation, writing, and release in `ASARedisCache.get_or_compute()`
  - Ensured Redis locks are explicitly released in finally
  - Reduced the maximum lock wait from 30 to 5 seconds to keep mobile requests responsive (unsure on what this value should be, load tests may help determine)

# Test Links:
[Landing Page](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5803-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
