### PR TITLE
API Portal: Access Only License

### DIFF
--- a/openshift/aps/sfms-fwi-dataset.yaml
+++ b/openshift/aps/sfms-fwi-dataset.yaml
@@ -18,7 +18,7 @@ notes: |
 tags: [sfms, fwi, fire-weather-index, wildfire, fire-danger, cffdrs, openapi]
 organization: ministry-of-forests
 organizationUnit: bc-wildfire-service
-license_title: Open Government Licence - British Columbia
+license_title: Access Only
 view_audience: Government
 security_class: PUBLIC
 record_publish_date: "2026-06-30"

--- a/openshift/aps/sfms-fwi-dataset.yaml
+++ b/openshift/aps/sfms-fwi-dataset.yaml
@@ -18,6 +18,7 @@ notes: |
 tags: [sfms, fwi, fire-weather-index, wildfire, fire-danger, cffdrs, openapi]
 organization: ministry-of-forests
 organizationUnit: bc-wildfire-service
+# License options: https://bcgov.github.io/data-publication/pages/dps_licences.html
 license_title: Access Only
 view_audience: Government
 security_class: PUBLIC


### PR DESCRIPTION
After discussion with Copyright/Intellectual Property program staff, they recommended switching the license in our API Portal to 'Access Only', which follows the pattern of the BC Data Catalogue, where datasets are either 'Open Government Licence - British Columbia' or 'Access Only'. 
License options link here: https://dev.developer.gov.bc.ca/docs/default/component/aps-infra-platform-docs/how-to/api-discovery/

Datasets are still protected by the government copyright listed in the API Directory footer.

This should give us clear justification to revoke API access from users if needed. 

# Test Links:
[Landing Page](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/)
[MoreCast](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/morecast)
[Percentile Calculator](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/percentile-calculator)
[FireCalc](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator)
[FireCalc bookmark](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-behaviour-calculator?s=266&f=c5&c=NaN&w=20,s=286&f=c7&c=NaN&w=16,s=1055&f=c7&c=NaN&w=NaN,s=305&f=c7&c=NaN&w=NaN,s=344&f=c5&c=NaN&w=NaN,s=346&f=c7&c=NaN&w=NaN,s=328&f=c7&c=NaN&w=NaN,s=1399&f=c7&c=NaN&w=NaN,s=334&f=c7&c=NaN&w=NaN,s=1082&f=c3&c=NaN&w=NaN,s=388&f=c7&c=NaN&w=NaN,s=309&f=c7&c=NaN&w=16,s=306&f=c7&c=NaN&w=NaN,s=1029&f=c7&c=NaN&w=NaN,s=298&f=c7&c=NaN&w=NaN,s=836&f=c7&c=NaN&w=NaN,s=9999&f=c7&c=NaN&w=NaN)
[Auto Spatial Advisory (ASA)](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/auto-spatial-advisory)
[HFI Calculator](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/hfi-calculator)
[SFMS Insights](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/insights)
[Fire Watch](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/fire-watch)
[Weather Toolkit](https://wps-pr-5813-e1e498-dev.apps.silver.devops.gov.bc.ca/weather-toolkit)
